### PR TITLE
feat: include validation error details in the exception message

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -102,8 +102,13 @@ export function generateManifest(
   ajv.addSchema(publicationSchemas);
   const valid = ajv.validate(publicationSchemaId, publication);
   if (!valid) {
+    const errors = ajv.errors
+      ?.map((value, index, array) => {
+        return `${value.dataPath} ${value.message}`;
+      })
+      .join('\n');
     throw new Error(
-      `Validation of pubManifest failed. Please check the schema: ${outputPath}`,
+      `Validation of pubManifest failed. Please check the schema: ${outputPath}\n${errors}`,
     );
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -283,8 +283,13 @@ export function collectVivliostyleConfig<T extends CliFlags>(
     addFormats(ajv);
     const valid = ajv.validate(configSchema, config);
     if (!valid) {
+      const errors = ajv.errors
+        ?.map((value, index, array) => {
+          return `${value.dataPath} ${value.message}`;
+        })
+        .join('\n');
       throw new Error(
-        `Validation of vivliostyle.config failed. Please check the schema: ${configPath}`,
+        `Validation of vivliostyle.config failed. Please check the schema: ${configPath}\n${errors}`,
       );
     }
     return config;


### PR DESCRIPTION
vivliostyle.config.jsやpublication.jsonの書式をAjvを使ってヴァリデーションチェックを行なっています。
しかし現状ではエラーになった際にどの項目が問題になったか不明なため、解決の為の手掛りが得られません。

そこで、エラーの詳細を例外メッセージに含めるように変更しました。

実際に作業中にしてしまったミスですが、vivliostyle.config.jsに以下のように記述すると

```
entry: ['bunko.md','bunko.html'],
```

bunko.mdがコンパイルされた結果bunko.htmlを上書きし、publication.jsonに同じファイルが二つ並ぶことになります。
その際のバリデーションエラーが以下のように表示されますが原因はわかりません。

```
✖ Error: Validation of pubManifest failed. Please check the schema: /[SNIP]/vivliostyle-cli/examples/theme-preset/publication.json
```

同じ状況で、このPRによって以下のように表示されるようになります。

```
✖ Error: Validation of pubManifest failed. Please check the schema: /[SNIP]/vivliostyle-cli/examples/theme-preset/publication.json
/readingOrder should be string
/readingOrder should be object
/readingOrder should match exactly one schema in oneOf
/readingOrder should NOT have duplicate items (items ## 0 and 1 are identical)
/readingOrder should match exactly one schema in oneOf
```

Ajvは正しい記述の可能性を全て出力するようなので原因を絞り込めていませんが、"should NOT have duplicate items"がヒントになって問題の原因に気付きました。

vivliostyle.config.jsでもcliのビルドとスキーマファイルのバージョン違いによるミスを低減できると考えています。