### PR TITLE
feat: Use new chrome headless mode

### DIFF
--- a/src/pdf.ts
+++ b/src/pdf.ts
@@ -117,7 +117,7 @@ export async function buildPDF({
     }
   }
   const browser = await launchBrowser({
-    headless: true,
+    headless: 'chrome',
     executablePath: executableChromium,
     args: [
       '--allow-file-access-from-files',


### PR DESCRIPTION
Changes `headless: true` to `headless: 'chrome'` in launchBrowser options.

The new "chrome" headless mode may solve issues existed in chromium headless mode.