### PR TITLE
feat: set UI language of Vivliostyle Viewer

### DIFF
--- a/src/preview.ts
+++ b/src/preview.ts
@@ -106,6 +106,13 @@ export async function preview(cliFlags: PreviewCliFlags) {
     disableWebSecurity: !config.viewer,
   });
   const page = await browser.newPage({ viewport: null });
+
+  // Vivliostyle Viewer uses `i18nextLng` in localStorage for UI language
+  const locale = Intl.DateTimeFormat().resolvedOptions().locale;
+  await page.addInitScript(
+    `window.localStorage.setItem('i18nextLng', '${locale}');`,
+  );
+
   await page.goto(viewerFullUrl);
 
   // Move focus from the address bar to the page


### PR DESCRIPTION
Vivliostyle Viewer (>=2.24) has UI language setting, which uses browser's language (navigator.language) by default. However Vivliostyle CLI sets `--lang=en` to the browser to avoid language-depended problem, so we cannot rely on browser language.

This commit solves this problem.