### PR TITLE
feat: Update Vivliostyle.js to 2.18.1: improved viewer settings and bug fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@vivliostyle/vfm": "1.2.2",
-    "@vivliostyle/viewer": "2.17.2",
+    "@vivliostyle/viewer": "2.18.1",
     "ajv": "^7.0.4",
     "ajv-formats": "^1.5.1",
     "better-ajv-errors": "^1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1251,10 +1251,10 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@vivliostyle/core@^2.17.2":
-  version "2.17.2"
-  resolved "https://registry.yarnpkg.com/@vivliostyle/core/-/core-2.17.2.tgz#7fc5ca0db3aa44af27c4bd943f3dddd58961faf2"
-  integrity sha512-PspifOP536XEcEEKUBxCiKVTmA+eyRLDKgkc8qq4yDu+uSwJYskqougJDDOQhdv5E1qVadktLyPLyiQHwctZ1Q==
+"@vivliostyle/core@^2.18.1":
+  version "2.18.1"
+  resolved "https://registry.yarnpkg.com/@vivliostyle/core/-/core-2.18.1.tgz#615679dabaef1937713b7cfbded5beeae5d19755"
+  integrity sha512-dAmQ+KVQMgR/X8PYMfBRJ0bbOtSfzRXtrDqxqO8WfGaKy6H4Qk+pJ6xpGy2DEutVu9c1nT14gDADvsf/G+/S4w==
   dependencies:
     fast-diff "^1.2.0"
 
@@ -1297,12 +1297,12 @@
     unist-util-visit "^2.0.3"
     unist-util-visit-parents "^3.1.1"
 
-"@vivliostyle/viewer@2.17.2":
-  version "2.17.2"
-  resolved "https://registry.yarnpkg.com/@vivliostyle/viewer/-/viewer-2.17.2.tgz#0f593e0384f2e664dcc77c5101184340f15e2212"
-  integrity sha512-hPkvAvdBoAy55e9eb310TRi1KLiNLv2BqPRseF91/8KnbqoockzpWBAvfz4lOlH22r5QjMU6dTpHFTrCUkWMbA==
+"@vivliostyle/viewer@2.18.1":
+  version "2.18.1"
+  resolved "https://registry.yarnpkg.com/@vivliostyle/viewer/-/viewer-2.18.1.tgz#e8101f951faf193d2a961fd4f7e37b059c4ecb47"
+  integrity sha512-B317aCeOewUCYtbYly8Qq8Rxo+9AwOUgc0ZOpf91aWD/c0vKQlI8PphYoMe0UVuH4pmZMU4ZKYQZeZ4HKO6O9w==
   dependencies:
-    "@vivliostyle/core" "^2.17.2"
+    "@vivliostyle/core" "^2.18.1"
     font-awesome "^4.7.0"
     knockout "^3.5.0"
 


### PR DESCRIPTION
- https://github.com/vivliostyle/vivliostyle.js/releases/tag/v2.18.1
- https://github.com/vivliostyle/vivliostyle.js/releases/tag/v2.18.0

### Features

- **viewer:** add crop marks setting ([1d0834b](https://github.com/vivliostyle/vivliostyle.js/commit/1d0834b778f41fcb65553d043d3de30a424a0aea)), closes [#993](https://github.com/vivliostyle/vivliostyle.js/issues/993)
- **viewer:** change "User Style" to "Custom Style" and treat it as an author stylesheet by default ([bdb26d4](https://github.com/vivliostyle/vivliostyle.js/commit/bdb26d474f803eb44c9f09e2489dcda668231396)), closes [#991](https://github.com/vivliostyle/vivliostyle.js/issues/991)
- **viewer:** set bookMode=true as default ([5411264](https://github.com/vivliostyle/vivliostyle.js/commit/5411264648341144997f1d60a44f218a13625b42)), closes [#992](https://github.com/vivliostyle/vivliostyle.js/issues/992)

### Bug Fixes

- error with `<object>` tag ([9e9565f](https://github.com/vivliostyle/vivliostyle.js/commit/9e9565f49288e58adcede797029c87cbc0f1236f)), closes [#995](https://github.com/vivliostyle/vivliostyle.js/issues/995)
- errors on the Acid2 Browser Test ([849a604](https://github.com/vivliostyle/vivliostyle.js/commit/849a6048572f400deacfee09070247b3d8436eac))
- failed some of the css-variables tests ([5d0f324](https://github.com/vivliostyle/vivliostyle.js/commit/5d0f3246e1c9b91af6f67427a268409848e20ed9))
- incorrect column-rule positioning in vertical writing mode ([3cc0e01](https://github.com/vivliostyle/vivliostyle.js/commit/3cc0e010eb0c41f9ffb7f3c4d34d214b573d5860)), closes [#978](https://github.com/vivliostyle/vivliostyle.js/issues/978)
- unnecessary page break caused by ruby elements ([21eb17c](https://github.com/vivliostyle/vivliostyle.js/commit/21eb17c4b1ef5c72f6695c2166c70a76aeb60373)), closes [#987](https://github.com/vivliostyle/vivliostyle.js/issues/987)
- valid CSS rules ignored after parsing error with invalid or unsupported CSS rule ([5e76ed5](https://github.com/vivliostyle/vivliostyle.js/commit/5e76ed5d49c2f4b4c06c69619df27e83429c6a54)), closes [#597](https://github.com/vivliostyle/vivliostyle.js/issues/597) [#976](https://github.com/vivliostyle/vivliostyle.js/issues/976)
- wrong cascading on shorthand property with CSS variable ([2ee7927](https://github.com/vivliostyle/vivliostyle.js/commit/2ee792705c7598be7660ac590872329f2fcde17d)), closes [#979](https://github.com/vivliostyle/vivliostyle.js/issues/979)
- wrong cascading with CSS !important ([fb1dae2](https://github.com/vivliostyle/vivliostyle.js/commit/fb1dae26981827ae099e27967625c9d2abb59da3)), closes [#986](https://github.com/vivliostyle/vivliostyle.js/issues/986)
- wrong text justification at last line of page caused by consecutive ruby elements ([ad26952](https://github.com/vivliostyle/vivliostyle.js/commit/ad2695206e796617f2712e5bfe4b92057fbaae27)), closes [#985](https://github.com/vivliostyle/vivliostyle.js/issues/985)
