### PR TITLE
feat: Viewer parameter setting: `--viewer-param` option (viewerParam property)

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ Options:
                                    vivliostyle-cli's one
                                    It is useful that using own viewer that has staging features.
                                    (ex: https://vivliostyle.vercel.app/)
+  --viewer-param <parameters>      specify viewer parameters.
+                                   (ex: "allowScripts=false&pixelRatio=16")
   -h, --help                       display help for command
 ```
 
@@ -161,6 +163,8 @@ Options:
                                   vivliostyle-cli's one
                                   It is useful that using own viewer that has staging features.
                                   (ex: https://vivliostyle.vercel.app/)
+  --viewer-param <parameters>     specify viewer parameters.
+                                  (ex: "allowScripts=false&pixelRatio=16")
   --browser <browser>             EXPERIMENTAL SUPPORT: Specify a browser type to launch
                                   Vivliostyle viewer [chromium]
                                   Currently, Firefox and Webkit support preview command only!

--- a/src/commands/build.parser.ts
+++ b/src/commands/build.parser.ts
@@ -136,6 +136,10 @@ It is useful that requires CORS such as external web fonts.`,
       `specify a URL of displaying viewer instead of vivliostyle-cli's one
 It is useful that using own viewer that has staging features. (ex: https://vivliostyle.vercel.app/)`,
     )
