### PR TITLE
Add metadata and outline to PDF

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   preset: 'ts-jest',
-  testEnvironment: 'node',
+  testEnvironment: './tests/fixtures/node.js',
   testMatch: ['**/src/__tests__/*.+(ts|tsx|js)', '**/tests/*.test.(ts|tsx|js)'],
   testPathIgnorePatterns: ['/dist/'],
 };

--- a/package.json
+++ b/package.json
@@ -12,10 +12,11 @@
     "test": "yarn build && jest --coverage"
   },
   "dependencies": {
-    "@vivliostyle/core": "2.0.0",
+    "@vivliostyle/core": "^2.1.0-pre.0",
     "commander": "^4.0.1",
     "debug": "^4.1.1",
     "mathjax": "2.7.7",
+    "pdf-lib": "^1.4.1",
     "portfinder": "^1.0.25",
     "preact": "^10.1.1",
     "press-ready": "^4.0.1",

--- a/src/lib/broker.d.ts
+++ b/src/lib/broker.d.ts
@@ -6,7 +6,16 @@ declare global {
 
 export interface CoreViewer {
   readyState: string;
+  addListener(type: string, listener: (payload: Payload) => void): void;
+  removeListener(type: string, listener: (payload: Payload) => void): void;
   getMetadata(): Meta;
+  showTOC(show: boolean): void;
+  getTOC(): TOCItem[];
+}
+
+export interface Payload {
+  t: string;
+  a?: string;
 }
 
 export interface Meta {
@@ -18,4 +27,10 @@ export interface MetaItem {
   o: number;
   s?: string;
   r?: Meta;
+}
+
+export interface TOCItem {
+  id: string;
+  title: string;
+  children: TOCItem[];
 }

--- a/src/lib/broker.d.ts
+++ b/src/lib/broker.d.ts
@@ -1,0 +1,9 @@
+declare global {
+  export interface Window {
+    coreViewer: CoreViewer;
+  }
+}
+
+export interface CoreViewer {
+  readyState: string;
+}

--- a/src/lib/broker.d.ts
+++ b/src/lib/broker.d.ts
@@ -6,4 +6,16 @@ declare global {
 
 export interface CoreViewer {
   readyState: string;
+  getMetadata(): Meta;
+}
+
+export interface Meta {
+  [key: string]: MetaItem[];
+}
+
+export interface MetaItem {
+  v: string;
+  o: number;
+  s?: string;
+  r?: Meta;
 }

--- a/src/lib/build.ts
+++ b/src/lib/build.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import chalk from 'chalk';
 import puppeteer from 'puppeteer';
 
-import { CoreViewer } from './broker';
+import { CoreViewer, Meta } from './broker';
 import { PostProcess } from './postprocess';
 import {
   getBrokerUrl,
@@ -126,6 +126,8 @@ export default async function run({
     },
   );
 
+  const metadata = await loadMetadata(page);
+
   log('Generating PDF...');
 
   const pdf = await page.pdf({
@@ -144,6 +146,7 @@ export default async function run({
   await browser.close();
 
   const post = await PostProcess.load(pdf);
+  await post.metadata(metadata);
   await post.save(outputFile, { pressReady });
 
   log(`🎉  Done`);
@@ -151,4 +154,8 @@ export default async function run({
 
   // TODO: gracefully exit broker & source server
   process.exit(0);
+}
+
+async function loadMetadata(page: puppeteer.Page): Promise<Meta> {
+  return page.evaluate(() => window.coreViewer.getMetadata());
 }

--- a/src/lib/build.ts
+++ b/src/lib/build.ts
@@ -6,6 +6,7 @@ import uuid from 'uuid/v1';
 import puppeteer from 'puppeteer';
 import * as pressReadyModule from 'press-ready';
 
+import { CoreViewer } from './broker';
 import {
   getBrokerUrl,
   launchSourceAndBrokerServer,
@@ -17,7 +18,6 @@ import {
   statFile,
   findEntryPointFile,
   debug,
-  retry,
   launchBrowser,
 } from './util';
 
@@ -120,20 +120,12 @@ export default async function run({
 
   await page.goto(navigateURL, { waitUntil: 'networkidle0' });
   await page.emulateMediaType('print');
-  await retry(
-    async () => {
-      const readyState = await page.evaluate(
-        () =>
-          ((window as unknown) as Window & {
-            coreViewer: { readyState: string };
-          }).coreViewer.readyState,
-      );
-
-      if (readyState !== 'complete') {
-        throw new Error(`Document being rendered: ${readyState}`);
-      }
+  await page.waitForFunction(
+    () => window.coreViewer.readyState === 'complete',
+    {
+      polling: 1000,
+      timeout,
     },
-    { timeout },
   );
 
   log('Generating PDF...');

--- a/src/lib/postprocess.ts
+++ b/src/lib/postprocess.ts
@@ -1,0 +1,30 @@
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import uuid from 'uuid/v1';
+import * as pressReadyModule from 'press-ready';
+
+export interface SaveOption {
+  pressReady: boolean;
+}
+
+export class PostProcess {
+  static async load(pdf: Buffer): Promise<PostProcess> {
+    return new PostProcess(pdf);
+  }
+
+  private constructor(private pdf: Buffer) {}
+
+  async save(output: string, { pressReady = false }: SaveOption) {
+    const input = pressReady
+      ? path.join(os.tmpdir(), `vivliostyle-cli-${uuid()}.pdf`)
+      : output;
+
+    const pdf = this.pdf;
+    await fs.promises.writeFile(input, pdf);
+
+    if (pressReady) {
+      await pressReadyModule.build({ input, output });
+    }
+  }
+}

--- a/src/lib/postprocess.ts
+++ b/src/lib/postprocess.ts
@@ -1,11 +1,18 @@
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
-import { PDFDocument } from 'pdf-lib';
+import {
+  PDFDocument,
+  PDFRef,
+  PDFDict,
+  PDFName,
+  PDFNumber,
+  PDFHexString,
+} from 'pdf-lib';
 import * as pressReadyModule from 'press-ready';
 import uuid from 'uuid/v1';
 
-import { Meta } from './broker';
+import { Meta, TOCItem } from './broker';
 
 export interface SaveOption {
   pressReady: boolean;
@@ -27,6 +34,12 @@ const metaTerms = {
   created: `${prefixes.meta}created`,
   date: `${prefixes.meta}date`,
 };
+
+interface PDFTocItem extends TOCItem {
+  children: PDFTocItem[];
+  ref: PDFRef;
+  parentRef: PDFRef;
+}
 
 export class PostProcess {
   static async load(pdf: Buffer): Promise<PostProcess> {
@@ -89,5 +102,64 @@ export class PostProcess {
     if (creationDate) {
       this.document.setCreationDate(creationDate);
     }
+  }
+
+  async toc(items: TOCItem[]) {
+    if (!items.length) {
+      return;
+    }
+
+    const addRefs = (items: TOCItem[], parentRef: PDFRef): PDFTocItem[] =>
+      items.map((item) => {
+        const ref = this.document.context.nextRef();
+        return {
+          ...item,
+          parentRef,
+          ref,
+          children: addRefs(item.children, ref),
+        };
+      });
+    const countAll = (items: PDFTocItem[]): number =>
+      items.reduce((sum, item) => sum + countAll(item.children), items.length);
+    const addObjectsToPDF = (items: PDFTocItem[]) => {
+      for (const [i, item] of items.entries()) {
+        const child = PDFDict.withContext(this.document.context);
+        child.set(PDFName.of('Title'), PDFHexString.fromText(item.title));
+        child.set(PDFName.of('Dest'), PDFName.of(item.id));
+        child.set(PDFName.of('Parent'), item.parentRef);
+        const prev = items[i - 1];
+        if (prev) {
+          child.set(PDFName.of('Prev'), prev.ref);
+        }
+        const next = items[i + 1];
+        if (next) {
+          child.set(PDFName.of('Next'), next.ref);
+        }
+        if (item.children.length) {
+          child.set(PDFName.of('First'), item.children[0].ref);
+          child.set(
+            PDFName.of('Last'),
+            item.children[item.children.length - 1].ref,
+          );
+          child.set(PDFName.of('Count'), PDFNumber.of(countAll(item.children)));
+        }
+        this.document.context.assign(item.ref, child);
+        addObjectsToPDF(item.children);
+      }
+    };
+
+    const outlineRef = this.document.context.nextRef();
+    const itemsWithRefs = addRefs(items, outlineRef);
+    addObjectsToPDF(itemsWithRefs);
+
+    const outline = PDFDict.withContext(this.document.context);
+    outline.set(PDFName.of('First'), itemsWithRefs[0].ref);
+    outline.set(
+      PDFName.of('Last'),
+      itemsWithRefs[itemsWithRefs.length - 1].ref,
+    );
+    outline.set(PDFName.of('Count'), PDFNumber.of(countAll(itemsWithRefs)));
+    this.document.context.assign(outlineRef, outline);
+    this.document.catalog.set(PDFName.of('Outlines'), outlineRef);
   }
 }

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -53,40 +53,6 @@ export async function findEntryPointFile(
   return path.relative(root, target);
 }
 
-export function retry(
-  fn: Function,
-  { timeout, freq = 1000 }: { timeout: number; freq?: number },
-): Promise<void> {
-  let time = 0;
-
-  function innerFunction(
-    resolve: ResolveFunction<void>,
-    reject: RejectFunction,
-  ) {
-    setTimeout(async () => {
-      if (time > timeout) {
-        return reject(
-          new Error(
-            `Failed because build process exceeded timeout limit ${timeout}ms. Try it again with --timeout option.`,
-          ),
-        );
-      }
-
-      try {
-        await Promise.resolve(fn());
-        resolve();
-      } catch (err) {
-        debug(err.message);
-      }
-
-      time += freq;
-      innerFunction(resolve, reject);
-    }, freq);
-  }
-
-  return new Promise((resolve, reject) => innerFunction(resolve, reject));
-}
-
 export async function launchBrowser(
   options?: puppeteer.LaunchOptions,
 ): Promise<puppeteer.Browser> {

--- a/tests/fixtures/node.js
+++ b/tests/fixtures/node.js
@@ -1,0 +1,9 @@
+const NodeEnvironment = require('jest-environment-node');
+
+// Workaround for https://github.com/facebook/jest/issues/4422
+module.exports = class extends NodeEnvironment {
+  async setup() {
+    await super.setup();
+    this.global.Uint8Array = Uint8Array;
+  }
+};

--- a/tests/fixtures/wood/index.html
+++ b/tests/fixtures/wood/index.html
@@ -13,8 +13,13 @@
   <body>
     <h1 class="title">Wood Engraving 木製彫刻</h1>
     <p class="author">R.J. Beedham</p>
+    <nav id="toc" role="doc-toc">
+      <ul>
+        <li><a href="#intro">INTRODUCTION (前書き)</a></li>
+      </ul>
+    </nav>
     <div class="main_text">
-      <h2>INTRODUCTION (by Eric Gill)</h2>
+      <h2 id="intro">INTRODUCTION (by Eric Gill)</h2>
 
       <p class="dropcap">
         <span class="dropcap">T</span>HIS book is not a treatise upon the art of

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */
-    "target": "es5" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */,
+    "target": "es2018" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */,
     "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     // "allowJs": false /* Allow javascript files to be compiled. */,

--- a/yarn.lock
+++ b/yarn.lock
@@ -307,6 +307,21 @@
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
+"@pdf-lib/standard-fonts@^0.0.4":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/@pdf-lib/standard-fonts/-/standard-fonts-0.0.4.tgz#49fffa97fe1a5fff9b8b60fd9decf79b10bd0982"
+  integrity sha512-2pg8hXnChVAF6aSFraXtwB0cx/AgE15FvuLJbdPJSq9LYp1xMp0lapH4+t1HsdD9cA05rnWYLqlEBwS4YK1jLg==
+  dependencies:
+    base64-arraybuffer "^0.1.5"
+    pako "^1.0.6"
+
+"@pdf-lib/upng@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@pdf-lib/upng/-/upng-1.0.1.tgz#7dc9c636271aca007a9df4deaf2dd7e7960280cb"
+  integrity sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==
+  dependencies:
+    pako "^1.0.10"
+
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz#ecdf48d532c58ea477acfcab80348424f8d0662f"
@@ -486,10 +501,10 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@vivliostyle/core@2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@vivliostyle/core/-/core-2.0.0.tgz#a2aa5915c7bd89580d53dcdc5ef6bbccfe8fbff4"
-  integrity sha512-rUMKNPmNiucFQ9HhQEOJ9FhA+xOScJFxlkLvPPpHHMoP4zigXK5ebzb8g4NihpxasY5KzZfJki4q//8rn8uI4Q==
+"@vivliostyle/core@^2.1.0-pre.0":
+  version "2.1.0-pre.0"
+  resolved "https://registry.yarnpkg.com/@vivliostyle/core/-/core-2.1.0-pre.0.tgz#74248f8509eeca21b27ae493db3cdca33444f375"
+  integrity sha512-QkrhAtxXC4oB5wJlYi8dPxxkpGQSNu0EUdx3/HXnB1j3d4mjDlXVX+biGoDw8csTz64kwNm1l2FEjcCnw/ZCvw==
 
 abab@^2.0.0:
   version "2.0.2"
@@ -761,6 +776,11 @@ balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
+
+base64-arraybuffer@^0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz#73926771923b5a19747ad666aa5cd4bf9c6e9ce8"
+  integrity sha1-c5JncZI7Whl0etZmqlzUv5xunOg=
 
 base@^0.11.1:
   version "0.11.2"
@@ -3494,6 +3514,11 @@ p-try@^2.0.0, p-try@^2.1.0:
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
+pako@^1.0.10, pako@^1.0.11, pako@^1.0.6:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
+  integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
+
 parse-json@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-4.0.0.tgz#be35f5425be1f7f6c747184f98a788cb99477ee0"
@@ -3573,6 +3598,16 @@ path-type@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
+
+pdf-lib@^1.4.1:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/pdf-lib/-/pdf-lib-1.5.0.tgz#858b9b4641d8ba5e721bc6f7e62a386efdacd4fa"
+  integrity sha512-ZpMB7AY7JxvhAAaz/YS0J67Con+ks63h9GWSTHbul46mg1j35pfz6LN/xNGiwoMM19PjaxTbtuhNQAePIyKyRA==
+  dependencies:
+    "@pdf-lib/standard-fonts" "^0.0.4"
+    "@pdf-lib/upng" "^1.0.1"
+    pako "^1.0.11"
+    tslib "^1.11.1"
 
 pend@~1.2.0:
   version "1.2.0"
@@ -4574,6 +4609,11 @@ ts-jest@^24.2.0:
     resolve "1.x"
     semver "^5.5"
     yargs-parser "10.x"
+
+tslib@^1.11.1:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
+  integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
 
 tslib@^1.9.0:
   version "1.10.0"


### PR DESCRIPTION
Adds postprocessing of the PDF to copy in the metadata and table of contents from the source document, as parsed by Vivliostyle Core.

The metadata copies over the Title, Author, Subject, Keywords, Creator, Language, and Creation Date from the source document, if provided. If not provided, Creator will be “Chromium”, which Chromium puts there. The Producer is set to “Vivliostyle”.

The PDF outline will match the structure of the source document’s TOC, including deep destination links.

The metadata and TOC use linked functionality in Vivliostyle, so this PR is paired with vivliostyle/vivliostyle.js#634. If the functionality is not in Vivliostyle, vivliostyle-cli will function as before; it will not break.

### TODO

- [x] Investigate issues [reported](https://github.com/vivliostyle/vivliostyle-cli/pull/47#issuecomment-615059715).