### PR TITLE
feat: Update Vivliostyle.js to 2.14.1: Improved text-spacing support

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@vivliostyle/vfm": "1.1.0",
-    "@vivliostyle/viewer": "2.13.0",
+    "@vivliostyle/viewer": "2.14.1",
     "ajv": "^7.0.4",
     "ajv-formats": "^1.5.1",
     "chalk": "^4.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1232,10 +1232,10 @@
   dependencies:
     "@types/node" "*"
 
-"@vivliostyle/core@^2.13.0":
-  version "2.13.0"
-  resolved "https://registry.yarnpkg.com/@vivliostyle/core/-/core-2.13.0.tgz#f2ffc59f8af3c262f81908bebf4a9f870643d1ed"
-  integrity sha512-7jD4KX6JwapgWSCiVJSMh/ChjVOuIsWL3HzCQMCmx9bfLF2BlY3Tow1oYZCxmiUz/SfFZRxkWUC1BtTKglkecA==
+"@vivliostyle/core@^2.14.1":
+  version "2.14.1"
+  resolved "https://registry.yarnpkg.com/@vivliostyle/core/-/core-2.14.1.tgz#e0268b1f4a0a8e3445cbe216777252882b962e8e"
+  integrity sha512-a+GRYiSjCMQMrWz7OH+SRcXiyiQiNaJBfBJhplU6x7LWfkHqq+sN8N9NjfglwtGL+SE3WckYXV/NqL33lEaTgg==
   dependencies:
     fast-diff "^1.2.0"
 
@@ -1278,12 +1278,12 @@
     unist-util-visit "^2.0.3"
     unist-util-visit-parents "^3.1.1"
 
-"@vivliostyle/viewer@2.13.0":
-  version "2.13.0"
-  resolved "https://registry.yarnpkg.com/@vivliostyle/viewer/-/viewer-2.13.0.tgz#804157d4d80ae6c601983db152e6fedc45c83126"
-  integrity sha512-WVMagcS7EiCsrz1DW0VfAn+e9fu83xLYrHCr6NJ0tCRRBdj//JgA0uMLZmf6l+zFF3fCY6KcjCviD+wxgTLoQQ==
+"@vivliostyle/viewer@2.14.1":
+  version "2.14.1"
+  resolved "https://registry.yarnpkg.com/@vivliostyle/viewer/-/viewer-2.14.1.tgz#4e77030fadf411bf26f2cfd879155e3baf921600"
+  integrity sha512-0XCcpn1RcSKyaqDmuVOAdMRZ2oM1gfhLtVIZocrsnJwlreNaR4w250efwk87Q7Jk0WaL6LvLucr5O/dRsGQqtg==
   dependencies:
-    "@vivliostyle/core" "^2.13.0"
+    "@vivliostyle/core" "^2.14.1"
     font-awesome "^4.7.0"
     knockout "^3.5.0"
 


### PR DESCRIPTION
- https://github.com/vivliostyle/vivliostyle.js/releases/tag/v2.14.1
- https://github.com/vivliostyle/vivliostyle.js/releases/tag/v2.14.0

### Features

- support CSS text-spacing and hanging-punctuation in generated content
- support the allow-end value of text-spacing and hanging-punctuation

### Bug Fixes

- text-spacing not working depending on fonts
- CSS text-orientation property was ignored in page margin boxes
- do not ignore metadata (language, author) in publication manifest
- follow-up fix to text-spacing and hanging-punctuation support
- overflow:hidden should not be default in page margin boxes
- page margin boxes with vertical writing-mode not properly aligned
- TypeError occurred with TOC button when the book url has fragment
- Unnecessary aria-hidden attributes caused tagged PDF output broken