### PR TITLE
docs: correct --timeout default value

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Options:
   -d, --single-doc                 single HTML document input
   -p, --press-ready                make generated PDF compatible with press ready PDF/X-1a [false]
                                    This option is equivalent with "--preflight press-ready"
-  -t, --timeout <seconds>          timeout limit for waiting Vivliostyle process [60s]
+  -t, --timeout <seconds>          timeout limit for waiting Vivliostyle process [120]
   -T, --theme <theme>              theme path or package name
   --title <title>                  title
   --author <author>                author

--- a/src/commands/build.parser.ts
+++ b/src/commands/build.parser.ts
@@ -74,7 +74,7 @@ This option is equivalent with "--preflight press-ready"`,
     )
     .option(
       '-t, --timeout <seconds>',
-      `timeout limit for waiting Vivliostyle process [60s]`,
+      `timeout limit for waiting Vivliostyle process [120]`,
       validateTimeoutFlag,
     )
     .option('-T, --theme <theme>', 'theme path or package name')


### PR DESCRIPTION
--timeout のデフォルト値が "[60s]" と記述されてました：
```
-t, --timeout <seconds>          timeout limit for waiting Vivliostyle process [60s]
```

しかし、ソースコードを見ると、120秒となっています。
また、"[60s]" と書かれてますが、単位 "s" を付けると無効になります。
次のように、"[120]" という記述に修正しました：

```
-t, --timeout <seconds>          timeout limit for waiting Vivliostyle process [120]
```