### PR TITLE
fix: Can't load from Web URL

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -437,12 +437,22 @@ async function composeSingleInputConfig<T extends CliFlags>(
 ): Promise<MergedConfig> {
   debug('entering single entry config mode');
 
-  const sourcePath = path.resolve(cliFlags.input);
-  const workspaceDir = path.dirname(sourcePath);
+  let sourcePath: string;
+  let workspaceDir: string;
+  let input: InputFormat;
   const entries: ParsedEntry[] = [];
   const exportAliases: { source: string; target: string }[] = [];
   const tmpPrefix = `.vs-${Date.now()}.`;
-  const input = detectInputFormat(sourcePath);
+
+  if (cliFlags.input && /https?:\/\//.test(cliFlags.input)) {
+    sourcePath = cliFlags.input;
+    input = { format: 'html', entry: sourcePath };
+    workspaceDir = '.';
+  } else {
+    sourcePath = path.resolve(cliFlags.input);
+    workspaceDir = path.dirname(sourcePath);
+    input = detectInputFormat(sourcePath);
+  }
 
   if (input.format === 'markdown') {
     // Single input file; create temporary file

--- a/src/config.ts
+++ b/src/config.ts
@@ -453,7 +453,7 @@ async function composeSingleInputConfig<T extends CliFlags>(
 
   if (cliFlags.input && /https?:\/\//.test(cliFlags.input)) {
     sourcePath = cliFlags.input;
-    workspaceDir = process.cwd();
+    workspaceDir = otherConfig.workspaceDir;
     input = { format: 'webbook', entry: sourcePath };
   } else {
     sourcePath = path.resolve(cliFlags.input);

--- a/src/config.ts
+++ b/src/config.ts
@@ -321,14 +321,21 @@ export async function mergeConfig<T extends CliFlags>(
   debug('context directory', context);
   debug('cliFlags', cliFlags);
   debug('vivliostyle.config.js', config);
+  let entryContextDir: string;
+  let workspaceDir: string;
 
-  const entryContextDir = path.resolve(
-    cliFlags.input
-      ? path.dirname(path.resolve(context, cliFlags.input))
-      : contextResolve(context, config?.entryContext) ?? context,
-  );
-  const workspaceDir =
-    contextResolve(context, config?.workspaceDir) ?? entryContextDir;
+  if (cliFlags.input && /https?:\/\//.test(cliFlags.input)) {
+    workspaceDir = entryContextDir = process.cwd();
+  } else {
+    entryContextDir = path.resolve(
+      cliFlags.input
+        ? path.dirname(path.resolve(context, cliFlags.input))
+        : contextResolve(context, config?.entryContext) ?? context,
+    );
+    workspaceDir =
+      contextResolve(context, config?.workspaceDir) ?? entryContextDir;
+  }
+
   const includeAssets = config?.includeAssets
     ? Array.isArray(config.includeAssets)
       ? config.includeAssets
@@ -446,8 +453,8 @@ async function composeSingleInputConfig<T extends CliFlags>(
 
   if (cliFlags.input && /https?:\/\//.test(cliFlags.input)) {
     sourcePath = cliFlags.input;
-    input = { format: 'html', entry: sourcePath };
-    workspaceDir = '.';
+    workspaceDir = process.cwd();
+    input = { format: 'webbook', entry: sourcePath };
   } else {
     sourcePath = path.resolve(cliFlags.input);
     workspaceDir = path.dirname(sourcePath);

--- a/src/input.ts
+++ b/src/input.ts
@@ -44,6 +44,10 @@ export type InputFormat =
   | EpubOpfInput;
 
 export function detectInputFormat(entry: string): InputFormat {
+  if (/^https?:\/\//.test(entry)) {
+    return { format: 'html', entry };
+  }
+
   const lowerCasedExt = path.extname(entry).toLowerCase();
   if (lowerCasedExt === '.md' || lowerCasedExt === '.markdown') {
     return { format: 'markdown', entry };

--- a/src/input.ts
+++ b/src/input.ts
@@ -44,10 +44,6 @@ export type InputFormat =
   | EpubOpfInput;
 
 export function detectInputFormat(entry: string): InputFormat {
-  if (/^https?:\/\//.test(entry)) {
-    return { format: 'html', entry };
-  }
-
   const lowerCasedExt = path.extname(entry).toLowerCase();
   if (lowerCasedExt === '.md' || lowerCasedExt === '.markdown') {
     return { format: 'markdown', entry };

--- a/src/server.ts
+++ b/src/server.ts
@@ -14,8 +14,13 @@ export function getBrokerUrl({
   loadMode?: LoadMode;
   outputSize?: PageSize;
 }) {
-  const sourceUrl = new URL('file://');
-  sourceUrl.pathname = sourceIndex;
+  let sourceUrl: URL;
+  if (/https?:\/\//.test(sourceIndex)) {
+    sourceUrl = new URL(sourceIndex);
+  } else {
+    sourceUrl = new URL('file://');
+    sourceUrl.pathname = sourceIndex;
+  }
 
   const brokerUrl = new URL('file://');
   brokerUrl.pathname = path.resolve(__dirname, '../broker/index.html');

--- a/tests/__snapshots__/config.test.ts.snap
+++ b/tests/__snapshots__/config.test.ts.snap
@@ -84,6 +84,48 @@ Object {
 }
 `;
 
+exports[`imports a https URL 1`] = `
+Object {
+  "cover": undefined,
+  "entries": Array [],
+  "entryContextDir": "__WORKSPACE__",
+  "executableChromium": "__EXECUTABLE_CHROMIUM_PATH__",
+  "exportAliases": Array [],
+  "includeAssets": Array [
+    "**/*.png",
+    "**/*.jpg",
+    "**/*.jpeg",
+    "**/*.svg",
+    "**/*.gif",
+    "**/*.webp",
+    "**/*.apng",
+    "**/*.ttf",
+    "**/*.otf",
+    "**/*.woff",
+    "**/*.woff2",
+  ],
+  "input": Object {
+    "entry": "https://vivliostyle.github.io/vivliostyle_doc/ja/vivliostyle-user-group-vol1/",
+    "format": "webbook",
+  },
+  "language": null,
+  "outputs": Array [
+    Object {
+      "format": "pdf",
+      "path": "__WORKSPACE__/tests/output.pdf",
+    },
+  ],
+  "pressReady": false,
+  "sandbox": true,
+  "size": undefined,
+  "themeIndexes": Array [],
+  "timeout": 120000,
+  "verbose": false,
+  "webbookEntryPath": "https://vivliostyle.github.io/vivliostyle_doc/ja/vivliostyle-user-group-vol1/",
+  "workspaceDir": "__WORKSPACE__",
+}
+`;
+
 exports[`imports a webbook compliant to Readium Web publication 1`] = `
 Object {
   "cover": undefined,

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -169,3 +169,11 @@ it('imports a webbook compliant to Readium Web publication', async () => {
   maskConfig(config);
   expect(config).toMatchSnapshot();
 });
+
+it('imports a https URL', async () => {
+  const config = await getMergedConfig([
+    'https://vivliostyle.github.io/vivliostyle_doc/ja/vivliostyle-user-group-vol1/',
+  ]);
+  maskConfig(config);
+  expect(config).toMatchSnapshot();
+});


### PR DESCRIPTION
まだ叩き台レベルですが、とりあえず以下のコマンドを実行してプレビューできるところまで実装しました。

```
vivliostyle preview https://vivliostyle.github.io/vivliostyle_doc/ja/vivliostyle-user-group-vol1/
```

しかし、buildすると以下のようなエラーが発生します。
また、生成されたPDFを見るとレイアウト崩れが発生しています。(脚注に次のページの先頭が食い込んでいる)

```
% vivliostyle build https://vivliostyle.github.io/vivliostyle_doc/ja/vivliostyle-user-group-vol1/                                                                                                                       (git)-[develop]
✖ 404 https://vivliostyle.github.io/vivliostyle_doc/ja/vivliostyle-user-group-vol1/assets/fonts/SourceHanSerifJP/SourceHanSerifJP-Regular.otf
✖ 404 https://vivliostyle.github.io/vivliostyle_doc/ja/vivliostyle-user-group-vol1/assets/fonts/SourceHanSerifJP/SourceHanSerifJP-SemiBold.otf
```

上記不具合の解決と、workspaceの設定(現在は仮にカレントディレクトリ固定にしています)が実装できれば実用になるのではないかと思います。