### PR TITLE
chore: Remove deprecated waitFor function

### DIFF
--- a/src/pdf.ts
+++ b/src/pdf.ts
@@ -125,7 +125,7 @@ export async function buildPDF({
   });
 
   await page.goto(navigateURL, { waitUntil: 'networkidle0' });
-  await page.waitFor(() => !!window.coreViewer);
+  await page.waitForFunction(() => !!window.coreViewer);
 
   const metadata = await loadMetadata(page);
   const toc = await loadTOC(page);


### PR DESCRIPTION
## Overview

This PR removes a deprecated `waitFor` function. [The `waitForFunction` is equivalent to that](https://github.com/puppeteer/puppeteer/issues/6214).