### PR TITLE
fix: remove no longer necessary chromium option to enable LayoutNGPrinting

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -45,9 +45,6 @@ export async function launchBrowser({
                 ]
               : []),
             '--allow-file-access-from-files',
-            // For consistent layout between preview and printing, enable LayoutNGPrinting
-            // https://bugs.chromium.org/p/chromium/issues/detail?id=1121942#c79
-            '--enable-blink-features=LayoutNGPrinting',
             disableWebSecurity ? '--disable-web-security' : '',
             disableDevShmUsage ? '--disable-dev-shm-usage' : '',
           ],


### PR DESCRIPTION
The chromium option `--enable-blink-features=LayoutNGPrinting` does not work on Chromium 107. This feature (LayoutNGPrinting) is enabled by default from Chromium 108.

- issue #347