### PR TITLE
fix: Non-ASCII directory/file is not available. Error: Validation of pubManifest failed

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -46,7 +46,7 @@ export function generateManifest(
   },
 ) {
   const entries: PublicationLinks[] = options.entries.map((entry) => ({
-    url: entry.path,
+    url: encodeURI(entry.path),
     title: entry.title,
     ...(entry.encodingFormat && { encodingFormat: entry.encodingFormat }),
     ...(entry.rel && { rel: entry.rel }),
@@ -65,7 +65,7 @@ export function generateManifest(
       if (mimeType) {
         links.push({
           rel: 'cover',
-          url: options.cover,
+          url: encodeURI(options.cover),
           encodingFormat: mimeType,
           width,
           height,

--- a/src/html.ts
+++ b/src/html.ts
@@ -26,7 +26,7 @@ export function generateTocHtml({
       'li',
       h(
         'a',
-        { href: path.relative(distDir, entry.target) },
+        { href: encodeURI(path.relative(distDir, entry.target)) },
         entry.title || path.basename(entry.target, '.html'),
       ),
     ),
@@ -38,7 +38,7 @@ export function generateTocHtml({
       ...[
         h('title', title ?? ''),
         h('link', {
-          href: path.relative(distDir, manifestPath),
+          href: encodeURI(path.relative(distDir, manifestPath)),
           rel: 'publication',
           type: 'application/ld+json',
         }),


### PR DESCRIPTION
Fixes #155

publication.json と 目次 HTML に url として渡されるパスを `encodeURI()` でエンコードするようにしました。

