### PR TITLE
fix: Reduce size of Docker image

### DIFF
--- a/.github/workflows/cd-workflow.yml
+++ b/.github/workflows/cd-workflow.yml
@@ -17,12 +17,12 @@ jobs:
         run: |
           VERSION=$(cat package.json | jq -r '.version')
           echo "::set-output name=version::$VERSION"
-      - name: Output current image tag of Playwright
+      - name: Output current Playwright version
         id: playwright
         run: |
           yarn install --frozen-lockfile
           VERSION=$(node -e 'console.log(require("playwright-core/package.json").version)')
-          echo "::set-output name=image_tag::v${VERSION}-focal"
+          echo "::set-output name=version::${VERSION}"
       - name: Docker meta
         id: docker_meta
         uses: docker/metadata-action@v3
@@ -56,6 +56,6 @@ jobs:
           platforms: linux/amd64,linux/arm64
           build-args: |
             VS_CLI_VERSION=${{ steps.package.outputs.version }}
-            PLAYWRIGHT_TAG=${{ steps.playwright.outputs.image_tag }}
+            PLAYWRIGHT_VERSION=${{ steps.playwright.outputs.version }}
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,12 +32,12 @@ jobs:
         run: |
           VERSION=$(cat package.json | jq -r '.version')
           echo "::set-output name=version::$VERSION"
-      - name: Output current image tag of Playwright
+      - name: Output current Playwright version
         id: playwright
         run: |
           yarn install --frozen-lockfile
           VERSION=$(node -e 'console.log(require("playwright-core/package.json").version)')
-          echo "::set-output name=image_tag::v${VERSION}-focal"
+          echo "::set-output name=version::${VERSION}"
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
@@ -51,7 +51,7 @@ jobs:
           push: true
           build-args: |
             VS_CLI_VERSION=${{ steps.package.outputs.version }}
-            PLAYWRIGHT_TAG=${{ steps.playwright.outputs.image_tag }}
+            PLAYWRIGHT_VERSION=${{ steps.playwright.outputs.version }}
           tags: localhost:5000/vivliostyle/cli:latest
       - name: Inspect
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,31 @@
-ARG PLAYWRIGHT_TAG
-FROM mcr.microsoft.com/playwright:$PLAYWRIGHT_TAG AS base
+FROM ubuntu:focal AS base
+ARG PLAYWRIGHT_VERSION
 LABEL maintainer "spring_raining <harusamex.com@gmail.com>"
 
+# Playwright's Dockerfile:
+# https://github.com/microsoft/playwright/blob/main/utils/docker/Dockerfile.focal
+# How to reduce size of Docker image for Playwright:
+# https://github.com/microsoft/playwright/issues/10168
+ARG DEBIAN_FRONTEND=noninteractive
+ARG TZ=Asia/Tokyo
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 RUN set -x \
   && apt-get update \
+  && apt-get install -y curl wget \
+  && curl -sL https://deb.nodesource.com/setup_16.x | bash - \
+  && apt-get install -y nodejs \
+  && apt-get install -y --no-install-recommends git openssh-client \
+  && npm install -g yarn \
+  && mkdir /ms-playwright \
+  && npx playwright@${PLAYWRIGHT_VERSION} install --with-deps chromium \
+  && chmod -R 777 /ms-playwright \
   && apt-get install -y --no-install-recommends \
     # dependencies for press-ready
-    ghostscript poppler-utils
+    ghostscript poppler-utils \
+  # clean cache
+  && rm -rf \
+    /var/lib/apt/lists/* \
+    `npm config get cache`/_npx
 WORKDIR /opt/vivliostyle-cli
 
 # Build stage
@@ -23,9 +42,6 @@ RUN test $VS_CLI_VERSION
 COPY . /opt/vivliostyle-cli
 RUN yarn install --frozen-lockfile --production \
   && echo $VS_CLI_VERSION > .vs-cli-version \
-  && rm -rf \
-    /var/lib/apt/lists/* \
-    `npm config get cache`/_npx \
   && yarn link \
   && ln -s /opt/vivliostyle-cli/node_modules/.bin/press-ready /usr/local/bin/press-ready \
   && ln -s /opt/vivliostyle-cli/node_modules/.bin/vfm /usr/local/bin/vfm


### PR DESCRIPTION
Before this change, the size of Docker image ghcr.io/vivliostyle/cli:5.1.0 was 2.12GB,
and with this change, it is reduced to 1.55GB.

- resolves #305