### PR TITLE
fix: prevent confirm dialog from being auto-dismissed

### DIFF
--- a/src/preview.ts
+++ b/src/preview.ts
@@ -114,6 +114,9 @@ export async function preview(cliFlags: PreviewCliFlags) {
     `window.localStorage.setItem('i18nextLng', '${locale}');`,
   );
 
+  // Prevent confirm dialog from being auto-dismissed
+  page.on('dialog', () => {});
+
   await page.goto(viewerFullUrl);
 
   // Move focus from the address bar to the page


### PR DESCRIPTION
Viewerの新機能であるマーカー注釈機能で、マーカー・注釈を削除するときの確認メッセージのダイアログが自動的にキャンセルされてしまう問題を修正します。

関連PR：
- https://github.com/vivliostyle/vivliostyle-cli/pull/391#issuecomment-1492892872

> CLIではこのままではその確認メッセージも出ない問題があることに気がつきました。原因はPlaywrightがデフォルトでconfirm()を閉じてしまうようにしてることのようです。
>
> https://playwright.dev/docs/next/dialogs
>
> > alert(), confirm(), prompt() dialogs
> >
> > By default, dialogs are auto-dismissed by Playwright,...

