### PR TITLE
chore: Update core version

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "yarn build && jest --coverage"
   },
   "dependencies": {
-    "@vivliostyle/core": "^2.1.1",
+    "@vivliostyle/core": "2.1.4",
     "commander": "^5.1.0",
     "debug": "^4.1.1",
     "mathjax": "3.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -682,10 +682,10 @@
   dependencies:
     "@types/node" "*"
 
-"@vivliostyle/core@^2.1.1":
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/@vivliostyle/core/-/core-2.1.1.tgz#d0be87d6d62e8d48ccfb6773d67d3b6b898af5a0"
-  integrity sha512-Qdbinr6hT/D3wBB+MaaTUeh/XFH8XEspO8i3Jb8YuJAKKsXRplyYJMb55mJcfBWecbaS7a+R1T20+/UAnEqn/g==
+"@vivliostyle/core@2.1.4":
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/@vivliostyle/core/-/core-2.1.4.tgz#dcce0cfb2207d6f7f08fb81a7b7ddfdf6f11ae70"
+  integrity sha512-AFFUwNRHEA618QXbTinLu7OfxRi1XaYon43FWDHVSo6Oxvts34BvHlYHswbhLMybXP/YKryqK4EbWgQQAHz4wA==
   dependencies:
     fast-diff "^1.2.0"
 


### PR DESCRIPTION
## Overview

FIxes #81

This PR update @vivliostyle/core to the specific version (2.1.4). This ensures us to use the same Vivliostyle version.