### PR TITLE
fix: Preview watch not working as expected

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -25,7 +25,7 @@ import {
   publicationSchemas,
 } from './schema/pubManifest.schema';
 import type { EntryObject } from './schema/vivliostyle.config';
-import { debug, log } from './util';
+import { debug, log, pathStartsWith } from './util';
 
 export function cleanup(location: string) {
   debug('cleanup file', location);
@@ -125,10 +125,7 @@ export async function compile(
   debug('entries', entries);
   debug('themes', themeIndexes);
 
-  if (
-    !reload &&
-    path.relative(workspaceDir, entryContextDir).startsWith('..')
-  ) {
+  if (!reload && !pathStartsWith(entryContextDir, workspaceDir)) {
     // workspaceDir is placed on different directory
     cleanup(workspaceDir);
   }
@@ -275,12 +272,12 @@ export function checkOverwriteViolation(
   target: string,
   fileInformation: string,
 ) {
-  if (!path.relative(target, entryContextDir).startsWith('..')) {
+  if (pathStartsWith(entryContextDir, target)) {
     throw new Error(
       `${target} is set as output destination of ${fileInformation}, however, this output path will overwrite the manuscript file(s). Please specify other paths.`,
     );
   }
-  if (!path.relative(target, workspaceDir).startsWith('..')) {
+  if (pathStartsWith(workspaceDir, target)) {
     throw new Error(
       `${target} is set as output destination of ${fileInformation}, however, this output path will overwrite the working directory of Vivliostyle. Please specify other paths.`,
     );

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -5,7 +5,7 @@ import path from 'upath';
 import { checkOverwriteViolation, compile, copyAssets } from '../builder';
 import { collectVivliostyleConfig, mergeConfig, MergedConfig } from '../config';
 import { buildPDF } from '../pdf';
-import { gracefulError, log, startLogging, stopLogging } from '../util';
+import { cwd, gracefulError, log, startLogging, stopLogging } from '../util';
 import { exportWebPublication } from '../webbook';
 import { BuildCliFlags, setupBuildParserProgram } from './build.parser';
 
@@ -39,9 +39,7 @@ export default async function build(cliFlags: BuildCliFlags) {
   const { vivliostyleConfig, vivliostyleConfigPath } = loadedConf;
   cliFlags = loadedConf.cliFlags;
 
-  const context = vivliostyleConfig
-    ? path.dirname(vivliostyleConfigPath)
-    : process.cwd();
+  const context = vivliostyleConfig ? path.dirname(vivliostyleConfigPath) : cwd;
 
   const config = await mergeConfig(cliFlags, vivliostyleConfig, context);
   checkUnsupportedOutputs(config);
@@ -79,9 +77,7 @@ export default async function build(cliFlags: BuildCliFlags) {
       });
     }
     if (output) {
-      const formattedOutput = chalk.bold.green(
-        path.relative(process.cwd(), output),
-      );
+      const formattedOutput = chalk.bold.green(path.relative(cwd, output));
       log(
         `\n${terminalLink(formattedOutput, 'file://' + output, {
           fallback: () => formattedOutput,

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import fs from 'fs';
 import path from 'upath';
-import { gracefulError, log } from '../util';
+import { cwd, gracefulError, log } from '../util';
 import { InitCliFlags, setupInitParserProgram } from './init.parser';
 
 try {
@@ -20,10 +20,7 @@ try {
 }
 
 export default async function init(cliFlags: InitCliFlags) {
-  const vivliostyleConfigPath = path.join(
-    process.cwd(),
-    'vivliostyle.config.js',
-  );
+  const vivliostyleConfigPath = path.join(cwd, 'vivliostyle.config.js');
 
   if (fs.existsSync(vivliostyleConfigPath)) {
     return log(

--- a/src/commands/preview.ts
+++ b/src/commands/preview.ts
@@ -98,52 +98,54 @@ export default async function preview(cliFlags: PreviewCliFlags) {
     }, 2000);
   }
 
-  if (!/https?:\/\//.test(config.input.entry)) {
-    chokidar
-      .watch('**', {
-        ignored: (path: string) => {
-          if (/^node_modules$|^\.git/.test(upath.basename(path))) {
-            return true;
-          }
-          if (
-            config.entryContextDir !== config.workspaceDir &&
-            pathStartsWith(path, config.workspaceDir)
-          ) {
-            return true; // ignore saved intermediate files
-          }
-          if (config.manifestAutoGenerate && path === config.manifestPath) {
-            return true; // ignore generated pub-manifest
-          }
-          if (
-            config.entries.length &&
-            /\.(md|markdown|html?|xhtml|xht)$/i.test(path) &&
-            !config.entries.find(
-              (entry) => path === (entry as { source: string }).source,
-            )
-          ) {
-            return true; // ignore md or html files not in entries source
-          }
-          if (
-            config.themeIndexes.find((theme) =>
-              theme.type === 'file'
-                ? path === theme.destination
-                : theme.type === 'package' &&
-                  pathStartsWith(path, theme.destination),
-            )
-          ) {
-            return true; // ignore copied theme files
-          }
-          return false;
-        },
-        cwd: config.entries.length ? context : config.entryContextDir,
-      })
-      .on('all', (event, path) => {
-        if (
-          upath.join(config.entryContextDir, path) === config.input.entry ||
-          /\.(md|markdown|html?|xhtml|xht|css|jpe?g|png|gif|svg)$/i.test(path)
-        ) {
-          handleChangeEvent(path);
-        }
-      });
+  if (/https?:\/\//.test(config.input.entry)) {
+    return;
   }
+
+  chokidar
+    .watch('**', {
+      ignored: (path: string) => {
+        if (/^node_modules$|^\.git/.test(upath.basename(path))) {
+          return true;
+        }
+        if (
+          config.entryContextDir !== config.workspaceDir &&
+          pathStartsWith(path, config.workspaceDir)
+        ) {
+          return true; // ignore saved intermediate files
+        }
+        if (config.manifestAutoGenerate && path === config.manifestPath) {
+          return true; // ignore generated pub-manifest
+        }
+        if (
+          config.entries.length &&
+          /\.(md|markdown|html?|xhtml|xht)$/i.test(path) &&
+          !config.entries.find(
+            (entry) => path === (entry as { source: string }).source,
+          )
+        ) {
+          return true; // ignore md or html files not in entries source
+        }
+        if (
+          config.themeIndexes.find((theme) =>
+            theme.type === 'file'
+              ? path === theme.destination
+              : theme.type === 'package' &&
+                pathStartsWith(path, theme.destination),
+          )
+        ) {
+          return true; // ignore copied theme files
+        }
+        return false;
+      },
+      cwd: config.entries.length ? context : config.entryContextDir,
+    })
+    .on('all', (event, path) => {
+      if (
+        upath.join(config.entryContextDir, path) === config.input.entry ||
+        /\.(md|markdown|html?|xhtml|xht|css|jpe?g|png|gif|svg)$/i.test(path)
+      ) {
+        handleChangeEvent(path);
+      }
+    });
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,7 +3,6 @@ import addFormats from 'ajv-formats';
 import chalk from 'chalk';
 import cheerio from 'cheerio';
 import fs from 'fs';
-import process from 'process';
 import puppeteer from 'puppeteer';
 import resolvePkg from 'resolve-pkg';
 import path from 'upath';
@@ -28,7 +27,7 @@ import type {
 } from './schema/vivliostyle.config';
 import configSchema from './schema/vivliostyle.config.schema.json';
 import { PageSize } from './server';
-import { debug, log, readJSON, touchTmpFile } from './util';
+import { cwd, debug, log, readJSON, touchTmpFile } from './util';
 
 export type ParsedTheme = UriTheme | FileTheme | PackageTheme;
 
@@ -291,7 +290,6 @@ export function collectVivliostyleConfig<T extends CliFlags>(
     return config;
   };
 
-  const cwd = process.cwd();
   let vivliostyleConfigPath = cliFlags.configPath
     ? path.resolve(cwd, cliFlags.configPath)
     : path.join(cwd, 'vivliostyle.config.js');
@@ -303,7 +301,7 @@ export function collectVivliostyleConfig<T extends CliFlags>(
   ) {
     // Load an input argument as a Vivliostyle config
     try {
-      const inputPath = path.resolve(process.cwd(), cliFlags.input);
+      const inputPath = path.resolve(cwd, cliFlags.input);
       const inputConfig = load(inputPath);
       if (inputConfig) {
         cliFlags = {
@@ -334,7 +332,7 @@ export async function mergeConfig<T extends CliFlags>(
   let workspaceDir: string;
 
   if (cliFlags.input && /https?:\/\//.test(cliFlags.input)) {
-    workspaceDir = entryContextDir = process.cwd();
+    workspaceDir = entryContextDir = cwd;
   } else {
     entryContextDir = path.resolve(
       cliFlags.input
@@ -365,7 +363,7 @@ export async function mergeConfig<T extends CliFlags>(
 
   const themeIndexes: ParsedTheme[] = [];
   const rootTheme =
-    parseTheme(cliFlags.theme, process.cwd(), workspaceDir) ??
+    parseTheme(cliFlags.theme, cwd, workspaceDir) ??
     parseTheme(config?.theme, context, workspaceDir);
   if (rootTheme) {
     themeIndexes.push(rootTheme);

--- a/src/util.ts
+++ b/src/util.ts
@@ -185,7 +185,7 @@ export function encodeHashParameter(params: Record<string, string>): string {
 }
 
 export function pathStartsWith(path1: string, path2: string): boolean {
-  const path1n = upath.normalizeTrim(path1) + '/';
-  const path2n = upath.normalizeTrim(path2) + '/';
+  const path1n = upath.normalize(path1).replace(/\/?$/, '/');
+  const path2n = upath.normalize(path2).replace(/\/?$/, '/');
   return path1n.startsWith(path2n);
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -6,9 +6,11 @@ import oraConstructor from 'ora';
 import puppeteer from 'puppeteer';
 import shelljs from 'shelljs';
 import tmp from 'tmp';
+import upath from 'upath';
 import util from 'util';
 
 export const debug = debugConstructor('vs-cli');
+export const cwd = upath.normalize(process.cwd());
 
 const ora = oraConstructor({ color: 'blue', spinner: 'circle' });
 
@@ -180,4 +182,10 @@ export function encodeHashParameter(params: Record<string, string>): string {
       return `${k}=${value}`;
     })
     .join('&');
+}
+
+export function pathStartsWith(path1: string, path2: string): boolean {
+  const path1n = upath.normalizeTrim(path1) + '/';
+  const path2n = upath.normalizeTrim(path2) + '/';
+  return path1n.startsWith(path2n);
 }


### PR DESCRIPTION
Fixes the following problems:

- On Windows, `process.cwd()` returns Windows path containing backslashes
  and it causes problem when matching with `startsWith()` to other paths
  that are normalized using forward slashes.
- When config file is not used, `workspaceDir` and `entryContextDir` are
  set to the directory containing the input file. In this condition,
  file changes inside that directory (`p.startsWith(config.workspaceDir)`)
  are ignored, but file changes in the current directory are watched.
  This is contrary to the expected behavior.
- XHTML, EPUB (.epub or .opf), pub-manifest (.json) input are ignored.