### PR TITLE
fix: wrong "Built …" message and unnecessary reloading on preview

### DIFF
--- a/src/preview.ts
+++ b/src/preview.ts
@@ -170,6 +170,7 @@ export async function preview(cliFlags: PreviewCliFlags) {
         return false;
       },
       cwd: config.entries.length ? context : config.entryContextDir,
+      ignoreInitial: true,
     })
     .on('all', (event, path) => {
       if (


### PR DESCRIPTION
The chokidar.watch() option `ignoreInitial` must be set to true to prevent unnecessary change event
that causes wrong "Built _file name_" message and unnecessary reloading on preview.

- fix #284