### PR TITLE
feat: add config_version to vivliostyle.config.js

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -104,6 +104,7 @@ export type ManifestConfig = XOR<
 >;
 
 export type MergedConfig = {
+  config_version: number;
   entryContextDir: string;
   workspaceDir: string;
   entries: ParsedEntry[];
@@ -349,6 +350,7 @@ export async function mergeConfig<T extends CliFlags>(
       : [config.includeAssets]
     : DEFAULT_ASSETS;
 
+  const config_version = config?.config_version ?? 0;
   const language = cliFlags.language ?? config?.language ?? null;
   const sizeFlag = cliFlags.size ?? config?.size;
   const size = sizeFlag ? parsePageSize(sizeFlag) : undefined;
@@ -409,6 +411,7 @@ export async function mergeConfig<T extends CliFlags>(
   })();
 
   const commonOpts: CommonOpts = {
+    config_version,
     entryContextDir,
     workspaceDir,
     includeAssets,

--- a/src/schema/vivliostyle.config.d.ts
+++ b/src/schema/vivliostyle.config.d.ts
@@ -11,6 +11,10 @@ export type Output = string;
 
 export interface CoreProps {
   /**
+   * Config version
+   */
+  config_version: number;
+  /**
    * Title
    */
   title?: string;

--- a/src/schema/vivliostyle.config.schema.json
+++ b/src/schema/vivliostyle.config.schema.json
@@ -157,6 +157,11 @@
         "timeout": {
           "type": "number",
           "minimum": 0
+        },
+        "config_version": {
+          "type": "number",
+          "minimum": 3.0,
+          "maximum": 3.0
         }
       }
     }

--- a/tests/__snapshots__/config.test.ts.snap
+++ b/tests/__snapshots__/config.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`imports a EPUB OPF file 1`] = `
 Object {
+  "config_version": 0,
   "cover": undefined,
   "entries": Array [],
   "entryContextDir": "__WORKSPACE__/tests/fixtures/epubs/adaptive/OPS",
@@ -44,6 +45,7 @@ Object {
 
 exports[`imports a EPUB file 1`] = `
 Object {
+  "config_version": 0,
   "cover": undefined,
   "entries": Array [],
   "entryContextDir": "__WORKSPACE__/tests/fixtures/epubs",
@@ -86,6 +88,7 @@ Object {
 
 exports[`imports a https URL 1`] = `
 Object {
+  "config_version": 0,
   "cover": undefined,
   "entries": Array [],
   "entryContextDir": "__WORKSPACE__",
@@ -128,6 +131,7 @@ Object {
 
 exports[`imports a webbook compliant to Readium Web publication 1`] = `
 Object {
+  "config_version": 0,
   "cover": undefined,
   "entries": Array [],
   "entryContextDir": "__WORKSPACE__/tests/fixtures/webbooks/readium-webpub",
@@ -171,6 +175,7 @@ Object {
 
 exports[`imports a webbook compliant to W3C Web publication 1`] = `
 Object {
+  "config_version": 0,
   "cover": undefined,
   "entries": Array [],
   "entryContextDir": "__WORKSPACE__/tests/fixtures/webbooks/w3c-webpub",
@@ -214,6 +219,7 @@ Object {
 
 exports[`imports single html file 1`] = `
 Object {
+  "config_version": 0,
   "cover": undefined,
   "entries": Array [],
   "entryContextDir": "__WORKSPACE__/tests/fixtures/config",
@@ -256,6 +262,7 @@ Object {
 
 exports[`override option by CLI command: valid.1.config.js 1`] = `
 Object {
+  "config_version": 0,
   "cover": "__WORKSPACE__/tests/fixtures/config/cover.png",
   "entries": Array [
     Object {
@@ -354,6 +361,7 @@ Object {
 
 exports[`parse vivliostyle config: valid.1.config.js 1`] = `
 Object {
+  "config_version": 0,
   "cover": "__WORKSPACE__/tests/fixtures/config/cover.png",
   "entries": Array [
     Object {
@@ -458,6 +466,7 @@ Object {
 
 exports[`parse vivliostyle config: valid.2.config.js 1`] = `
 Object {
+  "config_version": 0,
   "cover": undefined,
   "entries": Array [
     Object {
@@ -512,6 +521,62 @@ Object {
 
 exports[`parse vivliostyle config: valid.3.config.js 1`] = `
 Object {
+  "config_version": 0,
+  "cover": undefined,
+  "entries": Array [
+    Object {
+      "source": "__WORKSPACE__/tests/fixtures/config/manuscript.md",
+      "target": "__WORKSPACE__/tests/fixtures/config/manuscript.html",
+      "theme": undefined,
+      "title": "example",
+      "type": "text/markdown",
+    },
+  ],
+  "entryContextDir": "__WORKSPACE__/tests/fixtures/config",
+  "executableChromium": "__EXECUTABLE_CHROMIUM_PATH__",
+  "exportAliases": Array [],
+  "includeAssets": Array [
+    "**/*.png",
+    "**/*.jpg",
+    "**/*.jpeg",
+    "**/*.svg",
+    "**/*.gif",
+    "**/*.webp",
+    "**/*.apng",
+    "**/*.ttf",
+    "**/*.otf",
+    "**/*.woff",
+    "**/*.woff2",
+  ],
+  "input": Object {
+    "entry": "__WORKSPACE__/tests/fixtures/config/publication.json",
+    "format": "pub-manifest",
+  },
+  "language": null,
+  "manifestAutoGenerate": Object {
+    "author": "pkgAuthor",
+    "title": "example",
+  },
+  "manifestPath": "__WORKSPACE__/tests/fixtures/config/publication.json",
+  "outputs": Array [
+    Object {
+      "format": "pdf",
+      "path": "__WORKSPACE__/tests/fixtures/config/example.pdf",
+    },
+  ],
+  "pressReady": false,
+  "sandbox": true,
+  "size": undefined,
+  "themeIndexes": Array [],
+  "timeout": 120000,
+  "verbose": false,
+  "workspaceDir": "__WORKSPACE__/tests/fixtures/config",
+}
+`;
+
+exports[`parse vivliostyle config: valid.4.config.js 1`] = `
+Object {
+  "config_version": 3,
   "cover": undefined,
   "entries": Array [
     Object {
@@ -566,6 +631,7 @@ Object {
 
 exports[`yields a config with single input and vivliostyle config 1`] = `
 Object {
+  "config_version": 0,
   "cover": "__WORKSPACE__/tests/fixtures/config/cover.png",
   "entries": Array [
     Object {
@@ -640,6 +706,7 @@ Object {
 
 exports[`yields a config with single markdown 1`] = `
 Object {
+  "config_version": 0,
   "cover": undefined,
   "entries": Array [
     Object {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -6,8 +6,10 @@ const configFiles = [
   'valid.1',
   'valid.2',
   'valid.3',
+  'valid.4',
   'invalid.1',
   'invalid.2',
+  'invalid.3',
 ] as const;
 const configFilePath = configFiles.reduce(
   (p, v) => ({
@@ -33,6 +35,10 @@ it('parse vivliostyle config', async () => {
   const validConfig3 = await getMergedConfig(['-c', configFilePath['valid.3']]);
   maskConfig(validConfig3);
   expect(validConfig3).toMatchSnapshot('valid.3.config.js');
+
+  const validConfig4 = await getMergedConfig(['-c', configFilePath['valid.4']]);
+  maskConfig(validConfig4);
+  expect(validConfig4).toMatchSnapshot('valid.4.config.js');
 });
 
 it('override option by CLI command', async () => {
@@ -73,6 +79,12 @@ it('deny invalid config', () => {
 it('deny config which has no entry', () => {
   expect(
     getMergedConfig(['-c', configFilePath['invalid.2']]),
+  ).rejects.toThrow();
+});
+
+it('deny config version mismatch', () => {
+  expect(
+    getMergedConfig(['-c', configFilePath['invalid.3']]),
   ).rejects.toThrow();
 });
 

--- a/tests/fixtures/config/vivliostyle.config.invalid.3.js
+++ b/tests/fixtures/config/vivliostyle.config.invalid.3.js
@@ -1,0 +1,6 @@
+module.exports = {
+  config_version: 0.0, // invalid version
+  title: 'example',
+  entry: { path: 'manuscript.md' },
+  // output: 'example.pdf',
+};

--- a/tests/fixtures/config/vivliostyle.config.valid.4.js
+++ b/tests/fixtures/config/vivliostyle.config.valid.4.js
@@ -1,0 +1,6 @@
+module.exports = {
+  config_version: 3.0, // valid version
+  title: 'example',
+  entry: { path: 'manuscript.md' },
+  // output: 'example.pdf',
+};


### PR DESCRIPTION
2021年3月度の開発者会議で、vivliostyle.config.jsのバージョンチェックを入れたいという話がありましたが、
スキーマ定義を利用してバージョンの項目を追加してみました。

仮で"config_version: 3.0,"という記述にしていますが以下の項目は検討が必要だと思います。

* 項目名:"version"だけや、"conf_ver"のような省略形、"schema_version"、"schema"のような項目名も候補になると思います。
* 値の型: スキーマのminimum,maximumでバージョンチェックがしやすいので数値のほうが良いと思いますが、整数、実数のどちらが良いのか。
* バージョンの初期値: 1から始めるか、cliのバージョンに合わせるのか。バージョン項目なしはどうするのか。
* バージョンアップのルール

#153 と合わせて、バージョンが合わない場合に処理を停止し理由を表示できるようになります。