### PR TITLE
feat: Update VFM to 2.2.0: New features to control sectionization

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@napi-rs/canvas": "0.1.41",
     "@npmcli/arborist": "^6.1.3",
     "@vivliostyle/jsdom": "22.1.0-vivliostyle-cli.1",
-    "@vivliostyle/vfm": "2.1.0",
+    "@vivliostyle/vfm": "2.2.0",
     "@vivliostyle/viewer": "2.25.6",
     "ajv": "^8.11.2",
     "ajv-formats": "^2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1080,10 +1080,10 @@
     ws "^8.13.0"
     xml-name-validator "^4.0.0"
 
-"@vivliostyle/vfm@2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@vivliostyle/vfm/-/vfm-2.1.0.tgz#8d4e068123cffe1c2081ce3a1389c4fbe003d42d"
-  integrity sha512-qs26plUnRTd/XGQd7iLVkpSIY3pYPxwvYty8QJsSt+i9uS5W+LEY3QSRoWvbJTHco0IS8mmPmmf4XouABSQaQg==
+"@vivliostyle/vfm@2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@vivliostyle/vfm/-/vfm-2.2.0.tgz#f62929bf92b5a3630ba8a26bb607f31d24aeb7e2"
+  integrity sha512-YlkfwmVpo0azJDkLKizCoK0UVGrjRM1UybPMeQnj/3qJYvWezMDNPzBDgOe0W94SCBux8ufO6KuGYyHvm/Z3wg==
   dependencies:
     debug "^4.3.1"
     doctype "^2.0.4"


### PR DESCRIPTION
https://github.com/vivliostyle/vfm/releases/tag/v2.2.0

### Features

- Support non-sectionize headings, enclosed by equal number of hashes
- Support section-end mark (line with only hashes)

### Bug Fixes

- HTML block with markdown heading causes wrong HTML sectioning
- HTML title generated from heading should not have ruby text and HTML tags
- Added Type attribute to Link of CSS