### PR TITLE
feat: Update Vivliostyle.js to 2.16.0: Improve CSS support

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@vivliostyle/vfm": "1.2.2",
-    "@vivliostyle/viewer": "2.15.8",
+    "@vivliostyle/viewer": "2.16.0",
     "ajv": "^7.0.4",
     "ajv-formats": "^1.5.1",
     "better-ajv-errors": "^1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1251,10 +1251,10 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@vivliostyle/core@^2.15.8":
-  version "2.15.8"
-  resolved "https://registry.yarnpkg.com/@vivliostyle/core/-/core-2.15.8.tgz#a5576ea917762cfbf7fc13a12b11d23e85b4aa5d"
-  integrity sha512-lEJAmF/nZ1/IKpUHhywDSkuYj11IuqnRH8OTlhL5kxwIDWQlN+1tQjbN4htMNRU73sx4i2V4mm6tSERNc5HIKg==
+"@vivliostyle/core@^2.16.0":
+  version "2.16.0"
+  resolved "https://registry.yarnpkg.com/@vivliostyle/core/-/core-2.16.0.tgz#f9b5203c7b3b49702933aa6f705cd5ac6b89ac82"
+  integrity sha512-SHS7wbE1N2OJwAKIt8RYwUrSqMldozmN2CweX1ajQXf092ULJqAsle34SttiKUf0u5OHd1ZtUcru/H4PkzWN/w==
   dependencies:
     fast-diff "^1.2.0"
 
@@ -1297,12 +1297,12 @@
     unist-util-visit "^2.0.3"
     unist-util-visit-parents "^3.1.1"
 
-"@vivliostyle/viewer@2.15.8":
-  version "2.15.8"
-  resolved "https://registry.yarnpkg.com/@vivliostyle/viewer/-/viewer-2.15.8.tgz#0f6a0e9a75e427388e79c57611dc9e88ff349d3c"
-  integrity sha512-+au4w4u+FQ4jprUCSzI2VTepdjiDtGojCv5ploEDsTrRK5br6opoOgIC9EeVzg0XbGXx4y7rrRl6xpCnGy7LrA==
+"@vivliostyle/viewer@2.16.0":
+  version "2.16.0"
+  resolved "https://registry.yarnpkg.com/@vivliostyle/viewer/-/viewer-2.16.0.tgz#9a6732cfa3be7d3f2933144851d786c47c541309"
+  integrity sha512-qkJiSbiTGqzCmOh3j4cRtBC+FvP1SIJaIwI+x1MumnEgEWCmJRH/ZWEfbpZlEi1W7ClUCWLyWmjO75NAE/0hpw==
   dependencies:
-    "@vivliostyle/core" "^2.15.8"
+    "@vivliostyle/core" "^2.16.0"
     font-awesome "^4.7.0"
     knockout "^3.5.0"
 


### PR DESCRIPTION
https://github.com/vivliostyle/vivliostyle.js/releases/tag/v2.16.0

### Bug Fixes
- Content overflow caused by line breaks in table cells that are not present in preview and appear in print
- CSS explicit defaulting (e.g. all: unset, break-inside: inherit) may not work as expected
- font-size with rem on root element causes wrong 1em size
- Footnote may disappear on Adaptive Layout

### Features
- Add support for CSS 'inset' shorthand
- Add support for CSS property value keywords 'initial', 'unset' and
- Add support for CSS shorthand property
- Improve CSS validator to support new property values supported in browser