### PR TITLE
fix: Errors due to path problem on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "shelljs": "^0.8.4",
     "terminal-link": "^2.1.1",
     "to-vfile": "^6.1.0",
+    "upath": "^1.2.0",
     "uuid": "^8.2.0",
     "vfile": "^4.1.1"
   },

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -6,7 +6,7 @@ import h from 'hastscript';
 import { imageSize } from 'image-size';
 import { JSDOM } from 'jsdom';
 import { lookup as mime } from 'mime-types';
-import path from 'path';
+import path from 'upath';
 import shelljs from 'shelljs';
 import { contextResolve, Entry, MergedConfig, ParsedEntry } from './config';
 import { processMarkdown } from './markdown';

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,7 +2,7 @@
 
 import program from 'commander';
 import fs from 'fs';
-import { join } from 'path';
+import { join } from 'upath';
 import resolvePkg from 'resolve-pkg';
 import { readJSON } from './util';
 

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import program from 'commander';
-import path from 'path';
+import path from 'upath';
 import process from 'process';
 import terminalLink from 'terminal-link';
 import { buildArtifacts, cleanup } from '../builder';

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import program from 'commander';
 import fs from 'fs';
-import path from 'path';
+import path from 'upath';
 import { gracefulError, log } from '../util';
 
 export interface InitCliFlags {

--- a/src/commands/preview.ts
+++ b/src/commands/preview.ts
@@ -1,6 +1,6 @@
 import chokidar from 'chokidar';
 import program from 'commander';
-import path from 'path';
+import path from 'upath';
 import puppeteer from 'puppeteer';
 import { buildArtifacts } from '../builder';
 import {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,7 @@
 import Ajv from 'ajv';
 import fs from 'fs';
 import { JSDOM } from 'jsdom';
-import path from 'path';
+import path from 'upath';
 import pkgUp from 'pkg-up';
 import process from 'process';
 import puppeteer from 'puppeteer';

--- a/src/pdf.ts
+++ b/src/pdf.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import fs from 'fs';
-import path from 'path';
+import path from 'upath';
 import puppeteer from 'puppeteer';
 import shelljs from 'shelljs';
 import terminalLink from 'terminal-link';

--- a/src/postprocess.ts
+++ b/src/postprocess.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import os from 'os';
-import path from 'path';
+import path from 'upath';
 import {
   PDFDict,
   PDFDocument,

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import http, { RequestListener } from 'http';
 import https from 'https';
-import path from 'path';
+import path from 'upath';
 import handler from 'serve-handler';
 import url from 'url';
 import { debug, findAvailablePort } from './util';

--- a/src/util.ts
+++ b/src/util.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk';
 import debugConstructor from 'debug';
 import fs from 'fs';
 import oraConstructor from 'ora';
-import path from 'path';
+import path from 'upath';
 import portfinder from 'portfinder';
 import puppeteer from 'puppeteer';
 import util from 'util';

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,7 +1,7 @@
 import execa from 'execa';
 import fileType from 'file-type';
 import fs from 'fs';
-import path from 'path';
+import path from 'upath';
 import {
   PDFCatalog,
   PDFDict,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7255,6 +7255,11 @@ unset-value@^1.0.0:
     has-value "^0.3.1"
     isobject "^3.0.0"
 
+upath@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/upath/-/upath-1.2.0.tgz#8f66dbcd55a883acdae4408af8b035a5044c1894"
+  integrity sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==
+
 update-notifier@4.1.0, update-notifier@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/update-notifier/-/update-notifier-4.1.0.tgz#4866b98c3bc5b5473c020b1250583628f9a328f3"


### PR DESCRIPTION
On Windows, with Node.js `path` module,  `path.join()`, `path.relative()`, etc. functions return path strings containing backslashes as directory separator.

Path string with backslashes cannot be used where URL path is required (e.g. `href` in `manifest.json`), and cannot be used with [globby](https://www.npmjs.com/package/globby). So this problem causes [errors on Windows](https://github.com/vivliostyle/vivliostyle-cli/issues/68).

Using [`upath`](https://www.npmjs.com/package/upath) instead of normal `path` solves the problem.

Fixes #68 
