### PR TITLE
Require broker to render using the size passed in from the CLI

### DIFF
--- a/broker/main.js
+++ b/broker/main.js
@@ -417,11 +417,15 @@ class App extends Component {
       renderUrl,
     };
     this.defaultSettings = {
-      pageSizeOption: 'auto',
-      pageSizePresetSelect: 'A5',
+      pageSizeOption: query.format
+        ? 'preset'
+        : query.width && query.height
+        ? 'custom'
+        : 'auto',
+      pageSizePresetSelect: query.format || 'A5',
       pageSizeUseLandscape: false,
-      pageSizeWidth: '210mm',
-      pageSizeHeight: '297mm',
+      pageSizeWidth: query.width || '210mm',
+      pageSizeHeight: query.height || '297mm',
       overrideDocumentStylesheets: false,
       loadMode: query.loadMode || 'document',
     };
@@ -459,7 +463,7 @@ class App extends Component {
   }
 
   loadDocument(settings) {
-    const { renderUrl } = this.state;
+    const { renderUrl, pageSizeOption } = this.state;
     if (!renderUrl) {
       return;
     }
@@ -475,7 +479,7 @@ class App extends Component {
           ],
         },
         {
-          fitToScreen: true,
+          fitToScreen: pageSizeOption === 'auto',
           pageViewMode: 'singlePage',
         },
       );
@@ -490,7 +494,7 @@ class App extends Component {
           ],
         },
         {
-          fitToScreen: true,
+          fitToScreen: pageSizeOption === 'auto',
           pageViewMode: 'singlePage',
         },
       );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
     "declaration": true /* Generates corresponding '.d.ts' file. */,
     "declarationMap": true /* Generates a sourcemap for each corresponding '.d.ts' file. */,
-    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    "sourceMap": true /* Generates corresponding '.map' file. */,
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
     "outDir": "./dist" /* Redirect output structure to the directory. */,
     "rootDir": "./src" /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */,


### PR DESCRIPTION
Fixes #14.

The broker defaults to auto mode, which follows the viewport size. Chrome does not resize the viewport when printing, so Vivliostyle will not re-render. Chrome will instead try to fit the viewport inside the selected paper size, leading to it switching to landscape every time because of the `--window-size` parameter.

Instead, pass the paper size from the CLI to configure both the render size and the `@page size` directive, which in turn effects the paper size when printing. This saves us from having to worry about the viewport or calculate inch sizes ourselves: the browser and vivliostyle core handle all of it, so the parsing gets simpler.

Example output of portrait Letter outputting correctly: [output.pdf](https://github.com/vivliostyle/vivliostyle-cli/files/4023279/output.pdf).
