### PR TITLE
fix: Preview watch not refreshed when CSS file is changed

### DIFF
--- a/src/commands/preview.ts
+++ b/src/commands/preview.ts
@@ -127,11 +127,13 @@ export default async function preview(cliFlags: PreviewCliFlags) {
           return true; // ignore md or html files not in entries source
         }
         if (
-          config.themeIndexes.find((theme) =>
-            theme.type === 'file'
-              ? path === theme.destination
-              : theme.type === 'package' &&
-                pathStartsWith(path, theme.destination),
+          config.themeIndexes.find(
+            (theme) =>
+              (theme as any).destination !== theme.location &&
+              (theme.type === 'file'
+                ? path === theme.destination
+                : theme.type === 'package' &&
+                  pathStartsWith(path, theme.destination)),
           )
         ) {
           return true; // ignore copied theme files

--- a/src/commands/preview.ts
+++ b/src/commands/preview.ts
@@ -129,11 +129,11 @@ export default async function preview(cliFlags: PreviewCliFlags) {
         if (
           config.themeIndexes.find(
             (theme) =>
-              (theme as any).destination !== theme.location &&
+              (theme.type === 'file' || theme.type === 'package') &&
+              theme.destination !== theme.location &&
               (theme.type === 'file'
                 ? path === theme.destination
-                : theme.type === 'package' &&
-                  pathStartsWith(path, theme.destination)),
+                : pathStartsWith(path, theme.destination)),
           )
         ) {
           return true; // ignore copied theme files


### PR DESCRIPTION
This is a follow-up fix of https://github.com/vivliostyle/vivliostyle-cli/pull/149.

