### PR TITLE
fix: toc test fails due to separator on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "shelljs": "^0.8.4",
     "terminal-link": "^2.1.1",
     "to-vfile": "^6.1.0",
-    "upath": "^1.2.0",
+    "upath": "^2.0.1",
     "uuid": "^8.2.0",
     "vfile": "^4.1.1"
   },

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -6,8 +6,8 @@ import h from 'hastscript';
 import { imageSize } from 'image-size';
 import { JSDOM } from 'jsdom';
 import { lookup as mime } from 'mime-types';
-import path from 'upath';
 import shelljs from 'shelljs';
+import path from 'upath';
 import { contextResolve, Entry, MergedConfig, ParsedEntry } from './config';
 import { processMarkdown } from './markdown';
 import { debug } from './util';
@@ -92,7 +92,7 @@ export function generateToC(entries: ParsedEntry[], distDir: string) {
       'li',
       h(
         'a',
-        { href: path.relative(distDir, entry.target.path) },
+        { href: path.posix.relative(distDir, entry.target.path) },
         entry.title || path.basename(entry.target.path, '.html'),
       ),
     ),

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -92,7 +92,7 @@ export function generateToC(entries: ParsedEntry[], distDir: string) {
       'li',
       h(
         'a',
-        { href: path.posix.relative(distDir, entry.target.path) },
+        { href: path.relative(distDir, entry.target.path) },
         entry.title || path.basename(entry.target.path, '.html'),
       ),
     ),

--- a/yarn.lock
+++ b/yarn.lock
@@ -7255,10 +7255,10 @@ unset-value@^1.0.0:
     has-value "^0.3.1"
     isobject "^3.0.0"
 
-upath@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/upath/-/upath-1.2.0.tgz#8f66dbcd55a883acdae4408af8b035a5044c1894"
-  integrity sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==
+upath@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/upath/-/upath-2.0.1.tgz#50c73dea68d6f6b990f51d279ce6081665d61a8b"
+  integrity sha512-1uEe95xksV1O0CYKXo8vQvN1JEbtJp7lb7C5U9HMsIp6IVwntkH/oNUzyVNQSd4S1sYk2FpSSW44FqMc8qee5w==
 
 update-notifier@4.1.0, update-notifier@^4.0.0:
   version "4.1.0"


### PR DESCRIPTION
Windowsではpath.relativeで付与されるセパレータが&lt;a href="\.\.&yen;test.html"&gt;のように"&yen;"になるためテストに失敗します。
生成されたtoc.htmlをMacにコピーしてChromeで試した限りでは"/"でも"&yen;"でも区切りとして機能しているようなのでテストで引っ掛るところ以外は修正しなくても実用上は問題ないと思います。

import path form 'upath'; の順番が変わってしまったのはpretty-quickによる自動フォーマットの結果です。