### PR TITLE
fix: Update VFM to 1.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test": "jest --coverage"
   },
   "dependencies": {
-    "@vivliostyle/vfm": "1.2.1",
+    "@vivliostyle/vfm": "1.2.2",
     "@vivliostyle/viewer": "2.15.3",
     "ajv": "^7.0.4",
     "ajv-formats": "^1.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1265,10 +1265,10 @@
   dependencies:
     fast-diff "^1.2.0"
 
-"@vivliostyle/vfm@1.2.1":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@vivliostyle/vfm/-/vfm-1.2.1.tgz#ff8993696212fd9dfe7c02bc3f84f855bf506d23"
-  integrity sha512-dmE1kn1a0J+gnZ2gCULTI13sJc3YqlNMJeaAcjTqK7eh5AV04qebioeIJeiMelFz4uqOSKX4vnnDj5Jpbz09LA==
+"@vivliostyle/vfm@1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@vivliostyle/vfm/-/vfm-1.2.2.tgz#ae8fa4ed44b3bcf2d033e74f2b61d115994645fe"
+  integrity sha512-M8iGJ2wbJfrYUlvciZj1N234qnJIuX6ui7sywZr0RXlh7SbhKvOEQsezLKy00/TT2VSF0R+pVRnxMVBDSy6iag==
   dependencies:
     debug "^4.3.1"
     doctype "^2.0.4"


### PR DESCRIPTION
https://github.com/vivliostyle/vfm/releases/tag/v1.2.2

### Bug Fixes

* remove heading attributes notation on page title ([f23ff1f](https://github.com/vivliostyle/vfm/commit/f23ff1f5182b0554f73f0fe92ee3a068e7aab2a1))
* Type error of object property ([e8755d9](https://github.com/vivliostyle/vfm/commit/e8755d9de0839878b018a1b2c6f5b84c4ba93416))