### PR TITLE
feat: add VFM options (hardLineBreaks, disableFormatHtml) to vivliostyle.config.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [3.2.1](https://github.com/vivliostyle/vivliostyle-cli/compare/v3.2.0...v3.2.1) (2021-03-29)
+
+### Bug Fixes
+
+- Update Vivliostyle version to 2.6.2 ([fe058df](https://github.com/vivliostyle/vivliostyle-cli/commit/fe058df59a6802ea054db78571dadeeab229933f))
+
 # [3.2.0](https://github.com/vivliostyle/vivliostyle-cli/compare/v3.1.2...v3.2.0) (2021-03-29)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vivliostyle/cli",
   "description": "Save the pdf file via Headless Chrome and Vivliostyle.",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "author": "spring_raining <harusamex.com@gmail.com>",
   "scripts": {
     "build": "yarn clean && run-p build:*",

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -118,8 +118,7 @@ export async function compile(
     entries,
     language,
     cover,
-    hardLineBreaks,
-    disableFormatHtml,
+    vfmOptions,
     input,
   }: MergedConfig & WebPublicationManifestConfig,
   { reload = false }: { reload?: boolean } = {},
@@ -170,11 +169,10 @@ export async function compile(
     if (entry.type === 'text/markdown') {
       // compile markdown
       const vfile = processMarkdown(entry.source, {
+        ...vfmOptions,
         style,
         title: entry.title,
         language: language ?? undefined,
-        hardLineBreaks: hardLineBreaks ?? undefined,
-        disableFormatHtml: disableFormatHtml ?? undefined,
       });
       const compiledEntry = String(vfile);
       fs.writeFileSync(entry.target, compiledEntry);

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -118,6 +118,8 @@ export async function compile(
     entries,
     language,
     cover,
+    hardLineBreaks,
+    disableFormatHtml,
     input,
   }: MergedConfig & WebPublicationManifestConfig,
   { reload = false }: { reload?: boolean } = {},
@@ -171,6 +173,8 @@ export async function compile(
         style,
         title: entry.title,
         language: language ?? undefined,
+        hardLineBreaks: hardLineBreaks ?? undefined,
+        disableFormatHtml: disableFormatHtml ?? undefined,
       });
       const compiledEntry = String(vfile);
       fs.writeFileSync(entry.target, compiledEntry);

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -55,6 +55,10 @@ export default async function init(cliFlags: InitCliFlags) {
   // workspaceDir: '.vivliostyle', // directory which is saved intermediate files.
   // toc: true, // whether generate and include ToC HTML or not, default to 'false'.
   // cover: './cover.png', // cover image. default to undefined.
+  // vfm: { // options of VFM processor
+  //   hardLineBreaks: true, // converts line breaks of VFM to <br> tags. default to 'false'.
+  //   disableFormatHtml: true, // disables HTML formatting. default to 'false'.
+  // },
 };
 `;
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -127,8 +127,10 @@ export type MergedConfig = {
   quick: boolean;
   pressReady: boolean;
   language: string | null;
-  hardLineBreaks: boolean | undefined;
-  disableFormatHtml: boolean | undefined;
+  vfmOptions: {
+    hardLineBreaks: boolean;
+    disableFormatHtml: boolean;
+  };
   cover: string | undefined;
   verbose: boolean;
   timeout: number;
@@ -378,8 +380,10 @@ export async function mergeConfig<T extends CliFlags>(
   const cover = contextResolve(entryContextDir, config?.cover) ?? undefined;
   const pressReady = cliFlags.pressReady ?? config?.pressReady ?? false;
 
-  const hardLineBreaks = config?.hardLineBreaks ?? undefined;
-  const disableFormatHtml = config?.disableFormatHtml ?? undefined;
+  const vfmOptions = {
+    hardLineBreaks: config?.vfm?.hardLineBreaks ?? false,
+    disableFormatHtml: config?.vfm?.disableFormatHtml ?? false,
+  };
 
   const verbose = cliFlags.verbose ?? false;
   const timeout = cliFlags.timeout ?? config?.timeout ?? DEFAULT_TIMEOUT;
@@ -447,8 +451,7 @@ export async function mergeConfig<T extends CliFlags>(
     singleDoc,
     quick,
     language,
-    hardLineBreaks,
-    disableFormatHtml,
+    vfmOptions,
     cover,
     verbose,
     timeout,

--- a/src/config.ts
+++ b/src/config.ts
@@ -127,6 +127,8 @@ export type MergedConfig = {
   quick: boolean;
   pressReady: boolean;
   language: string | null;
+  hardLineBreaks: boolean | undefined;
+  disableFormatHtml: boolean | undefined;
   cover: string | undefined;
   verbose: boolean;
   timeout: number;
@@ -376,6 +378,9 @@ export async function mergeConfig<T extends CliFlags>(
   const cover = contextResolve(entryContextDir, config?.cover) ?? undefined;
   const pressReady = cliFlags.pressReady ?? config?.pressReady ?? false;
 
+  const hardLineBreaks = config?.hardLineBreaks ?? undefined;
+  const disableFormatHtml = config?.disableFormatHtml ?? undefined;
+
   const verbose = cliFlags.verbose ?? false;
   const timeout = cliFlags.timeout ?? config?.timeout ?? DEFAULT_TIMEOUT;
   const sandbox = cliFlags.sandbox ?? true;
@@ -442,6 +447,8 @@ export async function mergeConfig<T extends CliFlags>(
     singleDoc,
     quick,
     language,
+    hardLineBreaks,
+    disableFormatHtml,
     cover,
     verbose,
     timeout,

--- a/src/schema/vivliostyle.config.d.ts
+++ b/src/schema/vivliostyle.config.d.ts
@@ -34,8 +34,10 @@ export interface CoreProps {
   tocTitle?: string;
   cover?: string;
   timeout?: number;
-  hardLineBreaks?: boolean;
-  disableFormatHtml?: boolean;
+  vfm?: {
+    hardLineBreaks?: boolean;
+    disableFormatHtml?: boolean;
+  };
   [k: string]: unknown;
 }
 export interface EntryObject {

--- a/src/schema/vivliostyle.config.d.ts
+++ b/src/schema/vivliostyle.config.d.ts
@@ -34,6 +34,8 @@ export interface CoreProps {
   tocTitle?: string;
   cover?: string;
   timeout?: number;
+  hardLineBreaks?: boolean;
+  disableFormatHtml?: boolean;
   [k: string]: unknown;
 }
 export interface EntryObject {

--- a/src/schema/vivliostyle.config.schema.json
+++ b/src/schema/vivliostyle.config.schema.json
@@ -157,6 +157,12 @@
         "timeout": {
           "type": "number",
           "minimum": 0
+        },
+        "hardLineBreaks": {
+          "type": "boolean"
+        },
+        "disableFormatHtml": {
+          "type": "boolean"
         }
       }
     }

--- a/src/schema/vivliostyle.config.schema.json
+++ b/src/schema/vivliostyle.config.schema.json
@@ -158,11 +158,17 @@
           "type": "number",
           "minimum": 0
         },
-        "hardLineBreaks": {
-          "type": "boolean"
-        },
-        "disableFormatHtml": {
-          "type": "boolean"
+        "vfm": {
+          "type": "object",
+          "properties": {
+            "hardLineBreaks": {
+              "type": "boolean"
+            },
+            "disableFormatHtml": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
         }
       }
     }

--- a/tests/__snapshots__/config.test.ts.snap
+++ b/tests/__snapshots__/config.test.ts.snap
@@ -5,13 +5,11 @@ Object {
   "cover": undefined,
   "customStyle": undefined,
   "customUserStyle": undefined,
-  "disableFormatHtml": undefined,
   "entries": Array [],
   "entryContextDir": "__WORKSPACE__/tests/fixtures/epubs/adaptive/OPS",
   "epubOpfPath": "__WORKSPACE__/tests/fixtures/epubs/adaptive/OPS/content.opf",
   "executableChromium": "__EXECUTABLE_CHROMIUM_PATH__",
   "exportAliases": Array [],
-  "hardLineBreaks": undefined,
   "includeAssets": Array [
     "**/*.png",
     "**/*.jpg",
@@ -44,6 +42,10 @@ Object {
   "themeIndexes": Array [],
   "timeout": 120000,
   "verbose": false,
+  "vfmOptions": Object {
+    "disableFormatHtml": false,
+    "hardLineBreaks": false,
+  },
   "workspaceDir": "__WORKSPACE__/tests/fixtures/epubs/adaptive/OPS",
 }
 `;
@@ -53,13 +55,11 @@ Object {
   "cover": undefined,
   "customStyle": undefined,
   "customUserStyle": undefined,
-  "disableFormatHtml": undefined,
   "entries": Array [],
   "entryContextDir": "__WORKSPACE__/tests/fixtures/epubs",
   "epubOpfPath": "__SNIP__",
   "executableChromium": "__EXECUTABLE_CHROMIUM_PATH__",
   "exportAliases": Array [],
-  "hardLineBreaks": undefined,
   "includeAssets": Array [
     "**/*.png",
     "**/*.jpg",
@@ -92,6 +92,10 @@ Object {
   "themeIndexes": Array [],
   "timeout": 120000,
   "verbose": false,
+  "vfmOptions": Object {
+    "disableFormatHtml": false,
+    "hardLineBreaks": false,
+  },
   "workspaceDir": "__WORKSPACE__/tests/fixtures/epubs",
 }
 `;
@@ -101,12 +105,10 @@ Object {
   "cover": undefined,
   "customStyle": undefined,
   "customUserStyle": undefined,
-  "disableFormatHtml": undefined,
   "entries": Array [],
   "entryContextDir": "__WORKSPACE__",
   "executableChromium": "__EXECUTABLE_CHROMIUM_PATH__",
   "exportAliases": Array [],
-  "hardLineBreaks": undefined,
   "includeAssets": Array [
     "**/*.png",
     "**/*.jpg",
@@ -139,6 +141,10 @@ Object {
   "themeIndexes": Array [],
   "timeout": 120000,
   "verbose": false,
+  "vfmOptions": Object {
+    "disableFormatHtml": false,
+    "hardLineBreaks": false,
+  },
   "webbookEntryPath": "https://vivliostyle.github.io/vivliostyle_doc/ja/vivliostyle-user-group-vol1/",
   "workspaceDir": "__WORKSPACE__",
 }
@@ -149,12 +155,10 @@ Object {
   "cover": undefined,
   "customStyle": undefined,
   "customUserStyle": undefined,
-  "disableFormatHtml": undefined,
   "entries": Array [],
   "entryContextDir": "__WORKSPACE__/tests/fixtures/webbooks/readium-webpub",
   "executableChromium": "__EXECUTABLE_CHROMIUM_PATH__",
   "exportAliases": Array [],
-  "hardLineBreaks": undefined,
   "includeAssets": Array [
     "**/*.png",
     "**/*.jpg",
@@ -189,6 +193,10 @@ Object {
   "themeIndexes": Array [],
   "timeout": 120000,
   "verbose": false,
+  "vfmOptions": Object {
+    "disableFormatHtml": false,
+    "hardLineBreaks": false,
+  },
   "workspaceDir": "__WORKSPACE__/tests/fixtures/webbooks/readium-webpub",
 }
 `;
@@ -198,12 +206,10 @@ Object {
   "cover": undefined,
   "customStyle": undefined,
   "customUserStyle": undefined,
-  "disableFormatHtml": undefined,
   "entries": Array [],
   "entryContextDir": "__WORKSPACE__/tests/fixtures/webbooks/w3c-webpub",
   "executableChromium": "__EXECUTABLE_CHROMIUM_PATH__",
   "exportAliases": Array [],
-  "hardLineBreaks": undefined,
   "includeAssets": Array [
     "**/*.png",
     "**/*.jpg",
@@ -238,6 +244,10 @@ Object {
   "themeIndexes": Array [],
   "timeout": 120000,
   "verbose": false,
+  "vfmOptions": Object {
+    "disableFormatHtml": false,
+    "hardLineBreaks": false,
+  },
   "workspaceDir": "__WORKSPACE__/tests/fixtures/webbooks/w3c-webpub",
 }
 `;
@@ -247,12 +257,10 @@ Object {
   "cover": undefined,
   "customStyle": undefined,
   "customUserStyle": undefined,
-  "disableFormatHtml": undefined,
   "entries": Array [],
   "entryContextDir": "__WORKSPACE__/tests/fixtures/config",
   "executableChromium": "__EXECUTABLE_CHROMIUM_PATH__",
   "exportAliases": Array [],
-  "hardLineBreaks": undefined,
   "includeAssets": Array [
     "**/*.png",
     "**/*.jpg",
@@ -285,6 +293,10 @@ Object {
   "themeIndexes": Array [],
   "timeout": 120000,
   "verbose": false,
+  "vfmOptions": Object {
+    "disableFormatHtml": false,
+    "hardLineBreaks": false,
+  },
   "webbookEntryPath": "__WORKSPACE__/tests/fixtures/config/sample.html",
   "workspaceDir": "__WORKSPACE__/tests/fixtures/config",
 }
@@ -295,7 +307,6 @@ Object {
   "cover": "__WORKSPACE__/tests/fixtures/config/cover.png",
   "customStyle": "https://vivlostyle.org",
   "customUserStyle": "file://__WORKSPACE__/user/style/dummy.css",
-  "disableFormatHtml": undefined,
   "entries": Array [
     Object {
       "rel": "contents",
@@ -334,7 +345,6 @@ Object {
   "entryContextDir": "__WORKSPACE__/tests/fixtures/config",
   "executableChromium": "__EXECUTABLE_CHROMIUM_PATH__",
   "exportAliases": Array [],
-  "hardLineBreaks": undefined,
   "includeAssets": Array [
     "**/*.png",
     "**/*.jpg",
@@ -390,6 +400,10 @@ Object {
   ],
   "timeout": 42000,
   "verbose": false,
+  "vfmOptions": Object {
+    "disableFormatHtml": false,
+    "hardLineBreaks": false,
+  },
   "workspaceDir": "__WORKSPACE__/tests/fixtures/config/workspaceDir",
 }
 `;
@@ -399,7 +413,6 @@ Object {
   "cover": "__WORKSPACE__/tests/fixtures/config/cover.png",
   "customStyle": undefined,
   "customUserStyle": undefined,
-  "disableFormatHtml": undefined,
   "entries": Array [
     Object {
       "rel": "contents",
@@ -442,7 +455,6 @@ Object {
   "entryContextDir": "__WORKSPACE__/tests/fixtures/config",
   "executableChromium": "__EXECUTABLE_CHROMIUM_PATH__",
   "exportAliases": Array [],
-  "hardLineBreaks": undefined,
   "includeAssets": Array [
     "**/*.png",
     "**/*.jpg",
@@ -500,6 +512,10 @@ Object {
   ],
   "timeout": 1,
   "verbose": false,
+  "vfmOptions": Object {
+    "disableFormatHtml": false,
+    "hardLineBreaks": false,
+  },
   "workspaceDir": "__WORKSPACE__/tests/fixtures/config/workspaceDir",
 }
 `;
@@ -509,7 +525,6 @@ Object {
   "cover": undefined,
   "customStyle": undefined,
   "customUserStyle": undefined,
-  "disableFormatHtml": undefined,
   "entries": Array [
     Object {
       "source": "__WORKSPACE__/tests/fixtures/config/manuscript.md",
@@ -522,7 +537,6 @@ Object {
   "entryContextDir": "__WORKSPACE__/tests/fixtures/config",
   "executableChromium": "__EXECUTABLE_CHROMIUM_PATH__",
   "exportAliases": Array [],
-  "hardLineBreaks": undefined,
   "includeAssets": Array [
     "**/*.png",
     "**/*.jpg",
@@ -560,6 +574,10 @@ Object {
   "themeIndexes": Array [],
   "timeout": 120000,
   "verbose": false,
+  "vfmOptions": Object {
+    "disableFormatHtml": false,
+    "hardLineBreaks": false,
+  },
   "workspaceDir": "__WORKSPACE__/tests/fixtures/config",
 }
 `;
@@ -569,7 +587,6 @@ Object {
   "cover": undefined,
   "customStyle": undefined,
   "customUserStyle": undefined,
-  "disableFormatHtml": undefined,
   "entries": Array [
     Object {
       "source": "__WORKSPACE__/tests/fixtures/config/manuscript.md",
@@ -582,7 +599,6 @@ Object {
   "entryContextDir": "__WORKSPACE__/tests/fixtures/config",
   "executableChromium": "__EXECUTABLE_CHROMIUM_PATH__",
   "exportAliases": Array [],
-  "hardLineBreaks": undefined,
   "includeAssets": Array [
     "**/*.png",
     "**/*.jpg",
@@ -620,6 +636,10 @@ Object {
   "themeIndexes": Array [],
   "timeout": 120000,
   "verbose": false,
+  "vfmOptions": Object {
+    "disableFormatHtml": false,
+    "hardLineBreaks": false,
+  },
   "workspaceDir": "__WORKSPACE__/tests/fixtures/config",
 }
 `;
@@ -629,7 +649,6 @@ Object {
   "cover": "__WORKSPACE__/tests/fixtures/config/cover.png",
   "customStyle": undefined,
   "customUserStyle": undefined,
-  "disableFormatHtml": undefined,
   "entries": Array [
     Object {
       "source": "__WORKSPACE__/tests/fixtures/config/sample.md",
@@ -648,7 +667,6 @@ Object {
   "entryContextDir": "__WORKSPACE__/tests/fixtures/config",
   "executableChromium": "__EXECUTABLE_CHROMIUM_PATH__",
   "exportAliases": "__SNIP__",
-  "hardLineBreaks": undefined,
   "includeAssets": Array [
     "**/*.png",
     "**/*.jpg",
@@ -700,6 +718,10 @@ Object {
   ],
   "timeout": 1,
   "verbose": false,
+  "vfmOptions": Object {
+    "disableFormatHtml": false,
+    "hardLineBreaks": false,
+  },
   "workspaceDir": "__WORKSPACE__/tests/fixtures/config/workspaceDir",
 }
 `;
@@ -709,7 +731,6 @@ Object {
   "cover": undefined,
   "customStyle": undefined,
   "customUserStyle": undefined,
-  "disableFormatHtml": undefined,
   "entries": Array [
     Object {
       "source": "__WORKSPACE__/tests/fixtures/config/sample.md",
@@ -722,7 +743,6 @@ Object {
   "entryContextDir": "__WORKSPACE__/tests/fixtures/config",
   "executableChromium": "__EXECUTABLE_CHROMIUM_PATH__",
   "exportAliases": "__SNIP__",
-  "hardLineBreaks": undefined,
   "includeAssets": Array [
     "**/*.png",
     "**/*.jpg",
@@ -760,6 +780,10 @@ Object {
   "themeIndexes": Array [],
   "timeout": 120000,
   "verbose": false,
+  "vfmOptions": Object {
+    "disableFormatHtml": false,
+    "hardLineBreaks": false,
+  },
   "workspaceDir": "__WORKSPACE__/tests/fixtures/config",
 }
 `;

--- a/tests/__snapshots__/config.test.ts.snap
+++ b/tests/__snapshots__/config.test.ts.snap
@@ -394,6 +394,116 @@ Object {
 }
 `;
 
+exports[`parse vivliostyle config: valid.1.config.js 1`] = `
+Object {
+  "cover": "__WORKSPACE__/tests/fixtures/config/cover.png",
+  "customStyle": undefined,
+  "customUserStyle": undefined,
+  "disableFormatHtml": undefined,
+  "entries": Array [
+    Object {
+      "rel": "contents",
+      "target": "__WORKSPACE__/tests/fixtures/config/workspaceDir/toc.html",
+      "theme": Object {
+        "destination": "__WORKSPACE__/tests/fixtures/config/workspaceDir/themes/packages/debug-theme",
+        "location": "__WORKSPACE__/tests/fixtures/themes/debug-theme",
+        "name": "debug-theme",
+        "style": "./theme.css",
+        "type": "package",
+      },
+      "title": "Table of Contents",
+    },
+    Object {
+      "source": "__WORKSPACE__/tests/fixtures/config/manuscript.md",
+      "target": "__WORKSPACE__/tests/fixtures/config/workspaceDir/manuscript.html",
+      "theme": Object {
+        "destination": "__WORKSPACE__/tests/fixtures/config/workspaceDir/themes/packages/debug-theme",
+        "location": "__WORKSPACE__/tests/fixtures/themes/debug-theme",
+        "name": "debug-theme",
+        "style": "./theme.css",
+        "type": "package",
+      },
+      "title": "title",
+      "type": "text/markdown",
+    },
+    Object {
+      "source": "__WORKSPACE__/tests/fixtures/config/manuscript.md",
+      "target": "__WORKSPACE__/tests/fixtures/config/workspaceDir/manuscript.html",
+      "theme": Object {
+        "destination": "__WORKSPACE__/tests/fixtures/config/workspaceDir/theme.css",
+        "location": "__WORKSPACE__/tests/fixtures/config/theme.css",
+        "name": "theme.css",
+        "type": "file",
+      },
+      "title": "title",
+      "type": "text/markdown",
+    },
+  ],
+  "entryContextDir": "__WORKSPACE__/tests/fixtures/config",
+  "executableChromium": "__EXECUTABLE_CHROMIUM_PATH__",
+  "exportAliases": Array [],
+  "hardLineBreaks": undefined,
+  "includeAssets": Array [
+    "**/*.png",
+    "**/*.jpg",
+    "**/*.jpeg",
+    "**/*.svg",
+    "**/*.gif",
+    "**/*.webp",
+    "**/*.apng",
+    "**/*.ttf",
+    "**/*.otf",
+    "**/*.woff",
+    "**/*.woff2",
+  ],
+  "input": Object {
+    "entry": "__WORKSPACE__/tests/fixtures/config/workspaceDir/publication.json",
+    "format": "pub-manifest",
+  },
+  "language": "language",
+  "manifestAutoGenerate": Object {
+    "author": "author",
+    "title": "title",
+  },
+  "manifestPath": "__WORKSPACE__/tests/fixtures/config/workspaceDir/publication.json",
+  "outputs": Array [
+    Object {
+      "format": "pdf",
+      "path": "__WORKSPACE__/tests/fixtures/config/output1.pdf",
+    },
+    Object {
+      "format": "pdf",
+      "path": "__WORKSPACE__/tests/fixtures/config/output2.pdf",
+    },
+  ],
+  "pressReady": true,
+  "quick": false,
+  "sandbox": true,
+  "singleDoc": false,
+  "size": Object {
+    "format": "size",
+  },
+  "themeIndexes": Array [
+    Object {
+      "destination": "__WORKSPACE__/tests/fixtures/config/workspaceDir/themes/packages/debug-theme",
+      "location": "__WORKSPACE__/tests/fixtures/themes/debug-theme",
+      "name": "debug-theme",
+      "style": "./theme.css",
+      "type": "package",
+    },
+    Object {
+      "destination": "__WORKSPACE__/tests/fixtures/config/workspaceDir/theme.css",
+      "location": "__WORKSPACE__/tests/fixtures/config/theme.css",
+      "name": "theme.css",
+      "type": "file",
+    },
+  ],
+  "timeout": 1,
+  "verbose": false,
+  "workspaceDir": "__WORKSPACE__/tests/fixtures/config/workspaceDir",
+}
+`;
+
 exports[`parse vivliostyle config: valid.2.config.js 1`] = `
 Object {
   "cover": undefined,

--- a/tests/__snapshots__/config.test.ts.snap
+++ b/tests/__snapshots__/config.test.ts.snap
@@ -401,8 +401,8 @@ Object {
   "timeout": 42000,
   "verbose": false,
   "vfmOptions": Object {
-    "disableFormatHtml": false,
-    "hardLineBreaks": false,
+    "disableFormatHtml": true,
+    "hardLineBreaks": true,
   },
   "workspaceDir": "__WORKSPACE__/tests/fixtures/config/workspaceDir",
 }
@@ -513,8 +513,8 @@ Object {
   "timeout": 1,
   "verbose": false,
   "vfmOptions": Object {
-    "disableFormatHtml": false,
-    "hardLineBreaks": false,
+    "disableFormatHtml": true,
+    "hardLineBreaks": true,
   },
   "workspaceDir": "__WORKSPACE__/tests/fixtures/config/workspaceDir",
 }
@@ -719,8 +719,8 @@ Object {
   "timeout": 1,
   "verbose": false,
   "vfmOptions": Object {
-    "disableFormatHtml": false,
-    "hardLineBreaks": false,
+    "disableFormatHtml": true,
+    "hardLineBreaks": true,
   },
   "workspaceDir": "__WORKSPACE__/tests/fixtures/config/workspaceDir",
 }

--- a/tests/__snapshots__/config.test.ts.snap
+++ b/tests/__snapshots__/config.test.ts.snap
@@ -5,11 +5,13 @@ Object {
   "cover": undefined,
   "customStyle": undefined,
   "customUserStyle": undefined,
+  "disableFormatHtml": undefined,
   "entries": Array [],
   "entryContextDir": "__WORKSPACE__/tests/fixtures/epubs/adaptive/OPS",
   "epubOpfPath": "__WORKSPACE__/tests/fixtures/epubs/adaptive/OPS/content.opf",
   "executableChromium": "__EXECUTABLE_CHROMIUM_PATH__",
   "exportAliases": Array [],
+  "hardLineBreaks": undefined,
   "includeAssets": Array [
     "**/*.png",
     "**/*.jpg",
@@ -51,11 +53,13 @@ Object {
   "cover": undefined,
   "customStyle": undefined,
   "customUserStyle": undefined,
+  "disableFormatHtml": undefined,
   "entries": Array [],
   "entryContextDir": "__WORKSPACE__/tests/fixtures/epubs",
   "epubOpfPath": "__SNIP__",
   "executableChromium": "__EXECUTABLE_CHROMIUM_PATH__",
   "exportAliases": Array [],
+  "hardLineBreaks": undefined,
   "includeAssets": Array [
     "**/*.png",
     "**/*.jpg",
@@ -97,10 +101,12 @@ Object {
   "cover": undefined,
   "customStyle": undefined,
   "customUserStyle": undefined,
+  "disableFormatHtml": undefined,
   "entries": Array [],
   "entryContextDir": "__WORKSPACE__",
   "executableChromium": "__EXECUTABLE_CHROMIUM_PATH__",
   "exportAliases": Array [],
+  "hardLineBreaks": undefined,
   "includeAssets": Array [
     "**/*.png",
     "**/*.jpg",
@@ -143,10 +149,12 @@ Object {
   "cover": undefined,
   "customStyle": undefined,
   "customUserStyle": undefined,
+  "disableFormatHtml": undefined,
   "entries": Array [],
   "entryContextDir": "__WORKSPACE__/tests/fixtures/webbooks/readium-webpub",
   "executableChromium": "__EXECUTABLE_CHROMIUM_PATH__",
   "exportAliases": Array [],
+  "hardLineBreaks": undefined,
   "includeAssets": Array [
     "**/*.png",
     "**/*.jpg",
@@ -190,10 +198,12 @@ Object {
   "cover": undefined,
   "customStyle": undefined,
   "customUserStyle": undefined,
+  "disableFormatHtml": undefined,
   "entries": Array [],
   "entryContextDir": "__WORKSPACE__/tests/fixtures/webbooks/w3c-webpub",
   "executableChromium": "__EXECUTABLE_CHROMIUM_PATH__",
   "exportAliases": Array [],
+  "hardLineBreaks": undefined,
   "includeAssets": Array [
     "**/*.png",
     "**/*.jpg",
@@ -237,10 +247,12 @@ Object {
   "cover": undefined,
   "customStyle": undefined,
   "customUserStyle": undefined,
+  "disableFormatHtml": undefined,
   "entries": Array [],
   "entryContextDir": "__WORKSPACE__/tests/fixtures/config",
   "executableChromium": "__EXECUTABLE_CHROMIUM_PATH__",
   "exportAliases": Array [],
+  "hardLineBreaks": undefined,
   "includeAssets": Array [
     "**/*.png",
     "**/*.jpg",
@@ -283,6 +295,7 @@ Object {
   "cover": "__WORKSPACE__/tests/fixtures/config/cover.png",
   "customStyle": "https://vivlostyle.org",
   "customUserStyle": "file://__WORKSPACE__/user/style/dummy.css",
+  "disableFormatHtml": undefined,
   "entries": Array [
     Object {
       "rel": "contents",
@@ -321,6 +334,7 @@ Object {
   "entryContextDir": "__WORKSPACE__/tests/fixtures/config",
   "executableChromium": "__EXECUTABLE_CHROMIUM_PATH__",
   "exportAliases": Array [],
+  "hardLineBreaks": undefined,
   "includeAssets": Array [
     "**/*.png",
     "**/*.jpg",
@@ -380,119 +394,12 @@ Object {
 }
 `;
 
-exports[`parse vivliostyle config: valid.1.config.js 1`] = `
-Object {
-  "cover": "__WORKSPACE__/tests/fixtures/config/cover.png",
-  "customStyle": undefined,
-  "customUserStyle": undefined,
-  "entries": Array [
-    Object {
-      "rel": "contents",
-      "target": "__WORKSPACE__/tests/fixtures/config/workspaceDir/toc.html",
-      "theme": Object {
-        "destination": "__WORKSPACE__/tests/fixtures/config/workspaceDir/themes/packages/debug-theme",
-        "location": "__WORKSPACE__/tests/fixtures/themes/debug-theme",
-        "name": "debug-theme",
-        "style": "./theme.css",
-        "type": "package",
-      },
-      "title": "Table of Contents",
-    },
-    Object {
-      "source": "__WORKSPACE__/tests/fixtures/config/manuscript.md",
-      "target": "__WORKSPACE__/tests/fixtures/config/workspaceDir/manuscript.html",
-      "theme": Object {
-        "destination": "__WORKSPACE__/tests/fixtures/config/workspaceDir/themes/packages/debug-theme",
-        "location": "__WORKSPACE__/tests/fixtures/themes/debug-theme",
-        "name": "debug-theme",
-        "style": "./theme.css",
-        "type": "package",
-      },
-      "title": "title",
-      "type": "text/markdown",
-    },
-    Object {
-      "source": "__WORKSPACE__/tests/fixtures/config/manuscript.md",
-      "target": "__WORKSPACE__/tests/fixtures/config/workspaceDir/manuscript.html",
-      "theme": Object {
-        "destination": "__WORKSPACE__/tests/fixtures/config/workspaceDir/theme.css",
-        "location": "__WORKSPACE__/tests/fixtures/config/theme.css",
-        "name": "theme.css",
-        "type": "file",
-      },
-      "title": "title",
-      "type": "text/markdown",
-    },
-  ],
-  "entryContextDir": "__WORKSPACE__/tests/fixtures/config",
-  "executableChromium": "__EXECUTABLE_CHROMIUM_PATH__",
-  "exportAliases": Array [],
-  "includeAssets": Array [
-    "**/*.png",
-    "**/*.jpg",
-    "**/*.jpeg",
-    "**/*.svg",
-    "**/*.gif",
-    "**/*.webp",
-    "**/*.apng",
-    "**/*.ttf",
-    "**/*.otf",
-    "**/*.woff",
-    "**/*.woff2",
-  ],
-  "input": Object {
-    "entry": "__WORKSPACE__/tests/fixtures/config/workspaceDir/publication.json",
-    "format": "pub-manifest",
-  },
-  "language": "language",
-  "manifestAutoGenerate": Object {
-    "author": "author",
-    "title": "title",
-  },
-  "manifestPath": "__WORKSPACE__/tests/fixtures/config/workspaceDir/publication.json",
-  "outputs": Array [
-    Object {
-      "format": "pdf",
-      "path": "__WORKSPACE__/tests/fixtures/config/output1.pdf",
-    },
-    Object {
-      "format": "pdf",
-      "path": "__WORKSPACE__/tests/fixtures/config/output2.pdf",
-    },
-  ],
-  "pressReady": true,
-  "quick": false,
-  "sandbox": true,
-  "singleDoc": false,
-  "size": Object {
-    "format": "size",
-  },
-  "themeIndexes": Array [
-    Object {
-      "destination": "__WORKSPACE__/tests/fixtures/config/workspaceDir/themes/packages/debug-theme",
-      "location": "__WORKSPACE__/tests/fixtures/themes/debug-theme",
-      "name": "debug-theme",
-      "style": "./theme.css",
-      "type": "package",
-    },
-    Object {
-      "destination": "__WORKSPACE__/tests/fixtures/config/workspaceDir/theme.css",
-      "location": "__WORKSPACE__/tests/fixtures/config/theme.css",
-      "name": "theme.css",
-      "type": "file",
-    },
-  ],
-  "timeout": 1,
-  "verbose": false,
-  "workspaceDir": "__WORKSPACE__/tests/fixtures/config/workspaceDir",
-}
-`;
-
 exports[`parse vivliostyle config: valid.2.config.js 1`] = `
 Object {
   "cover": undefined,
   "customStyle": undefined,
   "customUserStyle": undefined,
+  "disableFormatHtml": undefined,
   "entries": Array [
     Object {
       "source": "__WORKSPACE__/tests/fixtures/config/manuscript.md",
@@ -505,6 +412,7 @@ Object {
   "entryContextDir": "__WORKSPACE__/tests/fixtures/config",
   "executableChromium": "__EXECUTABLE_CHROMIUM_PATH__",
   "exportAliases": Array [],
+  "hardLineBreaks": undefined,
   "includeAssets": Array [
     "**/*.png",
     "**/*.jpg",
@@ -551,6 +459,7 @@ Object {
   "cover": undefined,
   "customStyle": undefined,
   "customUserStyle": undefined,
+  "disableFormatHtml": undefined,
   "entries": Array [
     Object {
       "source": "__WORKSPACE__/tests/fixtures/config/manuscript.md",
@@ -563,6 +472,7 @@ Object {
   "entryContextDir": "__WORKSPACE__/tests/fixtures/config",
   "executableChromium": "__EXECUTABLE_CHROMIUM_PATH__",
   "exportAliases": Array [],
+  "hardLineBreaks": undefined,
   "includeAssets": Array [
     "**/*.png",
     "**/*.jpg",
@@ -609,6 +519,7 @@ Object {
   "cover": "__WORKSPACE__/tests/fixtures/config/cover.png",
   "customStyle": undefined,
   "customUserStyle": undefined,
+  "disableFormatHtml": undefined,
   "entries": Array [
     Object {
       "source": "__WORKSPACE__/tests/fixtures/config/sample.md",
@@ -627,6 +538,7 @@ Object {
   "entryContextDir": "__WORKSPACE__/tests/fixtures/config",
   "executableChromium": "__EXECUTABLE_CHROMIUM_PATH__",
   "exportAliases": "__SNIP__",
+  "hardLineBreaks": undefined,
   "includeAssets": Array [
     "**/*.png",
     "**/*.jpg",
@@ -687,6 +599,7 @@ Object {
   "cover": undefined,
   "customStyle": undefined,
   "customUserStyle": undefined,
+  "disableFormatHtml": undefined,
   "entries": Array [
     Object {
       "source": "__WORKSPACE__/tests/fixtures/config/sample.md",
@@ -699,6 +612,7 @@ Object {
   "entryContextDir": "__WORKSPACE__/tests/fixtures/config",
   "executableChromium": "__EXECUTABLE_CHROMIUM_PATH__",
   "exportAliases": "__SNIP__",
+  "hardLineBreaks": undefined,
   "includeAssets": Array [
     "**/*.png",
     "**/*.jpg",

--- a/tests/builder.test.ts
+++ b/tests/builder.test.ts
@@ -17,6 +17,7 @@ afterAll(() => {
     resolveFixture('builder/.vs-workspace'),
     resolveFixture('builder/.vs-entryContext'),
     resolveFixture('builder/.vs-variousManuscriptFormat'),
+    resolveFixture('builder/.vs-vfm'),
   ]);
 });
 
@@ -252,6 +253,32 @@ it('generate from various manuscript formats', async () => {
   expect(
     doc3.window.document.querySelector('html')?.getAttribute('xml:lang'),
   ).toEqual('ja');
+});
+
+it('generate with VFM options', async () => {
+  const configWithoutOption = await getMergedConfig([
+    '-c',
+    resolveFixture('builder/workspace.config.js'),
+  ]);
+  assertManifestPath(configWithoutOption);
+  await compile(configWithoutOption);
+  const output1 = fs.readFileSync(
+    resolveFixture('builder/.vs-workspace/manuscript/soda.html'),
+    'utf8',
+  );
+  expect(output1).toMatch('hardLineBreaks option test\n        foo');
+
+  const configWithOption = await getMergedConfig([
+    '-c',
+    resolveFixture('builder/vfm.config.js'),
+  ]);
+  assertManifestPath(configWithOption);
+  await compile(configWithOption);
+  const output2 = fs.readFileSync(
+    resolveFixture('builder/.vs-vfm/manuscript/soda.html'),
+    'utf8',
+  );
+  expect(output2).toMatch('hardLineBreaks option test<br>\nfoo');
 });
 
 it('check overwrite violation', async () => {

--- a/tests/fixtures/builder/manuscript/soda.md
+++ b/tests/fixtures/builder/manuscript/soda.md
@@ -1,1 +1,4 @@
 # SODA
+
+hardLineBreaks option test
+foo

--- a/tests/fixtures/builder/vfm.config.js
+++ b/tests/fixtures/builder/vfm.config.js
@@ -1,0 +1,10 @@
+const baseConfig = require('./workspace.config');
+
+module.exports = {
+  ...baseConfig,
+  workspaceDir: '.vs-vfm',
+  vfm: {
+    hardLineBreaks: true,
+    disableFormatHtml: true,
+  },
+};

--- a/tests/fixtures/config/vivliostyle.config.valid.1.js
+++ b/tests/fixtures/config/vivliostyle.config.valid.1.js
@@ -25,4 +25,8 @@ module.exports = {
   cover: './cover.png',
   timeout: 1,
   workspaceDir: 'workspaceDir',
+  vfm: {
+    hardLineBreaks: true,
+    disableFormatHtml: true,
+  },
 };


### PR DESCRIPTION
resolve #171 

```js
module.exports = {
  language: 'en',
  theme: 'theme_print.css',
  entry: [
    'example/Alice.md',
  ],
  hardLineBreaks: true,
  disableFormatHtml: true,
}
```

のように、vivliostyle.config.js 内で hardLineBreaks と disableFormatHtml オプションを指定できるようにしました。CLI のオプションとしては未実装です。