### PR TITLE
fix: Update Vivliostyle.js to 2.18.4: Bug Fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@vivliostyle/vfm": "1.2.2",
-    "@vivliostyle/viewer": "2.18.3",
+    "@vivliostyle/viewer": "2.18.4",
     "ajv": "^7.0.4",
     "ajv-formats": "^1.5.1",
     "better-ajv-errors": "^1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1251,10 +1251,10 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@vivliostyle/core@^2.18.3":
-  version "2.18.3"
-  resolved "https://registry.yarnpkg.com/@vivliostyle/core/-/core-2.18.3.tgz#efae16b5b56667083e326ce26228ca6a73960e25"
-  integrity sha512-es93oToBQZsBVosbQk8RFqARPq1O6fVZs1O6kcQZWK26JjAD8Ko3Kp+nufOb/W3GOtOux4tUHSw2ttGKachKWQ==
+"@vivliostyle/core@^2.18.4":
+  version "2.18.4"
+  resolved "https://registry.yarnpkg.com/@vivliostyle/core/-/core-2.18.4.tgz#4b5ff3d71c18d18d7ca59c83942991797d09f8b9"
+  integrity sha512-rTJIbfkt3hMFbeXNW2YbXCp16bJCWpYeOE8dtVC/YCIAp/OeWRQ9KzKYGKrFVGklPOzXqMAjTY7UO7fj089P2A==
   dependencies:
     fast-diff "^1.2.0"
 
@@ -1297,12 +1297,12 @@
     unist-util-visit "^2.0.3"
     unist-util-visit-parents "^3.1.1"
 
-"@vivliostyle/viewer@2.18.3":
-  version "2.18.3"
-  resolved "https://registry.yarnpkg.com/@vivliostyle/viewer/-/viewer-2.18.3.tgz#c4096269d093eda1bbbb14ddf7351ed68797dd19"
-  integrity sha512-KydPugN0VmTOZBrVhEDHLeGQsNNb7nO2wpfL1ETGZHxB1yNbACDJbABDY5PmQNc+awb+o5llZK6Z4DOh7+ggJA==
+"@vivliostyle/viewer@2.18.4":
+  version "2.18.4"
+  resolved "https://registry.yarnpkg.com/@vivliostyle/viewer/-/viewer-2.18.4.tgz#70ac226110e3c4541b9bd572259f070b9d66215c"
+  integrity sha512-Xxl0rFgSZg/ZqVP/pZmBUiM7czraHdpksRJZugT6UPXjh1plUrZTcXSfiy2RQuXGMpbmE7qYR4qONcqDT13mwA==
   dependencies:
-    "@vivliostyle/core" "^2.18.3"
+    "@vivliostyle/core" "^2.18.4"
     font-awesome "^4.7.0"
     knockout "^3.5.0"
 


### PR DESCRIPTION
https://github.com/vivliostyle/vivliostyle.js/releases/tag/v2.18.4

### Bug Fixes

- CSS parser error with calc expression including parens and variables ([88c4ae0](https://github.com/vivliostyle/vivliostyle.js/commit/88c4ae00039dab743945c141fcb5c167580ddf2a)), closes [1014](https://github.com/vivliostyle/vivliostyle.js/issues/1014)
- CSS parser error with property:calc(…) misinterpreted as selector with pseudo class ([71c39bf](https://github.com/vivliostyle/vivliostyle.js/commit/71c39bf665d6a2b668f175f8d3623184275ec23a)), closes [1020](https://github.com/vivliostyle/vivliostyle.js/issues/1020)
- percentage units in color value changed, resulting in invalid colors ([a45e861](https://github.com/vivliostyle/vivliostyle.js/commit/a45e861903946e3f2499f23d6ef4fe852fae30d5)), closes [1012](https://github.com/vivliostyle/vivliostyle.js/issues/1012)
- RTL direction not behaving in multi column ([d6280f1](https://github.com/vivliostyle/vivliostyle.js/commit/d6280f184e9217f05c98b937ae14b1efc2808192)), closes [1016](https://github.com/vivliostyle/vivliostyle.js/issues/1016)
- TypeError occurs with ::nth-fragment() and ::after-if-continues() selectors ([7a7c1aa](https://github.com/vivliostyle/vivliostyle.js/commit/7a7c1aa983a5142c05080a080e5e1c08cbc6bb0b)), closes [1023](https://github.com/vivliostyle/vivliostyle.js/issues/1023)
- wrong CSS variable scoping ([37e800a](https://github.com/vivliostyle/vivliostyle.js/commit/37e800a7074f3c907214b11630d9728fd652c4df)), closes [1015](https://github.com/vivliostyle/vivliostyle.js/issues/1015)