### PR TITLE
feat: allow empty input for preview command to open Viewer start page

### DIFF
--- a/src/preview.ts
+++ b/src/preview.ts
@@ -34,6 +34,11 @@ export async function preview(cliFlags: PreviewCliFlags) {
     ? upath.dirname(vivliostyleConfigPath)
     : cwd;
 
+  if (!cliFlags.input && !vivliostyleConfig) {
+    // Empty input, open Viewer start page
+    cliFlags.input = 'data:,';
+  }
+
   let config = await mergeConfig(
     cliFlags,
     // Only show preview of first entry

--- a/src/server.ts
+++ b/src/server.ts
@@ -107,7 +107,10 @@ export function getViewerFullUrl(
     return url.replace(/&/g, '%26');
   }
 
-  let viewerParams = `src=${escapeParam(sourceUrl.href)}`;
+  let viewerParams =
+    sourceUrl.href === 'data:,'
+      ? '' // open Viewer start page
+      : `src=${escapeParam(sourceUrl.href)}`;
   viewerParams += `&bookMode=${!singleDoc}&renderAllPages=${!quick}`;
 
   if (style) {


### PR DESCRIPTION
Vivliostyle Viewer start page has "Input a document URL or HTML code" box and that is useful for testing with HTML+CSS code.
