### PR TITLE
feat: Update Playwright to 1.34.3 (Chromium 114.0.5735.26)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
       # https://github.com/facebook/jest/issues/11438
       # - run: yarn test
       - run: yarn build
-      - run: yarn playwright install chromium
+      - run: yarn playwright-core install chromium
       - run: node --experimental-vm-modules node_modules/jest/bin/jest.js tests/api.test.ts
       - run: node --experimental-vm-modules node_modules/jest/bin/jest.js tests/builder.test.ts
       - run: node --experimental-vm-modules node_modules/jest/bin/jest.js tests/cli.test.ts

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "node-stream-zip": "^1.14.0",
     "ora": "^5.4.1",
     "pdf-lib": "^1.16.0",
-    "playwright-core": "1.33.0",
+    "playwright-core": "1.34.3",
     "portfinder": "^1.0.28",
     "press-ready": "^4.0.3",
     "prettier": "^2.3.2",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "dev": "run-p dev:*",
     "dev:cli": "tsc -w --preserveWatchOutput",
     "example": "yarn --cwd example build",
-    "pretest": "yarn build && playwright install chromium",
+    "pretest": "yarn build && playwright-core install chromium",
     "release": "release-it",
     "release:pre": "release-it --preRelease --npm.tag=next",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --coverage"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6850,10 +6850,10 @@ pkg-dir@^5.0.0:
   dependencies:
     find-up "^5.0.0"
 
-playwright-core@1.33.0:
-  version "1.33.0"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.33.0.tgz#269efe29a927cd6d144d05f3c2d2f72bd72447a1"
-  integrity sha512-aizyPE1Cj62vAECdph1iaMILpT0WUDCq3E6rW6I+dleSbBoGbktvJtzS6VHkZ4DKNEOG9qJpiom/ZxO+S15LAw==
+playwright-core@1.34.3:
+  version "1.34.3"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.34.3.tgz#bc906ea1b26bb66116ce329436ee59ba2e78fe9f"
+  integrity sha512-2pWd6G7OHKemc5x1r1rp8aQcpvDh7goMBZlJv6Co5vCNLVcQJdhxRL09SGaY6HcyHH9aT4tiynZabMofVasBYw==
 
 please-upgrade-node@^3.2.0:
   version "3.2.0"


### PR DESCRIPTION
- [feat: Update Playwright to 1.34.3 (Chromium 114.0.5735.26)](https://github.com/vivliostyle/vivliostyle-cli/commit/8dde8317e7bd3fb208077cb96477880999ae3560)
- [chore: change playwright to playwright-core in pretest script](https://github.com/vivliostyle/vivliostyle-cli/commit/eeb30c982bee654e507cabdf3df14e2d57f1a650)

  > This change is necessary because of the change in playwright v1.34.3.
  > see https://github.com/microsoft/playwright/pull/23260

- [chore: change playwright to playwright-core in test.yml](https://github.com/vivliostyle/vivliostyle-cli/pull/409/commits/87349d66dc3c88e14d395248731e0563fa2ee20d)