### PR TITLE
fix: Update Vivliostyle.js to 2.25.6: Viewer UI Bug Fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@npmcli/arborist": "^6.1.3",
     "@vivliostyle/jsdom": "22.1.0-vivliostyle-cli.1",
     "@vivliostyle/vfm": "2.1.0",
-    "@vivliostyle/viewer": "2.25.5",
+    "@vivliostyle/viewer": "2.25.6",
     "ajv": "^8.11.2",
     "ajv-formats": "^2.1.1",
     "archiver": "^5.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1119,10 +1119,10 @@
     unist-util-visit "^2.0.3"
     unist-util-visit-parents "^3.1.1"
 
-"@vivliostyle/viewer@2.25.5":
-  version "2.25.5"
-  resolved "https://registry.yarnpkg.com/@vivliostyle/viewer/-/viewer-2.25.5.tgz#35ac697fb089365d2a55ac15df4503f7499c5b2b"
-  integrity sha512-X3ttIVSwsClFctLuO807TXIzslu5dvrclOypmcbimT5cdXpZzaHn2ZalGTrSXj6o3oW2UN8+fwmO6Ck9/Wvj3w==
+"@vivliostyle/viewer@2.25.6":
+  version "2.25.6"
+  resolved "https://registry.yarnpkg.com/@vivliostyle/viewer/-/viewer-2.25.6.tgz#1e494256b70f72cb05a66dcd72b6d42b08a74085"
+  integrity sha512-wpzE4/iDmeVaYymXC4illLstCI9GPMkvq7dNRA4CYpPxoHKN7BWzSdI2jrPu7r1LzarTcS0Mz0HEfngS3RSw3w==
   dependencies:
     "@vivliostyle/core" "^2.25.5"
     i18next-ko "^3.0.1"


### PR DESCRIPTION
https://github.com/vivliostyle/vivliostyle.js/releases/tag/v2.25.6

### Bug Fixes

- viewer: Current page should be kept after Find results in "Not Found"
- viewer: Exclude generated page margin box content from text search
- viewer: Navigation with page slider should not affect browser history stack
- viewer: selection highlighting problems on iOS
- viewer: tweak viewer UI for mobile devices
- viewer: tweak viewer UI style for mobile devices