### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 ![Vivliostyle CLI](assets/cover.jpg)
 
 [![npm](https://flat.badgen.net/npm/v/@vivliostyle/cli)][npm-url]
-![npm: version (tag)](https://flat.badgen.net/npm/v/@vivliostyle/cli/next)
 [![npm: total downloads](https://flat.badgen.net/npm/dt/@vivliostyle/cli)][npm-url]
 
 [npm-url]: https://npmjs.org/package/@vivliostyle/cli
@@ -57,7 +56,7 @@ Options:
 
 > build and create PDF file.
 
-Put [vivliostyle.config.js](https://github.com/vivliostyle/vivliostyle-cli/issues/38) in the root directory, then:
+Put [vivliostyle.config.js](https://github.com/vivliostyle/create-book/blob/master/templates/default/vivliostyle.config.js) in the root directory, then:
 
 ```bash
 vivliostyle build
@@ -69,25 +68,28 @@ vivliostyle build
 
 ```
 Options:
-  -c, --config <config_file>    path to vivliostyle.config.js [vivliostyle.config.js]
-  -o, --output <path>           specify output file name or directory [<title>.pdf]
-                                This option can be specified multiple, then each -o options can be supplied one -f option.
-                                ex: -o output1 -f webpub -o output2.pdf -f pdf
-  -f, --format <format>         specify output format corresponding output target
-                                If an extension is specified on -o option, this field will be inferenced automatically.
-  -s, --size <size>             output pdf size [Letter]
-                                preset: A5, A4, A3, B5, B4, JIS-B5, JIS-B4, letter, legal, ledger
-                                custom(comma separated): 182mm,257mm or 8.5in,11in
-  -p, --press-ready             make generated PDF compatible with press ready PDF/X-1a [false]
-  -t, --timeout <seconds>       timeout limit for waiting Vivliostyle process [60s]
-  -T, --theme <theme>           theme path or package name
-  --title <title>               title
-  --author <author>             author
-  -l, --language <language>     language
-  --verbose                     verbose log output
-  --no-sandbox                  launch chrome without sandbox. use this option when ECONNREFUSED error occurred.
-  --executable-chromium <path>  specify a path of executable Chrome (or Chromium) you installed
-  -h, --help                    display help for command
+  -c, --config <config_file>      path to vivliostyle.config.js [vivliostyle.config.js]
+  -o, --output <path>             specify output file name or directory [<title>.pdf]
+                                  This option can be specified multiple, then each -o options can be supplied one -f option.
+                                  ex: -o output1 -f webpub -o output2.pdf -f pdf
+  -f, --format <format>           specify output format corresponding output target
+                                  If an extension is specified on -o option, this field will be inferenced automatically.
+  -s, --size <size>               output pdf size [Letter]
+                                  preset: A5, A4, A3, B5, B4, JIS-B5, JIS-B4, letter, legal, ledger
+                                  custom(comma separated): 182mm,257mm or 8.5in,11in
+  --style <stylesheet>            additional stylesheet URL or path
+  --user-style <user_stylesheet>  user stylesheet URL or path
+  -d, --single-doc                single HTML document input
+  -p, --press-ready               make generated PDF compatible with press ready PDF/X-1a [false]
+  -t, --timeout <seconds>         timeout limit for waiting Vivliostyle process [60s]
+  -T, --theme <theme>             theme path or package name
+  --title <title>                 title
+  --author <author>               author
+  -l, --language <language>       language
+  --verbose                       verbose log output
+  --no-sandbox                    launch chrome without sandbox. use this option when ECONNREFUSED error occurred.
+  --executable-chromium <path>    specify a path of executable Chrome (or Chromium) you installed
+  -h, --help                      display help for command
 ```
 
 ### `preview`
@@ -102,19 +104,27 @@ vivliostyle preview
 
 ```
 Options:
-  -c, --config <config_file>    path to vivliostyle.config.js
-  -T, --theme <theme>           theme path or package name
-  -s, --size <size>             output pdf size [Letter]
-                                preset: A5, A4, A3, B5, B4, JIS-B5, JIS-B4, letter, legal, ledger
-                                custom(comma separated): 182mm,257mm or 8.5in,11in
-  --title <title>               title
-  --author <author>             author
-  -l, --language <language>     language
-  --verbose                     verbose log output
-  --no-sandbox                  launch chrome without sandbox (use this option to avoid ECONNREFUSED error)
-  --executable-chromium <path>  specify a path of executable Chrome(Chromium) you installed
-  -h, --help                    display help for command
+  -c, --config <config_file>      path to vivliostyle.config.js
+  -T, --theme <theme>             theme path or package name
+  -s, --size <size>               output pdf size [Letter]
+                                  preset: A5, A4, A3, B5, B4, JIS-B5, JIS-B4, letter, legal, ledger
+                                  custom(comma separated): 182mm,257mm or 8.5in,11in
+  --style <stylesheet>            additional stylesheet URL or path
+  --user-style <user_stylesheet>  user stylesheet URL or path
+  -d, --single-doc                single HTML document input
+  -q, --quick                     quick loading with rough page count
+  --title <title>                 title
+  --author <author>               author
+  -l, --language <language>       language
+  --verbose                       verbose log output
+  --no-sandbox                    launch chrome without sandbox (use this option to avoid ECONNREFUSED error)
+  --executable-chromium <path>    specify a path of executable Chrome(Chromium) you installed
+  -h, --help                      display help for command
 ```
+
+## User Guide
+
+See [User Guide](https://docs.vivliostyle.org/#/vivliostyle-cli)
 
 ## Q&A
 


### PR DESCRIPTION
changes:
- remove `![npm: version (tag)](https://flat.badgen.net/npm/v/@vivliostyle/cli/next)` because the `@next` tag is not updated
- change [vivliostyle.config.js](https://github.com/vivliostyle/vivliostyle-cli/issues/38) link (the config spec was old) to [vivliostyle.config.js](https://github.com/vivliostyle/create-book/blob/master/templates/default/vivliostyle.config.js)
- updated CLI options
- add link to User Guide
