### PR TITLE
feat: Set chromium option --enable-blink-features=LayoutNGPrinting

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -44,6 +44,9 @@ export async function launchBrowser({
                 ]
               : []),
             '--allow-file-access-from-files',
+            // For consistent layout between preview and printing, enable LayoutNGPrinting
+            // https://bugs.chromium.org/p/chromium/issues/detail?id=1121942#c79
+            '--enable-blink-features=LayoutNGPrinting',
             disableWebSecurity ? '--disable-web-security' : '',
             disableDevShmUsage ? '--disable-dev-shm-usage' : '',
           ],


### PR DESCRIPTION
This solves the problem of inconsistent layout between viewing and printing.

About the --enable-blink-features=LayoutNGPrinting switch, see
https://bugs.chromium.org/p/chromium/issues/detail?id=1121942#c79