### PR TITLE
fix: browser address bar should not be focused when starting preview

### DIFF
--- a/src/preview.ts
+++ b/src/preview.ts
@@ -108,6 +108,11 @@ export async function preview(cliFlags: PreviewCliFlags) {
   const page = await browser.newPage({ viewport: null });
   await page.goto(viewerFullUrl);
 
+  // Move focus from the address bar to the page
+  await page.bringToFront();
+  // Focus to the URL input box if available
+  await page.locator('#vivliostyle-input-url').focus();
+
   stopLogging('Up and running ([ctrl+c] to quit)', '🚀');
 
   function reloadConfig(path: string) {


### PR DESCRIPTION
previewコマンドでブラウザが起動したとき、これまでアドレスバーにフォーカスがある状態になっていました。
この状態だと、矢印キーでのページ移動など、Viewerの操作にキーボードを利用しようとしても、うまくいきません。いったんページ内にフォーカスを移動するのにクリックする必要があって面倒でした。

また、入力の指定なしでpreviewを起動したときのURL入力ボックスが出るときもそこにフォーカスがあってすぐに入力できればいいのにそうなってませんでした。

この問題を修正しました。
