### PR TITLE
fix: Update Vivliostyle.js to 2.25.9: Bug Fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@npmcli/arborist": "^6.1.3",
     "@vivliostyle/jsdom": "22.1.0-vivliostyle-cli.1",
     "@vivliostyle/vfm": "2.2.1",
-    "@vivliostyle/viewer": "2.25.8",
+    "@vivliostyle/viewer": "2.25.9",
     "ajv": "^8.11.2",
     "ajv-formats": "^2.1.1",
     "archiver": "^5.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1044,10 +1044,10 @@
     loupe "^2.3.6"
     pretty-format "^29.5.0"
 
-"@vivliostyle/core@^2.25.8":
-  version "2.25.8"
-  resolved "https://registry.yarnpkg.com/@vivliostyle/core/-/core-2.25.8.tgz#3e55008bd4f2ae14d012d579bf4c3dc2e5cbd978"
-  integrity sha512-Mxhh9tARfg5B4bMKoGK/MLcXwUhmTLGAnJEQ+Q7Gjf3Ye0A0cqGrnIFZXJwotUrBIce6012ZBAYtABDefrTT4A==
+"@vivliostyle/core@^2.25.9":
+  version "2.25.9"
+  resolved "https://registry.yarnpkg.com/@vivliostyle/core/-/core-2.25.9.tgz#a02a6b0fded3d64a9a965fa9b407454d0d8b9584"
+  integrity sha512-jnriEF2NJfJavHucodLuVI6WW3yfJU8V1VcM8lAl/Hz6adEzsKxTXqX2q3rY9olO/ThbX9+cg9S5WM1e3ObgYA==
   dependencies:
     fast-diff "^1.2.0"
 
@@ -1119,12 +1119,12 @@
     unist-util-visit "^2.0.3"
     unist-util-visit-parents "^3.1.1"
 
-"@vivliostyle/viewer@2.25.8":
-  version "2.25.8"
-  resolved "https://registry.yarnpkg.com/@vivliostyle/viewer/-/viewer-2.25.8.tgz#90d69f14df00740400da926f49ac5f8852a120e7"
-  integrity sha512-lQVB1RfvU+LVZsxHqxeJ8uo5w6lQtUxQQGBcQ+GRRhN72OfDdBNOEtSZuv7v9qGOR2fG2RNq2JfgbdVjoDQ8Tg==
+"@vivliostyle/viewer@2.25.9":
+  version "2.25.9"
+  resolved "https://registry.yarnpkg.com/@vivliostyle/viewer/-/viewer-2.25.9.tgz#11985750f1eacbd3264594f1c3ae99d68184e1d8"
+  integrity sha512-w9fi4fVQXhtVHumjCAJoEsBVlSsFa/rtFWMLj6SGM2G3KVVwOh5j+Aimfylko++72zb4PEFKjxUXTtWwiQme2A==
   dependencies:
-    "@vivliostyle/core" "^2.25.8"
+    "@vivliostyle/core" "^2.25.9"
     i18next-ko "^3.0.1"
     knockout "^3.5.0"
 


### PR DESCRIPTION
https://github.com/vivliostyle/vivliostyle.js/releases/tag/v2.25.9

### Bug Fixes

- page breaking inside table with table-header may cause unexpected page type reset
- page-area content may disappear on print