### PR TITLE
feat: vivliostyle-preview reload when vivliostyle.config.js updated

### DIFF
--- a/src/commands/preview.ts
+++ b/src/commands/preview.ts
@@ -55,7 +55,7 @@ export default async function preview(cliFlags: PreviewCliFlags) {
     ? upath.dirname(vivliostyleConfigPath)
     : cwd;
 
-  const config = await mergeConfig(cliFlags, vivliostyleConfig, context);
+  let config = await mergeConfig(cliFlags, vivliostyleConfig, context);
 
   // build artifacts
   if (config.manifestPath) {
@@ -98,6 +98,13 @@ export default async function preview(cliFlags: PreviewCliFlags) {
     clearTimeout(timer);
     timer = setTimeout(async () => {
       startLogging(`Rebuilding ${path}`);
+      const confPath = upath.basename(vivliostyleConfigPath);
+      // reload vivliostyle config
+      if (path === confPath) {
+        const loadedConf = collectVivliostyleConfig(cliFlags);
+        const { vivliostyleConfig } = loadedConf;
+        config = await mergeConfig(cliFlags, vivliostyleConfig, context);
+      }
       // build artifacts
       if (config.manifestPath) {
         await compile(config, { reload: true });
@@ -155,7 +162,7 @@ export default async function preview(cliFlags: PreviewCliFlags) {
     .on('all', (event, path) => {
       if (
         upath.join(config.entryContextDir, path) === config.input.entry ||
-        /\.(md|markdown|html?|xhtml|xht|css|jpe?g|png|gif|svg)$/i.test(path)
+        /\.(md|markdown|html?|xhtml|xht|css|jpe?g|png|gif|svg|js)$/i.test(path)
       ) {
         handleChangeEvent(path);
       }

--- a/src/config.ts
+++ b/src/config.ts
@@ -286,6 +286,7 @@ export function collectVivliostyleConfig<T extends CliFlags>(
     if (!fs.existsSync(configPath)) {
       return undefined;
     }
+    delete require.cache[configPath]; // clear require cache
     const config = require(configPath) as VivliostyleConfigSchema;
 
     const ajv = new Ajv({ strict: false });


### PR DESCRIPTION
vivliostyle.config.js を更新した際にもpreviewをリロードします。

-c オプションでconfigファイルを指定した場合にも対応します。
ただし、監視対象のディレクトリの外にconfigファイルがある場合は対応できません。

ファイル名のみでチェックしているため監視対象ディレクトリ内の別ディレクトリの同名ファイルを変更した場合にもリロードしてしまいますが、レアケースですし致命的な問題にもならないと思いますので対応していません。