### PR TITLE
fix: Update Vivliostyle.js to 2.18.2: Bug fixes on text-spacing and viewer

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@vivliostyle/vfm": "1.2.2",
-    "@vivliostyle/viewer": "2.18.1",
+    "@vivliostyle/viewer": "2.18.2",
     "ajv": "^7.0.4",
     "ajv-formats": "^1.5.1",
     "better-ajv-errors": "^1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1251,10 +1251,10 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@vivliostyle/core@^2.18.1":
-  version "2.18.1"
-  resolved "https://registry.yarnpkg.com/@vivliostyle/core/-/core-2.18.1.tgz#615679dabaef1937713b7cfbded5beeae5d19755"
-  integrity sha512-dAmQ+KVQMgR/X8PYMfBRJ0bbOtSfzRXtrDqxqO8WfGaKy6H4Qk+pJ6xpGy2DEutVu9c1nT14gDADvsf/G+/S4w==
+"@vivliostyle/core@^2.18.2":
+  version "2.18.2"
+  resolved "https://registry.yarnpkg.com/@vivliostyle/core/-/core-2.18.2.tgz#bb13e25cd04383186e12d19ff5a8d34ef2d6afb2"
+  integrity sha512-/K/0DPDa2gI5yVCgZOfHa8lWkjBclIGv5wrOptfkG3p+0Dez8pd9UhHOk1KZx0/h8PBkQTSe+/K+EEbkRAk5Rg==
   dependencies:
     fast-diff "^1.2.0"
 
@@ -1297,12 +1297,12 @@
     unist-util-visit "^2.0.3"
     unist-util-visit-parents "^3.1.1"
 
-"@vivliostyle/viewer@2.18.1":
-  version "2.18.1"
-  resolved "https://registry.yarnpkg.com/@vivliostyle/viewer/-/viewer-2.18.1.tgz#e8101f951faf193d2a961fd4f7e37b059c4ecb47"
-  integrity sha512-B317aCeOewUCYtbYly8Qq8Rxo+9AwOUgc0ZOpf91aWD/c0vKQlI8PphYoMe0UVuH4pmZMU4ZKYQZeZ4HKO6O9w==
+"@vivliostyle/viewer@2.18.2":
+  version "2.18.2"
+  resolved "https://registry.yarnpkg.com/@vivliostyle/viewer/-/viewer-2.18.2.tgz#5ca786ae8f47120ce6cc1a92762ad94ac6d6d699"
+  integrity sha512-yBkuzZ0T0UVVQ8LRMKZOBncKZSBsmk2P35FWNQc1DRLQBRyT3426BXxzlQw2nBcoqs+q0YFuX3+06kK6meLqPA==
   dependencies:
-    "@vivliostyle/core" "^2.18.1"
+    "@vivliostyle/core" "^2.18.2"
     font-awesome "^4.7.0"
     knockout "^3.5.0"
 


### PR DESCRIPTION
https://github.com/vivliostyle/vivliostyle.js/releases/edit/v2.18.2

### Bug Fixes

- **viewer:** Apply and Cancel buttons in Settings menu should not be scrolled out ([2df1b74](https://github.com/vivliostyle/vivliostyle.js/commit/2df1b7449dd78ae30c0d3a45a1b90035dcda67c7))
- **viewer:** disable shortcut keys when an input box exists in document and that is activated ([0eedcc0](https://github.com/vivliostyle/vivliostyle.js/commit/0eedcc0510ca862753b0aa6f6474d06a5d4ce8e4))
- wrong text-spacing when non-fullwidth closing and fullwidth opening brackets are adjacent ([331322b](https://github.com/vivliostyle/vivliostyle.js/commit/331322b63b8105e3e73eb53f5d2028b1a2e3efbe)), closes [# 1003](https://github.com/vivliostyle/vivliostyle.js/issues/1003)
- wrong text-spacing with fullwidth punctuations in some edge cases ([6a79482](https://github.com/vivliostyle/vivliostyle.js/commit/6a794827e3f84b16659bb209d9ada7fe195b4582)), closes [# 1005](https://github.com/vivliostyle/vivliostyle.js/issues/1005) [# 1006](https://github.com/vivliostyle/vivliostyle.js/issues/1006)
- wrong text-spacing:space-first and hanging-punctuation:first at page break inside paragraph ([ddd6d6c](https://github.com/vivliostyle/vivliostyle.js/commit/ddd6d6c93afca7662023110d92acbb716dfa94fd)), closes [# 1008](https://github.com/vivliostyle/vivliostyle.js/issues/1008)