### PR TITLE
fix: Update Playwright to 1.31.1 (Chromium 111.0.5563.19, bugfixed on Windows)

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "node-stream-zip": "^1.14.0",
     "ora": "^5.4.1",
     "pdf-lib": "^1.16.0",
-    "playwright-core": "1.31.0",
+    "playwright-core": "1.31.1",
     "portfinder": "^1.0.28",
     "press-ready": "^4.0.3",
     "prettier": "^2.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6848,10 +6848,10 @@ pkg-dir@^5.0.0:
   dependencies:
     find-up "^5.0.0"
 
-playwright-core@1.31.0:
-  version "1.31.0"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.31.0.tgz#dbd184771535e76c6743ef5c082def5564f07e85"
-  integrity sha512-/KquBjS5DcASCh8cGeNVHuC0kyb7c9plKTwaKxgOGtxT7+DZO2fjmFvPDBSXslEIK5CeOO/2kk5rOCktFXKEdA==
+playwright-core@1.31.1:
+  version "1.31.1"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.31.1.tgz#4deeebbb8fb73b512593fe24bea206d8fd85ff7f"
+  integrity sha512-JTyX4kV3/LXsvpHkLzL2I36aCdml4zeE35x+G5aPc4bkLsiRiQshU5lWeVpHFAuC8xAcbI6FDcw/8z3q2xtJSQ==
 
 please-upgrade-node@^3.2.0:
   version "3.2.0"


### PR DESCRIPTION
The Chromium version installed with Playwright v1.31.0 had a bug that shows extra cmd windows in headless mode on Windows.

- https://github.com/microsoft/playwright/issues/21093

I tested `vivliostyle build` command on Windows and reproduced this problem. See screenshot:

<img width="598" alt="Screenshot 2023-02-23 at 15 11 36" src="https://user-images.githubusercontent.com/3324737/220836554-320024c5-91f5-479f-a5f9-02ea458d928e.png">

[Playwright v1.31.1](https://github.com/microsoft/playwright/releases/tag/v1.31.1) resolves this problem:

> https://github.com/microsoft/playwright/issues/21093 - [Regression v1.31] Headless Windows shows cascading cmd windows
