### PR TITLE
fix: Process not terminated in docker mode

### DIFF
--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -31,7 +31,11 @@ try {
     http: options.http,
     viewer: options.viewer,
     bypassedPdfBuilderOption: options.bypassedPdfBuilderOption,
-  }).catch(gracefulError);
+  })
+    .then(() => {
+      process.exit(0);
+    })
+    .catch(gracefulError);
 } catch (err) {
   gracefulError(err);
 }


### PR DESCRIPTION
- fix #269

This fixes the problem that the build process is not terminated in docker mode (`--render-mode=docker`).

The problem was caused by the change that `process.exit(0);` was removed from the `build()` function (commit https://github.com/vivliostyle/vivliostyle-cli/pull/243/commits/bed618317584bb280484544931c380cc3e3e2e86 "fix: importing command api causes process exit"), so this fix adds `process.exit(0);` in the `.then(…)` after the `build()` function call in `commands/build.ts`.
