### PR TITLE
feat: Add additional/user stylesheet options

### DIFF
--- a/src/commands/build.parser.ts
+++ b/src/commands/build.parser.ts
@@ -74,6 +74,8 @@ If an extension is specified on -o option, this field will be inferenced automat
 preset: A5, A4, A3, B5, B4, JIS-B5, JIS-B4, letter, legal, ledger
 custom(comma separated): 182mm,257mm or 8.5in,11in`,
     )
+    .option('--style <stylesheet>', 'additional stylesheet URL or path')
+    .option('--user-style <user_stylesheet>', 'user stylesheet URL or path')
     .option(
       '-p, --press-ready',
       `make generated PDF compatible with press ready PDF/X-1a [false]`,

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -19,6 +19,8 @@ try {
     targets: options.targets,
     theme: options.theme,
     size: options.size,
+    style: options.style,
+    userStyle: options.userStyle,
     title: options.title,
     author: options.author,
     language: options.language,
@@ -65,6 +67,8 @@ export default async function build(cliFlags: BuildCliFlags) {
           config.webbookEntryPath ??
           config.epubOpfPath) as string,
         output: target.path,
+        style: cliFlags.style,
+        userStyle: cliFlags.userStyle,
       });
     } else if (target.format === 'webpub') {
       if (!config.manifestPath) {

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -67,8 +67,8 @@ export default async function build(cliFlags: BuildCliFlags) {
           config.webbookEntryPath ??
           config.epubOpfPath) as string,
         output: target.path,
-        style: cliFlags.style,
-        userStyle: cliFlags.userStyle,
+        customStyle: config.customStyle,
+        customUserStyle: config.customUserStyle,
       });
     } else if (target.format === 'webpub') {
       if (!config.manifestPath) {

--- a/src/commands/preview.parser.ts
+++ b/src/commands/preview.parser.ts
@@ -17,6 +17,8 @@ export function setupPreviewParserProgram(): commander.Command {
 preset: A5, A4, A3, B5, B4, JIS-B5, JIS-B4, letter, legal, ledger
 custom(comma separated): 182mm,257mm or 8.5in,11in`,
     )
+    .option('--style <stylesheet>', 'additional stylesheet URL or path')
+    .option('--user-style <user_stylesheet>', 'user stylesheet URL or path')
     .option('--title <title>', 'title')
     .option('--author <author>', 'author')
     .option('-l, --language <language>', 'language')

--- a/src/commands/preview.ts
+++ b/src/commands/preview.ts
@@ -66,8 +66,8 @@ export default async function preview(cliFlags: PreviewCliFlags) {
       config.webbookEntryPath ??
       config.epubOpfPath) as string,
     outputSize: config.size,
-    style: cliFlags.style,
-    userStyle: cliFlags.userStyle,
+    style: config.customStyle,
+    userStyle: config.customUserStyle,
   });
 
   debug(

--- a/src/commands/preview.ts
+++ b/src/commands/preview.ts
@@ -8,6 +8,7 @@ import {
   cwd,
   debug,
   gracefulError,
+  isUrlString,
   launchBrowser,
   logSuccess,
   pathStartsWith,
@@ -27,6 +28,8 @@ try {
     configPath: options.config,
     theme: options.theme,
     size: options.size,
+    style: options.style,
+    userStyle: options.userStyle,
     title: options.title,
     author: options.author,
     language: options.language,
@@ -63,6 +66,8 @@ export default async function preview(cliFlags: PreviewCliFlags) {
       config.webbookEntryPath ??
       config.epubOpfPath) as string,
     outputSize: config.size,
+    style: cliFlags.style,
+    userStyle: cliFlags.userStyle,
   });
 
   debug(
@@ -99,7 +104,7 @@ export default async function preview(cliFlags: PreviewCliFlags) {
     }, 2000);
   }
 
