### PR TITLE
fix: build error when TOC is not available

### DIFF
--- a/src/lib/postprocess.ts
+++ b/src/lib/postprocess.ts
@@ -105,7 +105,7 @@ export class PostProcess {
   }
 
   async toc(items: TOCItem[]) {
-    if (!items.length) {
+    if (!items || !items.length) {
       return;
     }
 


### PR DESCRIPTION
PDF Bookmarks (outline) are now generated thanks to the PR #47 "Add metadata and outline to PDF".
But it causes "Error: Cannot read property 'length' of undefined" when TOC is not available.

Note: TOC (items) is generated in Vivliostyle Core only when Book mode is used and TOC element exists in the book.
So this fix is needed.