### PR TITLE
fix: Failed to load from web because of CORS error

### DIFF
--- a/src/commands/preview.ts
+++ b/src/commands/preview.ts
@@ -73,6 +73,7 @@ export default async function preview(cliFlags: PreviewCliFlags) {
     args: [
       '--allow-file-access-from-files',
       config.sandbox ? '' : '--no-sandbox',
+      '--disable-web-security',
     ],
   });
   const page = await browser.newPage();

--- a/src/pdf.ts
+++ b/src/pdf.ts
@@ -52,7 +52,11 @@ export async function buildPDF({
     headless: true,
     executablePath: executableChromium,
     // Why `--no-sandbox` flag? Running Chrome as root without --no-sandbox is not supported. See https://crbug.com/638180.
-    args: ['--allow-file-access-from-files', sandbox ? '' : '--no-sandbox'],
+    args: [
+      '--allow-file-access-from-files',
+      sandbox ? '' : '--no-sandbox',
+      '--disable-web-security',
+    ],
   });
   const version = await browser.version();
   debug(chalk.green('success'), `version=${version}`);


### PR DESCRIPTION
Chromiumの起動オプションに `--disable-web-security` を加えることで、CORS制限のためにWebの文書の組版ができなかった問題を解決します。

テスト
```
vivliostyle preview https://example.com
```

修正前:
![Screen Shot 2021-03-01 at 1 01 55](https://user-images.githubusercontent.com/3324737/109428320-f6f66700-7a39-11eb-9309-92a2898942f8.png)

修正後:
![Screen Shot 2021-03-01 at 1 08 26](https://user-images.githubusercontent.com/3324737/109428338-0970a080-7a3a-11eb-87f2-8aee6b6f40ce.png)


