### PR TITLE
fix: Update Vivliostyle.js to 2.15.2: Bug Fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@vivliostyle/vfm": "1.2.1",
-    "@vivliostyle/viewer": "2.15.1",
+    "@vivliostyle/viewer": "2.15.2",
     "ajv": "^7.0.4",
     "ajv-formats": "^1.5.1",
     "better-ajv-errors": "^1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1258,10 +1258,10 @@
   dependencies:
     "@types/node" "*"
 
-"@vivliostyle/core@^2.15.1":
-  version "2.15.1"
-  resolved "https://registry.yarnpkg.com/@vivliostyle/core/-/core-2.15.1.tgz#0027842a3a12a44a940c378e026d6e5dfdf87ebb"
-  integrity sha512-at0qN9yAK865a1E/5pEVZMj7iK5rX7wuvIqXyYxm30Hn1ZTUWWZSsCywoUhisrEBL1sS27L7ktkTBJZh+wAwww==
+"@vivliostyle/core@^2.15.2":
+  version "2.15.2"
+  resolved "https://registry.yarnpkg.com/@vivliostyle/core/-/core-2.15.2.tgz#ad28658a43218ca904f5baa43a8a185252a6d2c4"
+  integrity sha512-ZEBYxdnWYa0+/SgZ0nGkO90AjzlZzAIYzdtSyWNlyb3/nlMi1h/6R5bSA0FGdzmFa/WRkqv2CuEB2Dj7mzCdMQ==
   dependencies:
     fast-diff "^1.2.0"
 
@@ -1304,12 +1304,12 @@
     unist-util-visit "^2.0.3"
     unist-util-visit-parents "^3.1.1"
 
-"@vivliostyle/viewer@2.15.1":
-  version "2.15.1"
-  resolved "https://registry.yarnpkg.com/@vivliostyle/viewer/-/viewer-2.15.1.tgz#cbe1543846753ab1b6181c155cba13becc3257b1"
-  integrity sha512-y+MNtVVsstoNfwA8Ooigkx8ZSmOtQMSSXZaUkGG5OyOKKt6uYddv1rhhaixdYQ/SEnrxhkZeGWQldcUNkqegWw==
+"@vivliostyle/viewer@2.15.2":
+  version "2.15.2"
+  resolved "https://registry.yarnpkg.com/@vivliostyle/viewer/-/viewer-2.15.2.tgz#3d4b9c4c86c81663c77fb3ccb9189f076dbcf13c"
+  integrity sha512-dFLzuVPT3I+5gjkFK3QBMvFAIHgyxHm8qf+uByVApW554P8apEuU/4WCChfaF8WgJ7QPKpnwlrxao0v7ebX6ag==
   dependencies:
-    "@vivliostyle/core" "^2.15.1"
+    "@vivliostyle/core" "^2.15.2"
     font-awesome "^4.7.0"
     knockout "^3.5.0"
 


### PR DESCRIPTION
https://github.com/vivliostyle/vivliostyle.js/releases/tag/v2.15.2

### Bug Fixes

- showTOC() takes a long time on large HTML document
  - This also fixes https://github.com/vivliostyle/vivliostyle-cli/issues/285
- first-letter pseudo element with float disappears when page break occurs in the parent paragraph
- SyntaxError ':not(:not(script, link, style) ~ \*)' is not a valid selector in slightly older browsers
- Flexbox layout broken due to text-spacing side-effect
- hanging-punctuation/text-spacing not working correctly when a ruby element is adjacent
- wrong hanging-punctuation on half-width ideographic comma/fullstop