### PR TITLE
docs: page size initial value "Letter" is not correct

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Options:
   -f, --format <format>            specify output format corresponding output target
                                    If an extension is specified on -o option, this field will be
                                    inferenced automatically.
-  -s, --size <size>                output pdf size [Letter]
+  -s, --size <size>                output pdf size
                                    preset: A5, A4, A3, B5, B4, JIS-B5, JIS-B4, letter, legal,
                                    ledger
                                    custom(comma separated): 182mm,257mm or 8.5in,11in
@@ -134,7 +134,7 @@ vivliostyle preview
 Options:
   -c, --config <config_file>      path to vivliostyle.config.js
   -T, --theme <theme>             theme path or package name
-  -s, --size <size>               output pdf size [Letter]
+  -s, --size <size>               output pdf size
                                   preset: A5, A4, A3, B5, B4, JIS-B5, JIS-B4, letter, legal,
                                   ledger
                                   custom(comma separated): 182mm,257mm or 8.5in,11in

--- a/src/commands/build.parser.ts
+++ b/src/commands/build.parser.ts
@@ -64,7 +64,7 @@ If an extension is specified on -o option, this field will be inferenced automat
     )
     .option(
       '-s, --size <size>',
-      `output pdf size [Letter]
+      `output pdf size
 preset: A5, A4, A3, B5, B4, JIS-B5, JIS-B4, letter, legal, ledger
 custom(comma separated): 182mm,257mm or 8.5in,11in`,
     )

--- a/src/commands/preview.parser.ts
+++ b/src/commands/preview.parser.ts
@@ -10,7 +10,7 @@ export function setupPreviewParserProgram(): Command {
     .option('-T, --theme <theme>', 'theme path or package name')
     .option(
       '-s, --size <size>',
-      `output pdf size [Letter]
+      `output pdf size
 preset: A5, A4, A3, B5, B4, JIS-B5, JIS-B4, letter, legal, ledger
 custom(comma separated): 182mm,257mm or 8.5in,11in`,
     )

--- a/src/config.ts
+++ b/src/config.ts
@@ -286,7 +286,7 @@ export function parseTheme({
 
 function parsePageSize(size: string): PageSize {
   const [width, height, ...others] = `${size}`.split(',');
-  if (others.length) {
+  if (!width || others.length) {
     throw new Error(`Cannot parse size: ${size}`);
   } else if (width && height) {
     return {
@@ -295,7 +295,7 @@ function parsePageSize(size: string): PageSize {
     };
   } else {
     return {
-      format: width ?? 'Letter',
+      format: width,
     };
   }
 }


### PR DESCRIPTION
READMEや--helpでの `--size` オプションの説明に "[Letter]" とありますが、これは正しくないので "[Letter]" の記述を削除しました。

`parsePageSize()` に `format: width ?? 'Letter'` というコードがありましたが、実際は `width` が null や undefined でここに来ることはなくて、この 'Letter' が使われることはありません。

実際の初期値は設定なしです。スタイルシートでpage sizeが指定されていればそのサイズになります。
もしどこにもページサイズの設定がなければ、CSSでのpage sizeの初期値であるautoです。その場合、preview表示ではブラウザのウインドウサイズで決まるページサイズになり、buildでのPDF出力では適当なページサイズになります（その適当なページサイズについて詳しくは： https://github.com/vivliostyle/vivliostyle.js/pull/876 ）。