+    .option(
+      '--viewer-param <parameters>',
+      `specify viewer parameters. (ex: "allowScripts=false&pixelRatio=16")`,
+    )
     // Hide --browser option for now. There's no choice other than Chromium.
     //     .addOption(
     //       new commander.Option(

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -34,6 +34,7 @@ try {
     image: options.image,
     http: options.http,
     viewer: options.viewer,
+    viewerParam: options.viewerParam,
     // browser: options.browser,
     bypassedPdfBuilderOption: options.bypassedPdfBuilderOption,
     executableChromium: options.executableChromium, // TODO: Remove it in the next major version up

--- a/src/commands/preview.parser.ts
+++ b/src/commands/preview.parser.ts
@@ -53,6 +53,10 @@ It is useful that requires CORS such as external web fonts.`,
       `specify a URL of displaying viewer instead of vivliostyle-cli's one
 It is useful that using own viewer that has staging features. (ex: https://vivliostyle.vercel.app/)`,
     )
+    .option(
+      '--viewer-param <parameters>',
+      `specify viewer parameters. (ex: "allowScripts=false&pixelRatio=16")`,
+    )
     .addOption(
       new Option(
         '--browser <browser>',

--- a/src/commands/preview.ts
+++ b/src/commands/preview.ts
@@ -28,6 +28,7 @@ try {
     executableBrowser: options.executableBrowser,
     http: options.http,
     viewer: options.viewer,
+    viewerParam: options.viewerParam,
     browser: options.browser,
     executableChromium: options.executableChromium, // TODO: Remove it in the next major version up
   }).catch(gracefulError);

--- a/src/config.ts
+++ b/src/config.ts
@@ -120,6 +120,7 @@ export interface CliFlags {
   image?: string;
   http?: boolean;
   viewer?: string;
+  viewerParam?: string;
   browser?: 'chromium' | 'firefox' | 'webkit';
   /** @deprecated */ executableChromium?: string;
 }
@@ -179,6 +180,7 @@ export type MergedConfig = {
   image: string;
   httpServer: boolean;
   viewer: string | undefined;
+  viewerParam: string | undefined;
 } & ManifestConfig;
 
 const DEFAULT_TIMEOUT = 2 * 60 * 1000; // 2 minutes
@@ -523,6 +525,7 @@ export async function mergeConfig<T extends CliFlags>(
   const image = cliFlags.image ?? config?.image ?? CONTAINER_IMAGE;
   const httpServer = cliFlags.http ?? config?.http ?? false;
   const viewer = cliFlags.viewer ?? config?.viewer ?? undefined;
+  const viewerParam = cliFlags.viewerParam ?? config?.viewerParam ?? undefined;
 
   const rootThemes = cliFlags.theme
     ? [
@@ -642,6 +645,7 @@ export async function mergeConfig<T extends CliFlags>(
     image,
     httpServer,
     viewer,
+    viewerParam,
   };
   if (!cliFlags.input && !config) {
     throw new Error(

--- a/src/pdf.ts
+++ b/src/pdf.ts
@@ -93,6 +93,7 @@ export async function buildPDF({
   entries,
   httpServer,
   viewer,
+  viewerParam,
 }: BuildPdfOptions): Promise<string | null> {
   const isInContainer = checkContainerEnvironment();
   logUpdate(`Launching build environment`);
@@ -102,6 +103,7 @@ export async function buildPDF({
     workspaceDir,
     httpServer,
     viewer,
+    viewerParam,
     size,
     cropMarks,
     bleed,

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -74,6 +74,7 @@ export async function preview(cliFlags: PreviewCliFlags) {
     workspaceDir: config.workspaceDir,
     httpServer: config.httpServer,
     viewer: config.viewer,
+    viewerParam: config.viewerParam,
     size: config.size,
     cropMarks: config.cropMarks,
     bleed: config.bleed,

--- a/src/schema/vivliostyleConfig.schema.ts
+++ b/src/schema/vivliostyleConfig.schema.ts
@@ -112,6 +112,10 @@ export interface VivliostyleConfigEntry {
    */
   viewer?: string;
   /**
+   * specify viewer parameters. (ex: "allowScripts=false&pixelRatio=16")
+   */
+  viewerParam?: string;
+  /**
    * EXPERIMENTAL SUPPORT: Specify a browser type to launch Vivliostyle viewer. Currently, Firefox and Webkit support preview command only!
    */
   browser?: BrowserType;

--- a/src/server.ts
+++ b/src/server.ts
@@ -28,6 +28,7 @@ export type ViewerUrlOption = {
   userStyle?: string;
   singleDoc?: boolean;
   quick?: boolean;
+  viewerParam?: string | undefined;
 };
 
 export type ServerOption = ViewerUrlOption & {
@@ -106,6 +107,7 @@ export function getViewerFullUrl(
     userStyle,
     singleDoc,
     quick,
+    viewerParam,
   }: ViewerUrlOption,
   { viewerUrl, sourceUrl }: { viewerUrl: URL; sourceUrl: URL },
 ): string {
@@ -153,6 +155,11 @@ export function getViewerFullUrl(
     viewerParams += `&style=data:,/*<viewer>*/${encodeURIComponent(
       pageStyle,
     )}/*</viewer>*/${encodeURIComponent(css ?? '')}`;
+  }
+
+  if (viewerParam) {
+    // append additional viewer parameters
+    viewerParams += `&${viewerParam}`;
   }
 
   return `${viewerUrl.href}#${viewerParams}`;

--- a/tests/__snapshots__/config.test.ts.snap
+++ b/tests/__snapshots__/config.test.ts.snap
@@ -95,6 +95,7 @@ Object {
     "hardLineBreaks": false,
   },
   "viewer": undefined,
+  "viewerParam": undefined,
   "workspaceDir": "__WORKSPACE__/tests/fixtures/config",
 }
 `;
@@ -158,6 +159,7 @@ Object {
     "hardLineBreaks": false,
   },
   "viewer": undefined,
+  "viewerParam": undefined,
   "workspaceDir": "__WORKSPACE__/tests/fixtures/epubs/adaptive/OPS",
 }
 `;
@@ -221,6 +223,7 @@ Object {
     "hardLineBreaks": false,
   },
   "viewer": undefined,
+  "viewerParam": undefined,
   "workspaceDir": "__WORKSPACE__/tests/fixtures/epubs",
 }
 `;
@@ -283,6 +286,7 @@ Object {
     "hardLineBreaks": false,
   },
   "viewer": undefined,
+  "viewerParam": undefined,
   "webbookEntryPath": "https://vivliostyle.github.io/vivliostyle_doc/ja/vivliostyle-user-group-vol1/",
   "workspaceDir": "__WORKSPACE__",
 }
@@ -345,6 +349,7 @@ Object {
     "hardLineBreaks": false,
   },
   "viewer": undefined,
+  "viewerParam": undefined,
   "workspaceDir": "__WORKSPACE__/tests/fixtures/webbooks/readium-webpub",
 }
 `;
@@ -406,6 +411,7 @@ Object {
     "hardLineBreaks": false,
   },
   "viewer": undefined,
+  "viewerParam": undefined,
   "workspaceDir": "__WORKSPACE__/tests/fixtures/webbooks/w3c-webpub",
 }
 `;
@@ -468,6 +474,7 @@ Object {
     "hardLineBreaks": false,
   },
   "viewer": undefined,
+  "viewerParam": undefined,
   "webbookEntryPath": "__WORKSPACE__/tests/fixtures/config/sample.html",
   "workspaceDir": "__WORKSPACE__/tests/fixtures/config",
 }
@@ -600,6 +607,7 @@ Object {
     "hardLineBreaks": true,
   },
   "viewer": "https://vivliostyle.org/viewer/",
+  "viewerParam": "allowScripts=false&pixelRatio=16",
   "workspaceDir": "__WORKSPACE__/tests/fixtures/config/workspaceDir",
 }
 `;
@@ -742,6 +750,7 @@ Object {
     "hardLineBreaks": true,
   },
   "viewer": undefined,
+  "viewerParam": undefined,
   "workspaceDir": "__WORKSPACE__/tests/fixtures/config/workspaceDir",
 }
 `;
@@ -817,6 +826,7 @@ Object {
     "hardLineBreaks": false,
   },
   "viewer": undefined,
+  "viewerParam": undefined,
   "workspaceDir": "__WORKSPACE__/tests/fixtures/config",
 }
 `;
@@ -892,6 +902,7 @@ Object {
     "hardLineBreaks": false,
   },
   "viewer": undefined,
+  "viewerParam": undefined,
   "workspaceDir": "__WORKSPACE__/tests/fixtures/config",
 }
 `;
@@ -1034,6 +1045,7 @@ Object {
     "hardLineBreaks": true,
   },
   "viewer": undefined,
+  "viewerParam": undefined,
   "workspaceDir": "__WORKSPACE__/tests/fixtures/config/workspaceDir",
 }
 `;
@@ -1109,6 +1121,7 @@ Object {
     "hardLineBreaks": false,
   },
   "viewer": undefined,
+  "viewerParam": undefined,
   "workspaceDir": "__WORKSPACE__/tests/fixtures/config",
 }
 `;
@@ -1184,6 +1197,7 @@ Object {
     "hardLineBreaks": false,
   },
   "viewer": undefined,
+  "viewerParam": undefined,
   "workspaceDir": "__WORKSPACE__/tests/fixtures/config",
 }
 `;
@@ -1292,6 +1306,7 @@ Object {
     "hardLineBreaks": true,
   },
   "viewer": undefined,
+  "viewerParam": undefined,
   "workspaceDir": "__WORKSPACE__/tests/fixtures/config/workspaceDir",
 }
 `;
@@ -1367,6 +1382,7 @@ Object {
     "hardLineBreaks": false,
   },
   "viewer": undefined,
+  "viewerParam": undefined,
   "workspaceDir": "__WORKSPACE__/tests/fixtures/config",
 }
 `;

--- a/tests/__snapshots__/config.test.ts.snap
+++ b/tests/__snapshots__/config.test.ts.snap
@@ -750,7 +750,7 @@ Object {
     "hardLineBreaks": true,
   },
   "viewer": undefined,
-  "viewerParam": undefined,
+  "viewerParam": "foo=bar",
   "workspaceDir": "__WORKSPACE__/tests/fixtures/config/workspaceDir",
 }
 `;
@@ -1045,7 +1045,7 @@ Object {
     "hardLineBreaks": true,
   },
   "viewer": undefined,
-  "viewerParam": undefined,
+  "viewerParam": "foo=bar",
   "workspaceDir": "__WORKSPACE__/tests/fixtures/config/workspaceDir",
 }
 `;
@@ -1306,7 +1306,7 @@ Object {
     "hardLineBreaks": true,
   },
   "viewer": undefined,
-  "viewerParam": undefined,
+  "viewerParam": "foo=bar",
   "workspaceDir": "__WORKSPACE__/tests/fixtures/config/workspaceDir",
 }
 `;

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -75,6 +75,8 @@ it('override option by CLI command', async () => {
     '--http',
     '--viewer',
     'https://vivliostyle.org/viewer/',
+    '--viewer-param',
+    'allowScripts=false&pixelRatio=16',
   ]);
   maskConfig(config);
   expect(config).toMatchSnapshot('valid.1.config.js');

--- a/tests/fixtures/config/vivliostyle.config.valid.1.cjs
+++ b/tests/fixtures/config/vivliostyle.config.valid.1.cjs
@@ -33,4 +33,5 @@ module.exports = {
   },
   readingProgression: 'rtl',
   browser: 'firefox',
+  viewerParam: 'foo=bar',
 };

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -84,6 +84,7 @@ it('converts to valid broker url', async () => {
           'data:,#test>p::before{content:"エスケープ チェック";display:block}',
         userStyle:
           'file://path/to/local/style/file/which/might/include/white space/&/special#?character.css',
+        viewerParam: 'allowScripts=false&pixelRatio=16',
       },
       {
         viewerUrl: pathToFileURL(
@@ -98,7 +99,7 @@ it('converts to valid broker url', async () => {
   };
   maskConfig(validOut2);
   expect(validOut2.url).toBe(
-    `file://__WORKSPACE__/node_modules/@vivliostyle/viewer/lib/index.html#src=${sourceUrl2.toString()}&bookMode=false&renderAllPages=false&style=data:,#test>p::before{content:"エスケープ チェック";display:block}&userStyle=file://path/to/local/style/file/which/might/include/white space/%26/special#?character.css&style=data:,/*<viewer>*/%40page%7Bsize%3A5in%2010in%3B%7D/*</viewer>*/`,
+    `file://__WORKSPACE__/node_modules/@vivliostyle/viewer/lib/index.html#src=${sourceUrl2.toString()}&bookMode=false&renderAllPages=false&style=data:,#test>p::before{content:"エスケープ チェック";display:block}&userStyle=file://path/to/local/style/file/which/might/include/white space/%26/special#?character.css&style=data:,/*<viewer>*/%40page%7Bsize%3A5in%2010in%3B%7D/*</viewer>*/&allowScripts=false&pixelRatio=16`,
   );
 
   const sourceUrl3 = pathToFileURL('/absolute/path/to/something');


### PR DESCRIPTION
- resolves #169

preview and build option:

    --viewer-param <parameters>     specify viewer parameters. (ex: "allowScripts=false&pixelRatio=16")

config property:

    /**
     * specify viewer parameters. (ex: "allowScripts=false&pixelRatio=16")
     */
    viewerParam?: string;

The specified viewer parameters are appended to the viewer URL parameters.