### PR TITLE
fix: preview minimum font-size problem depending on locale on macOS

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -36,11 +36,13 @@ export async function launchBrowser({
             '--allow-file-access-from-files',
             disableWebSecurity ? '--disable-web-security' : '',
             disableDevShmUsage ? '--disable-dev-shm-usage' : '',
+            // set Chromium language to English to avoid locale-dependent issues (e.g. minimum font size)
             '--lang=en',
             ...(!headless && process.platform === 'darwin'
               ? ['-AppleLanguages', '(en)']
               : []),
           ],
+          env: { ...process.env, LANG: 'en.UTF-8' },
         }
       : // TODO: Investigate appropriate settings on Firefox & Webkit
         { executablePath, headless };

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -37,6 +37,9 @@ export async function launchBrowser({
             disableWebSecurity ? '--disable-web-security' : '',
             disableDevShmUsage ? '--disable-dev-shm-usage' : '',
             '--lang=en',
+            ...(!headless && process.platform === 'darwin'
+              ? ['-AppleLanguages', '(en)']
+              : []),
           ],
         }
       : // TODO: Investigate appropriate settings on Firefox & Webkit


### PR DESCRIPTION
- fix #399

Chromiumの言語設定が日本語や中国語など特定の言語の場合に最小フォントサイズ10pxあるいは12pxの制限が生じる問題に対して、Chromiumのコマンドラインオプションで言語設定を強制的に英語になるようにして対処してましたが、macOSではそれが機能してませんでした。

macOSの場合には、`-AppleLanguages '(en)'` を指定することで言語設定を英語に切り替えて起動することができることが分かったので、そのようにしてみました。--headless と同時に指定するとエラーになるので `!headless && process.platform === 'darwin'` の条件のときにこの指定をするようにしました（headlessの場合には常に英語になるのでこれで問題はない）。
