### PR TITLE
feat: display stacktrace on error

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -9,9 +9,6 @@ import util from 'util';
 
 export const debug = debugConstructor('vs-cli');
 
-// Display stacktrace on Error
-const verbose = true;
-
 const ora = oraConstructor({ color: 'blue', spinner: 'circle' });
 
 export function startLogging(text?: string) {
@@ -47,14 +44,14 @@ export function logInfo(...obj: string[]) {
 }
 
 export function gracefulError(err: Error) {
-  const message = `${chalk.red.bold('Error:')} ${err.message}`;
+  const message = err.stack
+    ? err.stack.replace(/^Error:/, chalk.red.bold('Error:'))
+    : `${chalk.red.bold('Error:')} ${err.message}`;
+
   if (ora.isSpinning) {
     ora.fail(message);
   } else {
     console.error(message);
-  }
-  if (verbose) {
-    console.log(err.stack);
   }
   console.log(
     chalk.gray(`

--- a/src/util.ts
+++ b/src/util.ts
@@ -2,12 +2,15 @@ import chalk from 'chalk';
 import debugConstructor from 'debug';
 import fs from 'fs';
 import oraConstructor from 'ora';
-import path from 'upath';
 import portfinder from 'portfinder';
 import puppeteer from 'puppeteer';
+import path from 'upath';
 import util from 'util';
 
 export const debug = debugConstructor('vs-cli');
+
+// Display stacktrace on Error
+const verbose = true;
 
 const ora = oraConstructor({ color: 'blue', spinner: 'circle' });
 
@@ -49,6 +52,9 @@ export function gracefulError(err: Error) {
     ora.fail(message);
   } else {
     console.error(message);
+  }
+  if (verbose) {
+    console.log(err.stack);
   }
   console.log(
     chalk.gray(`


### PR DESCRIPTION
JESTでテストを実行した際にエラーが発生しても、スタックトレースで表示されるのはテストケースの失敗までなのでどこでエラーが発生したかが判断しにくくなっています。

gracefulError関数でエラー発生時点のスタックトレースを表示することで障害箇所を見付けやすくなります。

一応verbose変数で表示をON/OFFできるようにしていますが、個人的には常時ONでも良いと思います。