### PR TITLE
fix: case-insensitive pathname comparison is necessary for Windows

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -6,6 +6,7 @@ import {
   beforeExitHandlers,
   logInfo,
   logSuccess,
+  pathEquals,
   startLogging,
   stopLogging,
 } from './util';
@@ -77,7 +78,9 @@ export function checkBrowserAvailability(path: string): boolean {
 }
 
 export function isPlaywrightExecutable(path: string): boolean {
-  return registry.executables().some((exe) => exe.executablePath() === path);
+  return registry
+    .executables()
+    .some((exe) => pathEquals(exe.executablePath() ?? '', path));
 }
 
 export async function downloadBrowser(

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -28,6 +28,7 @@ import {
   DetailError,
   filterRelevantAjvErrors,
   log,
+  pathEquals,
   pathStartsWith,
 } from './util';
 
@@ -202,7 +203,7 @@ export async function compile(
       entry.type === 'text/html' ||
       entry.type === 'application/xhtml+xml'
     ) {
-      if (entry.source !== entry.target) {
+      if (!pathEquals(entry.source, entry.target)) {
         const html = processManuscriptHtml(entry.source, {
           style,
           title: entry.title,
@@ -212,7 +213,7 @@ export async function compile(
         fs.writeFileSync(entry.target, html);
       }
     } else {
-      if (entry.source !== entry.target) {
+      if (!pathEquals(entry.source, entry.target)) {
         shelljs.cp(entry.source, entry.target);
       }
     }
@@ -221,7 +222,7 @@ export async function compile(
   // copy theme
   for (const theme of themeIndexes) {
     if (theme.type === 'file') {
-      if (theme.location !== theme.destination) {
+      if (!pathEquals(theme.location, theme.destination)) {
         shelljs.mkdir('-p', path.dirname(theme.destination));
         shelljs.cp(theme.location, theme.destination);
       }
@@ -273,7 +274,7 @@ export async function copyAssets({
   workspaceDir,
   includeAssets,
 }: MergedConfig): Promise<void> {
-  if (entryContextDir === workspaceDir) {
+  if (pathEquals(entryContextDir, workspaceDir)) {
     return;
   }
   const relWorkspaceDir = path.relative(entryContextDir, workspaceDir);

--- a/src/config.ts
+++ b/src/config.ts
@@ -41,6 +41,7 @@ import {
   isUrlString,
   log,
   logWarn,
+  pathEquals,
   readJSON,
   statFileSync,
   touchTmpFile,
@@ -714,7 +715,10 @@ async function composeProjectConfig<T extends CliFlags>(
     if (!('path' in entry)) {
       const theme =
         parseTheme(entry.theme, context, workspaceDir) ?? themeIndexes[0];
-      if (theme && themeIndexes.every((t) => t.location !== theme.location)) {
+      if (
+        theme &&
+        themeIndexes.every((t) => !pathEquals(t.location, theme.location))
+      ) {
         themeIndexes.push(theme);
       }
       return {
@@ -742,7 +746,10 @@ async function composeProjectConfig<T extends CliFlags>(
       metadata.theme ??
       themeIndexes[0];
 
-    if (theme && themeIndexes.every((t) => t.location !== theme.location)) {
+    if (
+      theme &&
+      themeIndexes.every((t) => !pathEquals(t.location, theme.location))
+    ) {
       themeIndexes.push(theme);
     }
 

--- a/src/container.ts
+++ b/src/container.ts
@@ -6,7 +6,14 @@ import process from 'process';
 import path from 'upath';
 import { fileURLToPath, pathToFileURL } from 'url';
 import { cliVersion } from './const';
-import { debug, isUrlString, log, startLogging, stopLogging } from './util';
+import {
+  debug,
+  isUrlString,
+  log,
+  pathEquals,
+  startLogging,
+  stopLogging,
+} from './util';
 
 export const CONTAINER_IMAGE = `ghcr.io/vivliostyle/cli:${cliVersion}`;
 export const CONTAINER_ROOT_DIR = '/data';
@@ -38,7 +45,7 @@ export function collectVolumeArgs(mountPoints: string[]): string[] {
         return false;
       }
       let parent = p;
-      while (parent !== path.dirname(parent)) {
+      while (!pathEquals(parent, path.dirname(parent))) {
         parent = path.dirname(parent);
         if (array.includes(parent)) {
           // other mount point contains its directory

--- a/src/pdf.ts
+++ b/src/pdf.ts
@@ -24,6 +24,7 @@ import {
   logInfo,
   logSuccess,
   logUpdate,
+  pathEquals,
   startLogging,
 } from './util';
 
@@ -182,9 +183,11 @@ export async function buildPDF({
       }
       const url = new URL(response.url());
       return url.protocol === 'file:'
-        ? entry.target === url.pathname
-        : path.relative(workspaceDir, entry.target) ===
-            url.pathname.substring(1);
+        ? pathEquals(entry.target, url.pathname)
+        : pathEquals(
+            path.relative(workspaceDir, entry.target),
+            url.pathname.substring(1),
+          );
     });
     if (entry) {
       if (!lastEntry) {

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -14,6 +14,7 @@ import {
   debug,
   isUrlString,
   logSuccess,
+  pathEquals,
   pathStartsWith,
   startLogging,
   stopLogging,
@@ -131,19 +132,22 @@ export async function preview(cliFlags: PreviewCliFlags) {
           return true;
         }
         if (
-          config.entryContextDir !== config.workspaceDir &&
+          !pathEquals(config.entryContextDir, config.workspaceDir) &&
           pathStartsWith(path, config.workspaceDir)
         ) {
           return true; // ignore saved intermediate files
         }
-        if (config.manifestAutoGenerate && path === config.manifestPath) {
+        if (
+          config.manifestAutoGenerate &&
+          pathEquals(path, config.manifestPath)
+        ) {
           return true; // ignore generated pub-manifest
         }
         if (
           config.entries.length &&
           /\.(md|markdown|html?|xhtml|xht)$/i.test(path) &&
-          !config.entries.find(
-            (entry) => path === (entry as { source: string }).source,
+          !config.entries.find((entry) =>
+            pathEquals(path, (entry as { source: string }).source),
           )
         ) {
           return true; // ignore md or html files not in entries source
@@ -152,9 +156,9 @@ export async function preview(cliFlags: PreviewCliFlags) {
           config.themeIndexes.find(
             (theme) =>
               (theme.type === 'file' || theme.type === 'package') &&
-              theme.destination !== theme.location &&
+              !pathEquals(theme.destination, theme.location) &&
               (theme.type === 'file'
-                ? path === theme.destination
+                ? pathEquals(path, theme.destination)
                 : pathStartsWith(path, theme.destination)),
           )
         ) {
@@ -167,11 +171,14 @@ export async function preview(cliFlags: PreviewCliFlags) {
     })
     .on('all', (event, path) => {
       if (
-        upath.join(config.entryContextDir, path) === config.input.entry ||
+        pathEquals(
+          upath.join(config.entryContextDir, path),
+          config.input.entry,
+        ) ||
         /\.(md|markdown|html?|xhtml|xht|css|jpe?g|png|gif|svg)$/i.test(path)
       ) {
         handleChangeEvent(path);
-      } else if (path === upath.basename(vivliostyleConfigPath)) {
+      } else if (pathEquals(path, upath.basename(vivliostyleConfigPath))) {
         reloadConfig(path);
       }
     });

--- a/src/util.ts
+++ b/src/util.ts
@@ -253,10 +253,12 @@ export async function touchTmpFile(path: string): Promise<() => void> {
   return callback;
 }
 
+export function pathEquals(path1: string, path2: string): boolean {
+  return upath.relative(path1, path2) === '';
+}
+
 export function pathStartsWith(path1: string, path2: string): boolean {
-  const path1n = upath.normalize(path1).replace(/\/?$/, '/');
-  const path2n = upath.normalize(path2).replace(/\/?$/, '/');
-  return path1n.startsWith(path2n);
+  return !upath.relative(path2, path1).startsWith('..');
 }
 
 export function isUrlString(str: string): boolean {

--- a/src/webbook.ts
+++ b/src/webbook.ts
@@ -7,7 +7,7 @@ import type {
   PublicationLinks,
   PublicationManifest,
 } from './schema/publication.schema';
-import { debug } from './util';
+import { debug, pathEquals } from './util';
 
 export async function exportWebPublication({
   exportAliases,
@@ -62,7 +62,7 @@ export async function exportWebPublication({
       if (stderr) {
         throw new Error(stderr);
       }
-      if (path.join(input, entry.source) === manifestPath) {
+      if (pathEquals(path.join(input, entry.source), manifestPath)) {
         actualManifestPath = target;
       }
     }
@@ -75,9 +75,9 @@ export async function exportWebPublication({
     for (const entry of relExportAliases) {
       const rewriteAliasPath = (e: PublicationLinks | string) => {
         if (typeof e === 'string') {
-          return e === entry.source ? entry.source : e;
+          return pathEquals(e, entry.source) ? entry.source : e;
         }
-        if (e.url === entry.source) {
+        if (pathEquals(e.url, entry.source)) {
           e.url = entry.target;
         }
         return e;


### PR DESCRIPTION
This is important especially on Windows. See issue #325.

- fix #325
