### PR TITLE
fix: Update Vivliostyle.js to 2.14.2: bug fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@vivliostyle/vfm": "1.2.1",
-    "@vivliostyle/viewer": "2.14.1",
+    "@vivliostyle/viewer": "2.14.2",
     "ajv": "^7.0.4",
     "ajv-formats": "^1.5.1",
     "chalk": "^4.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1232,10 +1232,10 @@
   dependencies:
     "@types/node" "*"
 
-"@vivliostyle/core@^2.14.1":
-  version "2.14.1"
-  resolved "https://registry.yarnpkg.com/@vivliostyle/core/-/core-2.14.1.tgz#e0268b1f4a0a8e3445cbe216777252882b962e8e"
-  integrity sha512-a+GRYiSjCMQMrWz7OH+SRcXiyiQiNaJBfBJhplU6x7LWfkHqq+sN8N9NjfglwtGL+SE3WckYXV/NqL33lEaTgg==
+"@vivliostyle/core@^2.14.2":
+  version "2.14.2"
+  resolved "https://registry.yarnpkg.com/@vivliostyle/core/-/core-2.14.2.tgz#31fad54a211ec5bdfe728c43080f067bc5ebadfe"
+  integrity sha512-f57w0XL/w4J2auAnYrvNMg0dyEH0CaV4bSV1hIA96ux7WkjJ0Xv9Nt4MStiMGRCKToXyA+H1eKBhqCCDKU/Gew==
   dependencies:
     fast-diff "^1.2.0"
 
@@ -1278,12 +1278,12 @@
     unist-util-visit "^2.0.3"
     unist-util-visit-parents "^3.1.1"
 
-"@vivliostyle/viewer@2.14.1":
-  version "2.14.1"
-  resolved "https://registry.yarnpkg.com/@vivliostyle/viewer/-/viewer-2.14.1.tgz#4e77030fadf411bf26f2cfd879155e3baf921600"
-  integrity sha512-0XCcpn1RcSKyaqDmuVOAdMRZ2oM1gfhLtVIZocrsnJwlreNaR4w250efwk87Q7Jk0WaL6LvLucr5O/dRsGQqtg==
+"@vivliostyle/viewer@2.14.2":
+  version "2.14.2"
+  resolved "https://registry.yarnpkg.com/@vivliostyle/viewer/-/viewer-2.14.2.tgz#3c3e2f1c2709f8124bb5df606f17c4c22996c6ce"
+  integrity sha512-q6jFjubhYqrH0LSEE/T5fP0mNaij/U5iNXhdTRNJD94rJG3zbSZF1oAJd3QbVhj4L6Xt1PodT5ynKm3sOIWhuQ==
   dependencies:
-    "@vivliostyle/core" "^2.14.1"
+    "@vivliostyle/core" "^2.14.2"
     font-awesome "^4.7.0"
     knockout "^3.5.0"
 


### PR DESCRIPTION
- https://github.com/vivliostyle/vivliostyle.js/releases/tag/v2.14.2

### Bug Fixes

- footnotes not positioned correctly in vertical writing mode
- hang-up with footnote/pagefloat and ::after pseudo element
- margin-block-end on page floats ignored in vertical writing mode
- should generate single text node for pseudo elements if possible
- use appropriate fallback page size when window size is not available
- wrong indent of fullwidth opening punctuation at first line in second page