### PR TITLE
fix: exmaples/theme-preset size(JIS-B6 -> A5)

### DIFF
--- a/examples/theme-preset/vivliostyle.config.js
+++ b/examples/theme-preset/vivliostyle.config.js
@@ -2,7 +2,7 @@ module.exports = {
   title: 'Draft with the preset theme',
   author: 'spring-raining',
   language: 'ja',
-  size: 'JIS-B6',
+  size: 'A5',
   theme: '@vivliostyle/theme-bunko',
   entry: 'bunko.md',
   output: 'bunko.pdf',


### PR DESCRIPTION
README.mdには、
```
 -s, --size <size>             output pdf size [Letter]
                                preset: A5, A4, A3, B5, B4, JIS-B5, JIS-B4, letter, legal, ledger
                                custom(comma separated): 182mm,257mm or 8.5in,11in
```
とありますが、同梱のexamples/theme-preset内のvivliostyle.config.jsでは
```
  size: 'JIS-B6',
```
のように存在しないサイズ指定になっています。

このままbuildするとA5サイズのpdfが出力されます。

試しにJIS-B6にするためにsize: '128mm,182mm' と指定したところレイアウトが崩れてしまいました。

size: 'A5' に変更したほうが良いのではないでしょうか。