### PR TITLE
Re-enable using commands as api

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -1,59 +1,15 @@
 import chalk from 'chalk';
-import process from 'process';
 import terminalLink from 'terminal-link';
 import path from 'upath';
 import { getExecutableBrowserPath } from './browser';
 import { checkOverwriteViolation, compile, copyAssets } from './builder';
-import {
-  BuildCliFlags,
-  setupBuildParserProgram,
-} from './commands/build.parser';
+import { BuildCliFlags } from './commands/build.parser';
 import { collectVivliostyleConfig, mergeConfig, MergedConfig } from './config';
 import { checkContainerEnvironment } from './container';
 import { buildPDF, buildPDFWithContainer } from './pdf';
 import { teardownServer } from './server';
-import {
-  cwd,
-  debug,
-  gracefulError,
-  log,
-  startLogging,
-  stopLogging,
-} from './util';
+import { cwd, debug, log, startLogging, stopLogging } from './util';
 import { exportWebPublication } from './webbook';
-
-try {
-  const program = setupBuildParserProgram();
-  program.parse(process.argv);
-  const options = program.opts();
-  build({
-    input: program.args?.[0],
-    configPath: options.config,
-    targets: options.targets,
-    theme: options.theme,
-    size: options.size,
-    style: options.style,
-    userStyle: options.userStyle,
-    singleDoc: options.singleDoc,
-    title: options.title,
-    author: options.author,
-    language: options.language,
-    pressReady: options.pressReady,
-    renderMode: options.renderMode || 'local',
-    preflight: options.preflight,
-    preflightOption: options.preflightOption,
-    verbose: options.verbose,
-    timeout: options.timeout,
-    sandbox: options.sandbox,
-    executableChromium: options.executableChromium,
-    image: options.image,
-    http: options.http,
-    viewer: options.viewer,
-    bypassedPdfBuilderOption: options.bypassedPdfBuilderOption,
-  }).catch(gracefulError);
-} catch (err) {
-  gracefulError(err);
-}
 
 export default async function build(cliFlags: BuildCliFlags) {
   if (cliFlags.bypassedPdfBuilderOption) {
@@ -64,7 +20,7 @@ export default async function build(cliFlags: BuildCliFlags) {
 
     await buildPDF(option);
     log();
-    process.exit(0);
+    return;
   }
 
   const isInContainer = checkContainerEnvironment();
@@ -138,7 +94,6 @@ export default async function build(cliFlags: BuildCliFlags) {
   }
 
   teardownServer();
-  process.exit(0);
 }
 
 export function checkUnsupportedOutputs({

--- a/src/build.ts
+++ b/src/build.ts
@@ -2,12 +2,16 @@ import chalk from 'chalk';
 import process from 'process';
 import terminalLink from 'terminal-link';
 import path from 'upath';
-import { getExecutableBrowserPath } from '../browser';
-import { checkOverwriteViolation, compile, copyAssets } from '../builder';
-import { collectVivliostyleConfig, mergeConfig, MergedConfig } from '../config';
-import { checkContainerEnvironment } from '../container';
-import { buildPDF, buildPDFWithContainer } from '../pdf';
-import { teardownServer } from '../server';
+import { getExecutableBrowserPath } from './browser';
+import { checkOverwriteViolation, compile, copyAssets } from './builder';
+import {
+  BuildCliFlags,
+  setupBuildParserProgram,
+} from './commands/build.parser';
+import { collectVivliostyleConfig, mergeConfig, MergedConfig } from './config';
+import { checkContainerEnvironment } from './container';
+import { buildPDF, buildPDFWithContainer } from './pdf';
+import { teardownServer } from './server';
 import {
   cwd,
   debug,
@@ -15,9 +19,8 @@ import {
   log,
   startLogging,
   stopLogging,
-} from '../util';
-import { exportWebPublication } from '../webbook';
-import { BuildCliFlags, setupBuildParserProgram } from './build.parser';
+} from './util';
+import { exportWebPublication } from './webbook';
 
 try {
   const program = setupBuildParserProgram();

--- a/src/build.ts
+++ b/src/build.ts
@@ -3,15 +3,27 @@ import terminalLink from 'terminal-link';
 import path from 'upath';
 import { getExecutableBrowserPath } from './browser';
 import { checkOverwriteViolation, compile, copyAssets } from './builder';
-import { BuildCliFlags } from './commands/build.parser';
-import { collectVivliostyleConfig, mergeConfig, MergedConfig } from './config';
+import {
+  CliFlags,
+  collectVivliostyleConfig,
+  mergeConfig,
+  MergedConfig,
+} from './config';
 import { checkContainerEnvironment } from './container';
 import { buildPDF, buildPDFWithContainer } from './pdf';
 import { teardownServer } from './server';
 import { cwd, debug, log, startLogging, stopLogging } from './util';
 import { exportWebPublication } from './webbook';
 
-export default async function build(cliFlags: BuildCliFlags) {
+export interface BuildCliFlags extends CliFlags {
+  output?: {
+    output?: string;
+    format?: string;
+  }[];
+  bypassedPdfBuilderOption?: string;
+}
+
+export async function build(cliFlags: BuildCliFlags) {
   if (cliFlags.bypassedPdfBuilderOption) {
     const option = JSON.parse(cliFlags.bypassedPdfBuilderOption);
     // Host doesn't know inside path of chromium path
@@ -96,7 +108,7 @@ export default async function build(cliFlags: BuildCliFlags) {
   teardownServer();
 }
 
-export function checkUnsupportedOutputs({
+function checkUnsupportedOutputs({
   webbookEntryPath,
   epubOpfPath,
   outputs,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,12 +11,12 @@ program
   .name('vivliostyle')
   .version(version, '-v, --version')
   .command('init', 'create vivliostyle config', {
-    executableFile: 'commands/init',
+    executableFile: 'init',
   })
   .command('build', 'build and create PDF file', {
-    executableFile: 'commands/build',
+    executableFile: 'build',
   })
   .command('preview', 'launch preview server', {
-    executableFile: 'commands/preview',
+    executableFile: 'preview',
   })
   .parse(process.argv);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,12 +11,12 @@ program
   .name('vivliostyle')
   .version(version, '-v, --version')
   .command('init', 'create vivliostyle config', {
-    executableFile: 'init',
+    executableFile: 'commands/init',
   })
   .command('build', 'build and create PDF file', {
-    executableFile: 'build',
+    executableFile: 'commands/build',
   })
   .command('preview', 'launch preview server', {
-    executableFile: 'preview',
+    executableFile: 'commands/preview',
   })
   .parse(process.argv);

--- a/src/commands/build.parser.ts
+++ b/src/commands/build.parser.ts
@@ -1,14 +1,7 @@
 import commander from 'commander';
-import { CliFlags, validateTimeoutFlag } from '../config';
+import { BuildCliFlags } from '../build';
+import { validateTimeoutFlag } from '../config';
 import { checkOutputFormat, detectOutputFormat, OutputFormat } from '../output';
-
-export interface BuildCliFlags extends CliFlags {
-  output?: {
-    output?: string;
-    format?: string;
-  }[];
-  bypassedPdfBuilderOption?: string;
-}
 
 export function setupBuildParserProgram(): commander.Command {
   // Provide an order-sensitive command parser

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -1,0 +1,37 @@
+import process from 'process';
+import { build } from '../build';
+import { gracefulError } from '../util';
+import { setupBuildParserProgram } from './build.parser';
+
+try {
+  const program = setupBuildParserProgram();
+  program.parse(process.argv);
+  const options = program.opts();
+  build({
+    input: program.args?.[0],
+    configPath: options.config,
+    targets: options.targets,
+    theme: options.theme,
+    size: options.size,
+    style: options.style,
+    userStyle: options.userStyle,
+    singleDoc: options.singleDoc,
+    title: options.title,
+    author: options.author,
+    language: options.language,
+    pressReady: options.pressReady,
+    renderMode: options.renderMode || 'local',
+    preflight: options.preflight,
+    preflightOption: options.preflightOption,
+    verbose: options.verbose,
+    timeout: options.timeout,
+    sandbox: options.sandbox,
+    executableChromium: options.executableChromium,
+    image: options.image,
+    http: options.http,
+    viewer: options.viewer,
+    bypassedPdfBuilderOption: options.bypassedPdfBuilderOption,
+  }).catch(gracefulError);
+} catch (err) {
+  gracefulError(err);
+}

--- a/src/commands/init.parser.ts
+++ b/src/commands/init.parser.ts
@@ -1,13 +1,5 @@
 import commander from 'commander';
 
-export interface InitCliFlags {
-  title?: string;
-  author?: string;
-  language?: string;
-  theme?: string;
-  size?: string;
-}
-
 export function setupInitParserProgram(): commander.Command {
   const program = new commander.Command();
   program

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,0 +1,18 @@
+import { init } from '../init';
+import { gracefulError } from '../util';
+import { setupInitParserProgram } from './init.parser';
+
+try {
+  const program = setupInitParserProgram();
+  program.parse(process.argv);
+  const options = program.opts();
+  init({
+    title: options.title,
+    author: options.author,
+    language: options.language,
+    size: options.size,
+    theme: options.theme,
+  }).catch(gracefulError);
+} catch (err) {
+  gracefulError(err);
+}

--- a/src/commands/preview.parser.ts
+++ b/src/commands/preview.parser.ts
@@ -1,7 +1,4 @@
 import commander from 'commander';
-import { CliFlags } from '../config';
-
-export interface PreviewCliFlags extends CliFlags {}
 
 export function setupPreviewParserProgram(): commander.Command {
   const program = new commander.Command();

--- a/src/commands/preview.ts
+++ b/src/commands/preview.ts
@@ -1,0 +1,30 @@
+import { preview } from '../preview';
+import { gracefulError } from '../util';
+import { setupPreviewParserProgram } from './preview.parser';
+
+try {
+  const program = setupPreviewParserProgram();
+  program.parse(process.argv);
+  const options = program.opts();
+  preview({
+    input: program.args?.[0],
+    configPath: options.config,
+    theme: options.theme,
+    size: options.size,
+    style: options.style,
+    userStyle: options.userStyle,
+    singleDoc: options.singleDoc,
+    quick: options.quick,
+    title: options.title,
+    author: options.author,
+    language: options.language,
+    verbose: options.verbose,
+    timeout: options.timeout,
+    sandbox: options.sandbox,
+    executableChromium: options.executableChromium,
+    http: options.http,
+    viewer: options.viewer,
+  }).catch(gracefulError);
+} catch (err) {
+  gracefulError(err);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
-import build from './commands/build';
+import build from './build';
 import { BuildCliFlags } from './commands/build.parser';
-import preview from './commands/preview';
 import { PreviewCliFlags } from './commands/preview.parser';
+import preview from './preview';
 
 export { build, preview, BuildCliFlags, PreviewCliFlags };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,3 @@
-import build from './build';
-import { BuildCliFlags } from './commands/build.parser';
-import { PreviewCliFlags } from './commands/preview.parser';
-import preview from './preview';
-
-export { build, preview, BuildCliFlags, PreviewCliFlags };
+export { build, BuildCliFlags } from './build';
+export { init, InitCliFlags } from './init';
+export { preview, PreviewCliFlags } from './preview';

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,11 +1,18 @@
 import chalk from 'chalk';
 import fs from 'fs';
 import path from 'upath';
-import { InitCliFlags } from './commands/init.parser';
 import { CONTAINER_IMAGE } from './container';
 import { cwd, log } from './util';
 
-export default async function init(cliFlags: InitCliFlags) {
+export interface InitCliFlags {
+  title?: string;
+  author?: string;
+  language?: string;
+  theme?: string;
+  size?: string;
+}
+
+export async function init(cliFlags: InitCliFlags) {
   const vivliostyleConfigPath = path.join(cwd, 'vivliostyle.config.js');
 
   if (fs.existsSync(vivliostyleConfigPath)) {

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,24 +1,9 @@
 import chalk from 'chalk';
 import fs from 'fs';
 import path from 'upath';
-import { InitCliFlags, setupInitParserProgram } from './commands/init.parser';
+import { InitCliFlags } from './commands/init.parser';
 import { CONTAINER_IMAGE } from './container';
-import { cwd, gracefulError, log } from './util';
-
-try {
-  const program = setupInitParserProgram();
-  program.parse(process.argv);
-  const options = program.opts();
-  init({
-    title: options.title,
-    author: options.author,
-    language: options.language,
-    size: options.size,
-    theme: options.theme,
-  }).catch(gracefulError);
-} catch (err) {
-  gracefulError(err);
-}
+import { cwd, log } from './util';
 
 export default async function init(cliFlags: InitCliFlags) {
   const vivliostyleConfigPath = path.join(cwd, 'vivliostyle.config.js');

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,9 +1,9 @@
 import chalk from 'chalk';
 import fs from 'fs';
 import path from 'upath';
-import { CONTAINER_IMAGE } from '../container';
-import { cwd, gracefulError, log } from '../util';
-import { InitCliFlags, setupInitParserProgram } from './init.parser';
+import { InitCliFlags, setupInitParserProgram } from './commands/init.parser';
+import { CONTAINER_IMAGE } from './container';
+import { cwd, gracefulError, log } from './util';
 
 try {
   const program = setupInitParserProgram();

--- a/src/pdf.ts
+++ b/src/pdf.ts
@@ -226,10 +226,13 @@ export async function buildPDF({
 
   await page.setDefaultNavigationTimeout(timeout);
   await page.goto(viewerFullUrl, { waitUntil: 'networkidle0' });
-  await page.waitForFunction(() => !!window.coreViewer);
+  await page.waitForFunction(
+    /* istanbul ignore next */ () => !!window.coreViewer,
+  );
 
   await page.emulateMediaType('print');
   await page.waitForFunction(
+    /* istanbul ignore next */
     () => window.coreViewer.readyState === 'complete',
     {
       polling: 1000,
@@ -241,10 +244,11 @@ export async function buildPDF({
     logSuccess(stringifyEntry(lastEntry));
   }
 
-  const viewerCoreVersion = await page.evaluate(() =>
-    document
-      .querySelector('#vivliostyle-menu_settings .version')
-      ?.textContent?.replace(/^.*?: (\d[-+.\w]+).*$/, '$1'),
+  const viewerCoreVersion = await page.evaluate(
+    /* istanbul ignore next */ () =>
+      document
+        .querySelector('#vivliostyle-menu_settings .version')
+        ?.textContent?.replace(/^.*?: (\d[-+.\w]+).*$/, '$1'),
   );
   const metadata = await loadMetadata(page);
   const toc = await loadTOC(page);
@@ -293,7 +297,9 @@ export async function buildPDF({
 }
 
 async function loadMetadata(page: PuppeteerPage): Promise<Meta> {
-  return page.evaluate(() => window.coreViewer.getMetadata());
+  return page.evaluate(
+    /* istanbul ignore next */ () => window.coreViewer.getMetadata(),
+  );
 }
 
 // Show and hide the TOC in order to read its contents.
@@ -301,7 +307,7 @@ async function loadMetadata(page: PuppeteerPage): Promise<Meta> {
 // the PDF destinations used during postprocessing.
 async function loadTOC(page: PuppeteerPage): Promise<TOCItem[]> {
   return page.evaluate(
-    () =>
+    /* istanbul ignore next */ () =>
       new Promise<TOCItem[]>((resolve) => {
         function listener(payload: Payload) {
           if (payload.a !== 'toc') {

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -5,10 +5,14 @@ import {
   downloadBrowser,
   getExecutableBrowserPath,
   launchBrowser,
-} from '../browser';
-import { compile, copyAssets } from '../builder';
-import { collectVivliostyleConfig, mergeConfig } from '../config';
-import { prepareServer } from '../server';
+} from './browser';
+import { compile, copyAssets } from './builder';
+import {
+  PreviewCliFlags,
+  setupPreviewParserProgram,
+} from './commands/preview.parser';
+import { collectVivliostyleConfig, mergeConfig } from './config';
+import { prepareServer } from './server';
 import {
   cwd,
   debug,
@@ -18,8 +22,7 @@ import {
   pathStartsWith,
   startLogging,
   stopLogging,
-} from '../util';
-import { PreviewCliFlags, setupPreviewParserProgram } from './preview.parser';
+} from './util';
 
 let timer: NodeJS.Timeout;
 

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -7,16 +7,12 @@ import {
   launchBrowser,
 } from './browser';
 import { compile, copyAssets } from './builder';
-import {
-  PreviewCliFlags,
-  setupPreviewParserProgram,
-} from './commands/preview.parser';
+import { PreviewCliFlags } from './commands/preview.parser';
 import { collectVivliostyleConfig, mergeConfig } from './config';
 import { prepareServer } from './server';
 import {
   cwd,
   debug,
-  gracefulError,
   isUrlString,
   logSuccess,
   pathStartsWith,
@@ -25,33 +21,6 @@ import {
 } from './util';
 
 let timer: NodeJS.Timeout;
-
-try {
-  const program = setupPreviewParserProgram();
-  program.parse(process.argv);
-  const options = program.opts();
-  preview({
-    input: program.args?.[0],
-    configPath: options.config,
-    theme: options.theme,
-    size: options.size,
-    style: options.style,
-    userStyle: options.userStyle,
-    singleDoc: options.singleDoc,
-    quick: options.quick,
-    title: options.title,
-    author: options.author,
-    language: options.language,
-    verbose: options.verbose,
-    timeout: options.timeout,
-    sandbox: options.sandbox,
-    executableChromium: options.executableChromium,
-    http: options.http,
-    viewer: options.viewer,
-  }).catch(gracefulError);
-} catch (err) {
-  gracefulError(err);
-}
 
 export default async function preview(cliFlags: PreviewCliFlags) {
   startLogging('Collecting preview config');

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -7,8 +7,7 @@ import {
   launchBrowser,
 } from './browser';
 import { compile, copyAssets } from './builder';
-import { PreviewCliFlags } from './commands/preview.parser';
-import { collectVivliostyleConfig, mergeConfig } from './config';
+import { CliFlags, collectVivliostyleConfig, mergeConfig } from './config';
 import { prepareServer } from './server';
 import {
   cwd,
@@ -22,7 +21,9 @@ import {
 
 let timer: NodeJS.Timeout;
 
-export default async function preview(cliFlags: PreviewCliFlags) {
+export interface PreviewCliFlags extends CliFlags {}
+
+export async function preview(cliFlags: PreviewCliFlags) {
   startLogging('Collecting preview config');
 
   const loadedConf = collectVivliostyleConfig(cliFlags);

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -1,0 +1,41 @@
+import fileType from 'file-type';
+import fs from 'fs';
+import path from 'upath';
+import { build } from '../src';
+
+const rootPath = path.resolve(__dirname, '..');
+const fixtureRoot = path.resolve(__dirname, 'fixtures/wood');
+const fixtureFile = path.join(fixtureRoot, 'index.html');
+
+const localTmpDir = path.join(rootPath, 'tmp');
+fs.mkdirSync(localTmpDir, { recursive: true });
+
+function cleanUp(filePath: string) {
+  try {
+    fs.unlinkSync(filePath);
+  } catch (err) {
+    if (err.code !== 'ENOENT') {
+      throw err;
+    }
+  }
+}
+
+test('api generates pdf without errors', async () => {
+  const outputPath = path.join(localTmpDir, 'test-api.pdf');
+  cleanUp(outputPath);
+
+  await build({
+    targets: [
+      {
+        path: outputPath,
+        format: 'pdf',
+      },
+    ],
+    input: fixtureFile,
+    size: 'A4',
+  });
+
+  // mimetype test
+  const type = await fileType.fromFile(outputPath);
+  expect(type!.mime).toEqual('application/pdf');
+}, 20000);


### PR DESCRIPTION
This PR fixes using the named exports `build` and `preview` by other packages. For completeness, it also adds `init`. A test is added for using `build` this way.

The exports were first made available in #52. They were broken after #96, because the subcommands ran their parsing at the top level of the file. Just importing the methods would run the command parser and exit the process, ignoring the arguments passed in.

The named exports `build`, `preview`, and `init` are moved to separate files. The new files specifically don’t import `commander` so that they work with tree-shaking tools.