### PR TITLE
feat: Update Vivliostyle.js to 2.26.0: Update CSS text-spacing support

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@npmcli/arborist": "^6.1.3",
     "@vivliostyle/jsdom": "22.1.0-vivliostyle-cli.1",
     "@vivliostyle/vfm": "2.2.1",
-    "@vivliostyle/viewer": "2.25.9",
+    "@vivliostyle/viewer": "2.26.0",
     "ajv": "^8.11.2",
     "ajv-formats": "^2.1.1",
     "archiver": "^5.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1051,10 +1051,10 @@
     loupe "^2.3.6"
     pretty-format "^29.5.0"
 
-"@vivliostyle/core@^2.25.9":
-  version "2.25.9"
-  resolved "https://registry.yarnpkg.com/@vivliostyle/core/-/core-2.25.9.tgz#a02a6b0fded3d64a9a965fa9b407454d0d8b9584"
-  integrity sha512-jnriEF2NJfJavHucodLuVI6WW3yfJU8V1VcM8lAl/Hz6adEzsKxTXqX2q3rY9olO/ThbX9+cg9S5WM1e3ObgYA==
+"@vivliostyle/core@^2.26.0":
+  version "2.26.0"
+  resolved "https://registry.yarnpkg.com/@vivliostyle/core/-/core-2.26.0.tgz#910cc3c63191a197232756449bf19c675014c80e"
+  integrity sha512-AkA8F8sK261xW1R9eJBAyrUk+SLX92udTqu2CuUgAC+3iWo/VeSPGo4eAOdOmDdA7+Kp1jHSRMEfVEfYQA13aA==
   dependencies:
     fast-diff "^1.2.0"
 
@@ -1126,12 +1126,12 @@
     unist-util-visit "^2.0.3"
     unist-util-visit-parents "^3.1.1"
 
-"@vivliostyle/viewer@2.25.9":
-  version "2.25.9"
-  resolved "https://registry.yarnpkg.com/@vivliostyle/viewer/-/viewer-2.25.9.tgz#11985750f1eacbd3264594f1c3ae99d68184e1d8"
-  integrity sha512-w9fi4fVQXhtVHumjCAJoEsBVlSsFa/rtFWMLj6SGM2G3KVVwOh5j+Aimfylko++72zb4PEFKjxUXTtWwiQme2A==
+"@vivliostyle/viewer@2.26.0":
+  version "2.26.0"
+  resolved "https://registry.yarnpkg.com/@vivliostyle/viewer/-/viewer-2.26.0.tgz#a269f62fa2a31bfd4fb4071389dc01b8407666af"
+  integrity sha512-M2n/Ld+X728qB0rs2KSVVWGXxhs1ybtAK8K895gy5Z/9iRlcSJF24eRkR4ueJ/Ls12Nl8xGXslCyE6XWnCl40g==
   dependencies:
-    "@vivliostyle/core" "^2.25.9"
+    "@vivliostyle/core" "^2.26.0"
     i18next-ko "^3.0.1"
     knockout "^3.5.0"
 


### PR DESCRIPTION
https://github.com/vivliostyle/vivliostyle.js/releases/tag/v2.26.0

### Features

- Update CSS text-spacing-trim property to support the latest spec change

### Bug Fixes

- set hanging-punctuation:none for pre-formatted text default style
- text-spacing-trim not working properly in some cases