-  if (/https?:\/\//.test(config.input.entry)) {
+  if (isUrlString(config.input.entry)) {
     return;
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,7 @@ import fs from 'fs';
 import puppeteer from 'puppeteer';
 import resolvePkg from 'resolve-pkg';
 import path from 'upath';
+import { pathToFileURL } from 'url';
 import { MANIFEST_FILENAME, TOC_FILENAME, TOC_TITLE } from './const';
 import { openEpubToTmpDirectory } from './epub';
 import {
@@ -118,8 +119,8 @@ export type MergedConfig = {
     target: string;
   }[];
   size: PageSize | undefined;
-  style: string | undefined;
-  userStyle: string | undefined;
+  customStyle: string | undefined;
+  customUserStyle: string | undefined;
   pressReady: boolean;
   language: string | null;
   cover: string | undefined;
@@ -356,8 +357,16 @@ export async function mergeConfig<T extends CliFlags>(
   const language = cliFlags.language ?? config?.language ?? null;
   const sizeFlag = cliFlags.size ?? config?.size;
   const size = sizeFlag ? parsePageSize(sizeFlag) : undefined;
-  const style = cliFlags.style;
-  const userStyle = cliFlags.userStyle;
+  const customStyle =
+    cliFlags.style &&
+    (isUrlString(cliFlags.style)
+      ? cliFlags.style
+      : pathToFileURL(cliFlags.style).href);
+  const customUserStyle =
+    cliFlags.userStyle &&
+    (isUrlString(cliFlags.userStyle)
+      ? cliFlags.userStyle
+      : pathToFileURL(cliFlags.userStyle).href);
   const cover = contextResolve(entryContextDir, config?.cover) ?? undefined;
   const pressReady = cliFlags.pressReady ?? config?.pressReady ?? false;
 
@@ -422,8 +431,8 @@ export async function mergeConfig<T extends CliFlags>(
     themeIndexes,
     pressReady,
     size,
-    style,
-    userStyle,
+    customStyle,
+    customUserStyle,
     language,
     cover,
     verbose,

--- a/src/pdf.ts
+++ b/src/pdf.ts
@@ -31,6 +31,8 @@ export async function buildPDF({
   output,
   workspaceDir,
   size,
+  style,
+  userStyle,
   executableChromium,
   sandbox,
   verbose,
@@ -44,6 +46,8 @@ export async function buildPDF({
   const navigateURL = getBrokerUrl({
     sourceIndex: input,
     outputSize: size,
+    style,
+    userStyle,
   });
   debug('brokerURL', navigateURL);
 

--- a/src/pdf.ts
+++ b/src/pdf.ts
@@ -31,8 +31,8 @@ export async function buildPDF({
   output,
   workspaceDir,
   size,
-  style,
-  userStyle,
+  customStyle,
+  customUserStyle,
   executableChromium,
   sandbox,
   verbose,
@@ -46,8 +46,8 @@ export async function buildPDF({
   const navigateURL = getBrokerUrl({
     sourceIndex: input,
     outputSize: size,
-    style,
-    userStyle,
+    style: customStyle,
+    userStyle: customUserStyle,
   });
   debug('brokerURL', navigateURL);
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -39,17 +39,26 @@ export function getBrokerUrl({
         (outputSize as { height: string }).height
       }`);
 
-  let viewerParams = `src=${sourceUrl.href}&bookMode=${loadMode === 'book'}`;
+  function escapeParam(url: string) {
+    return url.replace(/&/g, '%26');
+  }
+
+  let viewerParams = `src=${escapeParam(sourceUrl.href)}&bookMode=${
+    loadMode === 'book'
+  }`;
 
   if (style) {
     viewerParams +=
-      '&style=' + (isUrlString(style) ? style : pathToFileURL(style).href);
+      '&style=' +
+      escapeParam(isUrlString(style) ? style : pathToFileURL(style).href);
   }
 
   if (userStyle) {
     viewerParams +=
       '&userStyle=' +
-      (isUrlString(userStyle) ? userStyle : pathToFileURL(userStyle).href);
+      escapeParam(
+        isUrlString(userStyle) ? userStyle : pathToFileURL(userStyle).href,
+      );
   }
 
   if (pageSizeValue) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -47,17 +47,11 @@ export function getBrokerUrl({
   }`;
 
   if (style) {
-    viewerParams +=
-      '&style=' +
-      escapeParam(isUrlString(style) ? style : pathToFileURL(style).href);
+    viewerParams += `&style=${escapeParam(style)}`;
   }
 
   if (userStyle) {
-    viewerParams +=
-      '&userStyle=' +
-      escapeParam(
-        isUrlString(userStyle) ? userStyle : pathToFileURL(userStyle).href,
-      );
+    viewerParams += `&userStyle=${escapeParam(userStyle)}`;
   }
 
   if (pageSizeValue) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,7 @@
 import resolvePkg from 'resolve-pkg';
 import upath from 'upath';
-import { URL } from 'url';
+import { pathToFileURL, URL } from 'url';
+import { isUrlString } from './util';
 
 export type LoadMode = 'document' | 'book';
 export type PageSize = { format: string } | { width: string; height: string };
@@ -9,17 +10,20 @@ export function getBrokerUrl({
   sourceIndex,
   loadMode = 'book',
   outputSize,
+  style,
+  userStyle,
 }: {
   sourceIndex: string;
   loadMode?: LoadMode;
   outputSize?: PageSize;
+  style?: string;
+  userStyle?: string;
 }) {
   let sourceUrl: URL;
-  if (/https?:\/\//.test(sourceIndex)) {
+  if (isUrlString(sourceIndex)) {
     sourceUrl = new URL(sourceIndex);
   } else {
-    sourceUrl = new URL('file://');
-    sourceUrl.pathname = sourceIndex;
+    sourceUrl = pathToFileURL(sourceIndex);
   }
 
   const viewerUrl = new URL('file://');
@@ -36,6 +40,17 @@ export function getBrokerUrl({
       }`);
 
   let viewerParams = `src=${sourceUrl.href}&bookMode=${loadMode === 'book'}`;
+
+  if (style) {
+    viewerParams +=
+      '&style=' + (isUrlString(style) ? style : pathToFileURL(style).href);
+  }
+
+  if (userStyle) {
+    viewerParams +=
+      '&userStyle=' +
+      (isUrlString(userStyle) ? userStyle : pathToFileURL(userStyle).href);
+  }
 
   if (pageSizeValue) {
     viewerParams +=

--- a/src/util.ts
+++ b/src/util.ts
@@ -172,3 +172,7 @@ export function pathStartsWith(path1: string, path2: string): boolean {
   const path2n = upath.normalize(path2).replace(/\/?$/, '/');
   return path1n.startsWith(path2n);
 }
+
+export function isUrlString(str: string): boolean {
+  return /^(https?|file|data):/i.test(str);
+}

--- a/tests/__snapshots__/config.test.ts.snap
+++ b/tests/__snapshots__/config.test.ts.snap
@@ -269,8 +269,8 @@ Object {
 exports[`override option by CLI command: valid.1.config.js 1`] = `
 Object {
   "cover": "__WORKSPACE__/tests/fixtures/config/cover.png",
-  "customStyle": undefined,
-  "customUserStyle": undefined,
+  "customStyle": "https://vivlostyle.org",
+  "customUserStyle": "file://__WORKSPACE__/user/style/dummy.css",
   "entries": Array [
     Object {
       "rel": "contents",

--- a/tests/__snapshots__/config.test.ts.snap
+++ b/tests/__snapshots__/config.test.ts.snap
@@ -35,8 +35,10 @@ Object {
   "pressReady": false,
   "sandbox": true,
   "size": undefined,
+  "style": undefined,
   "themeIndexes": Array [],
   "timeout": 120000,
+  "userStyle": undefined,
   "verbose": false,
   "workspaceDir": "__WORKSPACE__/tests/fixtures/epubs/adaptive/OPS",
 }
@@ -77,8 +79,10 @@ Object {
   "pressReady": false,
   "sandbox": true,
   "size": undefined,
+  "style": undefined,
   "themeIndexes": Array [],
   "timeout": 120000,
+  "userStyle": undefined,
   "verbose": false,
   "workspaceDir": "__WORKSPACE__/tests/fixtures/epubs",
 }
@@ -118,8 +122,10 @@ Object {
   "pressReady": false,
   "sandbox": true,
   "size": undefined,
+  "style": undefined,
   "themeIndexes": Array [],
   "timeout": 120000,
+  "userStyle": undefined,
   "verbose": false,
   "webbookEntryPath": "https://vivliostyle.github.io/vivliostyle_doc/ja/vivliostyle-user-group-vol1/",
   "workspaceDir": "__WORKSPACE__",
@@ -162,8 +168,10 @@ Object {
   "pressReady": false,
   "sandbox": true,
   "size": undefined,
+  "style": undefined,
   "themeIndexes": Array [],
   "timeout": 120000,
+  "userStyle": undefined,
   "verbose": false,
   "workspaceDir": "__WORKSPACE__/tests/fixtures/webbooks/readium-webpub",
 }
@@ -205,8 +213,10 @@ Object {
   "pressReady": false,
   "sandbox": true,
   "size": undefined,
+  "style": undefined,
   "themeIndexes": Array [],
   "timeout": 120000,
+  "userStyle": undefined,
   "verbose": false,
   "workspaceDir": "__WORKSPACE__/tests/fixtures/webbooks/w3c-webpub",
 }
@@ -246,8 +256,10 @@ Object {
   "pressReady": false,
   "sandbox": true,
   "size": undefined,
+  "style": undefined,
   "themeIndexes": Array [],
   "timeout": 120000,
+  "userStyle": undefined,
   "verbose": false,
   "webbookEntryPath": "__WORKSPACE__/tests/fixtures/config/sample.html",
   "workspaceDir": "__WORKSPACE__/tests/fixtures/config",
@@ -333,6 +345,7 @@ Object {
   "size": Object {
     "format": "JIS-B5",
   },
+  "style": undefined,
   "themeIndexes": Array [
     Object {
       "location": "https://myTheme.example.com",
@@ -347,6 +360,7 @@ Object {
     },
   ],
   "timeout": 42000,
+  "userStyle": undefined,
   "verbose": false,
   "workspaceDir": "__WORKSPACE__/tests/fixtures/config/workspaceDir",
 }
@@ -435,6 +449,7 @@ Object {
   "size": Object {
     "format": "size",
   },
+  "style": undefined,
   "themeIndexes": Array [
     Object {
       "destination": "__WORKSPACE__/tests/fixtures/config/workspaceDir/themes/packages/debug-theme",
@@ -451,6 +466,7 @@ Object {
     },
   ],
   "timeout": 1,
+  "userStyle": undefined,
   "verbose": false,
   "workspaceDir": "__WORKSPACE__/tests/fixtures/config/workspaceDir",
 }
@@ -503,8 +519,10 @@ Object {
   "pressReady": false,
   "sandbox": true,
   "size": undefined,
+  "style": undefined,
   "themeIndexes": Array [],
   "timeout": 120000,
+  "userStyle": undefined,
   "verbose": false,
   "workspaceDir": "__WORKSPACE__/tests/fixtures/config",
 }
@@ -557,8 +575,10 @@ Object {
   "pressReady": false,
   "sandbox": true,
   "size": undefined,
+  "style": undefined,
   "themeIndexes": Array [],
   "timeout": 120000,
+  "userStyle": undefined,
   "verbose": false,
   "workspaceDir": "__WORKSPACE__/tests/fixtures/config",
 }
@@ -623,6 +643,7 @@ Object {
   "size": Object {
     "format": "size",
   },
+  "style": undefined,
   "themeIndexes": Array [
     Object {
       "destination": "__WORKSPACE__/tests/fixtures/config/workspaceDir/themes/packages/debug-theme",
@@ -633,6 +654,7 @@ Object {
     },
   ],
   "timeout": 1,
+  "userStyle": undefined,
   "verbose": false,
   "workspaceDir": "__WORKSPACE__/tests/fixtures/config/workspaceDir",
 }
@@ -685,8 +707,10 @@ Object {
   "pressReady": false,
   "sandbox": true,
   "size": undefined,
+  "style": undefined,
   "themeIndexes": Array [],
   "timeout": 120000,
+  "userStyle": undefined,
   "verbose": false,
   "workspaceDir": "__WORKSPACE__/tests/fixtures/config",
 }

--- a/tests/__snapshots__/config.test.ts.snap
+++ b/tests/__snapshots__/config.test.ts.snap
@@ -3,6 +3,8 @@
 exports[`imports a EPUB OPF file 1`] = `
 Object {
   "cover": undefined,
+  "customStyle": undefined,
+  "customUserStyle": undefined,
   "entries": Array [],
   "entryContextDir": "__WORKSPACE__/tests/fixtures/epubs/adaptive/OPS",
   "epubOpfPath": "__WORKSPACE__/tests/fixtures/epubs/adaptive/OPS/content.opf",
@@ -35,10 +37,8 @@ Object {
   "pressReady": false,
   "sandbox": true,
   "size": undefined,
-  "style": undefined,
   "themeIndexes": Array [],
   "timeout": 120000,
-  "userStyle": undefined,
   "verbose": false,
   "workspaceDir": "__WORKSPACE__/tests/fixtures/epubs/adaptive/OPS",
 }
@@ -47,6 +47,8 @@ Object {
 exports[`imports a EPUB file 1`] = `
 Object {
   "cover": undefined,
+  "customStyle": undefined,
+  "customUserStyle": undefined,
   "entries": Array [],
   "entryContextDir": "__WORKSPACE__/tests/fixtures/epubs",
   "epubOpfPath": "__SNIP__",
@@ -79,10 +81,8 @@ Object {
   "pressReady": false,
   "sandbox": true,
   "size": undefined,
-  "style": undefined,
   "themeIndexes": Array [],
   "timeout": 120000,
-  "userStyle": undefined,
   "verbose": false,
   "workspaceDir": "__WORKSPACE__/tests/fixtures/epubs",
 }
@@ -91,6 +91,8 @@ Object {
 exports[`imports a https URL 1`] = `
 Object {
   "cover": undefined,
+  "customStyle": undefined,
+  "customUserStyle": undefined,
   "entries": Array [],
   "entryContextDir": "__WORKSPACE__",
   "executableChromium": "__EXECUTABLE_CHROMIUM_PATH__",
@@ -122,10 +124,8 @@ Object {
   "pressReady": false,
   "sandbox": true,
   "size": undefined,
-  "style": undefined,
   "themeIndexes": Array [],
   "timeout": 120000,
-  "userStyle": undefined,
   "verbose": false,
   "webbookEntryPath": "https://vivliostyle.github.io/vivliostyle_doc/ja/vivliostyle-user-group-vol1/",
   "workspaceDir": "__WORKSPACE__",
@@ -135,6 +135,8 @@ Object {
 exports[`imports a webbook compliant to Readium Web publication 1`] = `
 Object {
   "cover": undefined,
+  "customStyle": undefined,
+  "customUserStyle": undefined,
   "entries": Array [],
   "entryContextDir": "__WORKSPACE__/tests/fixtures/webbooks/readium-webpub",
   "executableChromium": "__EXECUTABLE_CHROMIUM_PATH__",
@@ -168,10 +170,8 @@ Object {
   "pressReady": false,
   "sandbox": true,
   "size": undefined,
-  "style": undefined,
   "themeIndexes": Array [],
   "timeout": 120000,
-  "userStyle": undefined,
   "verbose": false,
   "workspaceDir": "__WORKSPACE__/tests/fixtures/webbooks/readium-webpub",
 }
@@ -180,6 +180,8 @@ Object {
 exports[`imports a webbook compliant to W3C Web publication 1`] = `
 Object {
   "cover": undefined,
+  "customStyle": undefined,
+  "customUserStyle": undefined,
   "entries": Array [],
   "entryContextDir": "__WORKSPACE__/tests/fixtures/webbooks/w3c-webpub",
   "executableChromium": "__EXECUTABLE_CHROMIUM_PATH__",
@@ -213,10 +215,8 @@ Object {
   "pressReady": false,
   "sandbox": true,
   "size": undefined,
-  "style": undefined,
   "themeIndexes": Array [],
   "timeout": 120000,
-  "userStyle": undefined,
   "verbose": false,
   "workspaceDir": "__WORKSPACE__/tests/fixtures/webbooks/w3c-webpub",
 }
@@ -225,6 +225,8 @@ Object {
 exports[`imports single html file 1`] = `
 Object {
   "cover": undefined,
+  "customStyle": undefined,
+  "customUserStyle": undefined,
   "entries": Array [],
   "entryContextDir": "__WORKSPACE__/tests/fixtures/config",
   "executableChromium": "__EXECUTABLE_CHROMIUM_PATH__",
@@ -256,10 +258,8 @@ Object {
   "pressReady": false,
   "sandbox": true,
   "size": undefined,
-  "style": undefined,
   "themeIndexes": Array [],
   "timeout": 120000,
-  "userStyle": undefined,
   "verbose": false,
   "webbookEntryPath": "__WORKSPACE__/tests/fixtures/config/sample.html",
   "workspaceDir": "__WORKSPACE__/tests/fixtures/config",
@@ -269,6 +269,8 @@ Object {
 exports[`override option by CLI command: valid.1.config.js 1`] = `
 Object {
   "cover": "__WORKSPACE__/tests/fixtures/config/cover.png",
+  "customStyle": undefined,
+  "customUserStyle": undefined,
   "entries": Array [
     Object {
       "rel": "contents",
@@ -345,7 +347,6 @@ Object {
   "size": Object {
     "format": "JIS-B5",
   },
-  "style": undefined,
   "themeIndexes": Array [
     Object {
       "location": "https://myTheme.example.com",
@@ -360,7 +361,6 @@ Object {
     },
   ],
   "timeout": 42000,
-  "userStyle": undefined,
   "verbose": false,
   "workspaceDir": "__WORKSPACE__/tests/fixtures/config/workspaceDir",
 }
@@ -369,6 +369,8 @@ Object {
 exports[`parse vivliostyle config: valid.1.config.js 1`] = `
 Object {
   "cover": "__WORKSPACE__/tests/fixtures/config/cover.png",
+  "customStyle": undefined,
+  "customUserStyle": undefined,
   "entries": Array [
     Object {
       "rel": "contents",
@@ -449,7 +451,6 @@ Object {
   "size": Object {
     "format": "size",
   },
-  "style": undefined,
   "themeIndexes": Array [
     Object {
       "destination": "__WORKSPACE__/tests/fixtures/config/workspaceDir/themes/packages/debug-theme",
@@ -466,7 +467,6 @@ Object {
     },
   ],
   "timeout": 1,
-  "userStyle": undefined,
   "verbose": false,
   "workspaceDir": "__WORKSPACE__/tests/fixtures/config/workspaceDir",
 }
@@ -475,6 +475,8 @@ Object {
 exports[`parse vivliostyle config: valid.2.config.js 1`] = `
 Object {
   "cover": undefined,
+  "customStyle": undefined,
+  "customUserStyle": undefined,
   "entries": Array [
     Object {
       "source": "__WORKSPACE__/tests/fixtures/config/manuscript.md",
@@ -519,10 +521,8 @@ Object {
   "pressReady": false,
   "sandbox": true,
   "size": undefined,
-  "style": undefined,
   "themeIndexes": Array [],
   "timeout": 120000,
-  "userStyle": undefined,
   "verbose": false,
   "workspaceDir": "__WORKSPACE__/tests/fixtures/config",
 }
@@ -531,6 +531,8 @@ Object {
 exports[`parse vivliostyle config: valid.3.config.js 1`] = `
 Object {
   "cover": undefined,
+  "customStyle": undefined,
+  "customUserStyle": undefined,
   "entries": Array [
     Object {
       "source": "__WORKSPACE__/tests/fixtures/config/manuscript.md",
@@ -575,10 +577,8 @@ Object {
   "pressReady": false,
   "sandbox": true,
   "size": undefined,
-  "style": undefined,
   "themeIndexes": Array [],
   "timeout": 120000,
-  "userStyle": undefined,
   "verbose": false,
   "workspaceDir": "__WORKSPACE__/tests/fixtures/config",
 }
@@ -587,6 +587,8 @@ Object {
 exports[`yields a config with single input and vivliostyle config 1`] = `
 Object {
   "cover": "__WORKSPACE__/tests/fixtures/config/cover.png",
+  "customStyle": undefined,
+  "customUserStyle": undefined,
   "entries": Array [
     Object {
       "source": "__WORKSPACE__/tests/fixtures/config/sample.md",
@@ -643,7 +645,6 @@ Object {
   "size": Object {
     "format": "size",
   },
-  "style": undefined,
   "themeIndexes": Array [
     Object {
       "destination": "__WORKSPACE__/tests/fixtures/config/workspaceDir/themes/packages/debug-theme",
@@ -654,7 +655,6 @@ Object {
     },
   ],
   "timeout": 1,
-  "userStyle": undefined,
   "verbose": false,
   "workspaceDir": "__WORKSPACE__/tests/fixtures/config/workspaceDir",
 }
@@ -663,6 +663,8 @@ Object {
 exports[`yields a config with single markdown 1`] = `
 Object {
   "cover": undefined,
+  "customStyle": undefined,
+  "customUserStyle": undefined,
   "entries": Array [
     Object {
       "source": "__WORKSPACE__/tests/fixtures/config/sample.md",
@@ -707,10 +709,8 @@ Object {
   "pressReady": false,
   "sandbox": true,
   "size": undefined,
-  "style": undefined,
   "themeIndexes": Array [],
   "timeout": 120000,
-  "userStyle": undefined,
   "verbose": false,
   "workspaceDir": "__WORKSPACE__/tests/fixtures/config",
 }

--- a/tests/broker.test.ts
+++ b/tests/broker.test.ts
@@ -1,0 +1,33 @@
+import { getBrokerUrl } from '../src/server';
+import { maskConfig } from './commandUtil';
+
+it('converts to valid broker url', async () => {
+  const validOut1 = {
+    url: getBrokerUrl({
+      sourceIndex: '/absolute/path/to/manifest/file.json',
+    }),
+  };
+  maskConfig(validOut1);
+  expect(validOut1.url).toBe(
+    'file://__WORKSPACE__/node_modules/@vivliostyle/viewer/lib/index.html#src=file:///absolute/path/to/manifest/file.json&bookMode=true',
+  );
+
+  const validOut2 = {
+    url: getBrokerUrl({
+      sourceIndex: '/absolute/path/to/something',
+      loadMode: 'document',
+      outputSize: {
+        width: '5in',
+        height: '10in',
+      },
+      style:
+        'data:,#test>p::before{content:"エスケープ チェック";display:block}',
+      userStyle:
+        'file://path/to/local/style/file/which/might/include/white space/&/special#?character.css',
+    }),
+  };
+  maskConfig(validOut2);
+  expect(validOut2.url).toBe(
+    'file://__WORKSPACE__/node_modules/@vivliostyle/viewer/lib/index.html#src=file:///absolute/path/to/something&bookMode=false&style=data:,#test>p::before{content:"エスケープ チェック";display:block}&userStyle=file://path/to/local/style/file/which/might/include/white space/%26/special#?character.css&userStyle=data:,/*<viewer>*/%40page%7Bsize%3A5in%2010in!important%3B%7D/*</viewer>*/',
+  );
+});

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -59,6 +59,10 @@ it('override option by CLI command', async () => {
     '42',
     '--executable-chromium',
     'myChromium',
+    '--style',
+    'https://vivlostyle.org',
+    '--user-style',
+    './user/style/dummy.css',
   ]);
   maskConfig(config);
   expect(config).toMatchSnapshot('valid.1.config.js');


### PR DESCRIPTION
Resolves #112

New CLI options:

```
  --style <stylesheet>            additional stylesheet URL or path
  --user-style <user_stylesheet>  user stylesheet URL or path
```

These options are passed to the vivliostyle-viewer `style` and `userStyle` parameters.

Note:
- `--style` is to add an [author stylesheet](https://developer.mozilla.org/en-US/docs/Web/CSS/Cascade#author_stylesheets),
  and `--user-style` is to set a [user stylesheet](https://developer.mozilla.org/en-US/docs/Web/CSS/Cascade#user_stylesheets).
- The stylesheet URL can be a data URL, e.g., `data:,@page{margin:0}body{margin:0}`.
- A relative path is resolved relative to the current working directory.

With this update, URL tests using `/^https?:\/\//.test(str)` are replaced to `isUrlString(str)`,
which tests `/^(https?|file|data):/i.test(str)`, to add support for data and file URLs.