### PR TITLE
Added Type attribute to Link of CSS

### DIFF
--- a/src/processor/html.ts
+++ b/src/processor/html.ts
@@ -167,7 +167,9 @@ export function generateTocHtml({
           rel: 'publication',
           type: 'application/ld+json',
         }),
-        ...stylesheets.map((s) => h('link', { href: s, rel: 'stylesheet' })),
+        ...stylesheets.map((s) =>
+          h('link', { type: 'text/css', href: s, rel: 'stylesheet' }),
+        ),
       ].filter((n) => !!n),
     ),
     h(
@@ -228,7 +230,9 @@ export function generateCoverHtml({
         h('meta', { charset: 'utf-8' }),
         h('title', title ?? ''),
         h('style', getCoverHtmlStyle(styleOptions)),
-        ...stylesheets.map((s) => h('link', { href: s, rel: 'stylesheet' })),
+        ...stylesheets.map((s) =>
+          h('link', { type: 'text/css', href: s, rel: 'stylesheet' }),
+        ),
       ].filter((n) => !!n),
     ),
     h(
@@ -267,7 +271,7 @@ export function processManuscriptHtml(
     $('title').text(title);
   }
   for (const s of style ?? []) {
-    $('head').append(`<link rel="stylesheet" />`);
+    $('head').append(`<link rel="stylesheet" type="text/css" />`);
     $('head > *:last-child').attr('href', s);
   }
   if (language) {


### PR DESCRIPTION
Added this attribute because CSS was not applied correctly without it on e-reader devices (Checked on Kindle paperwhite 11th).

マークダウンからKindle Paperwhite 11thで日本語縦書きに対応したEPUB出力を試していて気付いたのですが。

vivliostyle.config.jsに”readingProgression: 'rtl',”のオプションを追加するとCSSが正常に読み込まれず、右開き縦書きのはずが左開き横書きEPUBとなり、縦書きが適用されなくなりました。不思議なことに他は何も変更せず、このオプションを削除すると左開き縦書きEPUBとなります。
ネットで取得した、正常に右開き縦書き表示できるEPUBとVivliostyle-cliで出力した右開き縦書き（端末で見ると横書き）のEPUBと比較して判明したのが”type="text.css"の有無でした。

CLIだけ問題かと思ってソースを辿っていくとマークダウンからの出力の場合はVFMも影響していましたので[こちら](https://github.com/vivliostyle/vfm/pull/173)も修正しました。

Kindle Paperwhite 11thにも対応してほしいので、レビューよろしくお願いします。

サンプルに修正前（無印）と後（FIX)で出力したEPUBも添付しておきます。どちらもViewerでは縦書きですが、端末でみると無印は横書きになってしまいます。
[ProgressionRTL_FIX.epub.zip](https://github.com/vivliostyle/vivliostyle-cli/files/12872882/ProgressionRTL_FIX.epub.zip)
[ProgressionRTL.epub.zip](https://github.com/vivliostyle/vivliostyle-cli/files/12872885/ProgressionRTL.epub.zip)
