### PR TITLE
fix: Improve EPUB nav elements

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -19,6 +19,9 @@ export const EPUB_CONTAINER_XML = `${XML_DECLARATION}
     <rootfile full-path="EPUB/content.opf" media-type="application/oebps-package+xml" />
   </rootfiles>
 </container>`;
+export const EPUB_LANDMARKS_TITLE = 'Landmarks';
+export const EPUB_LANDMARKS_TOC_ENTRY = TOC_TITLE;
+export const EPUB_LANDMARKS_COVER_ENTRY = 'Cover Page';
 
 export const cliRoot = upath.join(fileURLToPath(import.meta.url), '../..');
 export const cliVersion = (() => {

--- a/src/output/epub.ts
+++ b/src/output/epub.ts
@@ -9,7 +9,15 @@ import fs from 'node:fs';
 import { pathToFileURL } from 'node:url';
 import { v4 as uuid } from 'uuid';
 import serializeToXml from 'w3c-xmlserializer';
-import { EPUB_CONTAINER_XML, EPUB_NS, XML_DECLARATION } from '../const.js';
+import {
+  EPUB_CONTAINER_XML,
+  EPUB_LANDMARKS_COVER_ENTRY,
+  EPUB_LANDMARKS_TITLE,
+  EPUB_LANDMARKS_TOC_ENTRY,
+  EPUB_NS,
+  TOC_TITLE,
+  XML_DECLARATION,
+} from '../const.js';
 import {
   PageListResourceTreeRoot,
   TocResourceTreeItem,
@@ -249,14 +257,14 @@ export async function exportEpub({
     {
       type: 'toc',
       href: `${manifestItem[tocHtml].href}#${TOC_ID}`,
-      text: 'Table of Contents',
+      text: EPUB_LANDMARKS_TOC_ENTRY,
     },
   ];
   if (htmlCoverResource) {
     landmarks.push({
       type: 'cover',
       href: changeExtname(htmlCoverResource.url, '.xhtml'),
-      text: 'Cover Page',
+      text: EPUB_LANDMARKS_COVER_ENTRY,
     });
   }
 
@@ -471,6 +479,9 @@ async function processTocDocument({
       nav.setAttribute('role', 'doc-toc');
       nav.setAttribute('epub:type', 'toc');
       nav.setAttribute('hidden', '');
+      const h2 = document.createElement('h2');
+      h2.textContent = TOC_TITLE;
+      nav.appendChild(h2);
       const ol = document.createElement('ol');
       tocResourceTree = {
         element: nav,
@@ -500,10 +511,14 @@ async function processTocDocument({
     }
 
     if (landmarks.length > 0) {
+      debug(`Generating landmark nav element: ${target}`);
       const nav = document.createElement('nav');
       nav.setAttribute('epub:type', 'landmarks');
       nav.setAttribute('id', LANDMARKS_ID);
       nav.setAttribute('hidden', '');
+      const h2 = document.createElement('h2');
+      h2.textContent = EPUB_LANDMARKS_TITLE;
+      nav.appendChild(h2);
       const ol = document.createElement('ol');
       for (const { type, href, text } of landmarks) {
         const li = document.createElement('li');
@@ -516,6 +531,7 @@ async function processTocDocument({
       }
       nav.appendChild(ol);
       document.body.appendChild(nav);
+      debug('Generated landmark nav element', nav.outerHTML);
     }
   }
 

--- a/tests/__snapshots__/epub.test.ts.snap
+++ b/tests/__snapshots__/epub.test.ts.snap
@@ -43,6 +43,7 @@ exports[`generate EPUB from series of HTML files > src/index.xhtml 1`] = `
     <a href=\\"b/c/d\\">3</a>
 
     <nav id=\\"toc\\" role=\\"doc-toc\\" epub:type=\\"toc\\" hidden=\\"\\">
+      <h2>Table of Contents</h2>
       <ol>
         <li><a href=\\"index.xhtml\\">My book</a></li>
         <li><a href=\\"a/index.xhtml\\">yuno</a></li>
@@ -50,6 +51,7 @@ exports[`generate EPUB from series of HTML files > src/index.xhtml 1`] = `
       </ol>
     </nav>
     <nav epub:type=\\"landmarks\\" id=\\"landmarks\\" hidden=\\"\\">
+      <h2>Landmarks</h2>
       <ol>
         <li><a epub:type=\\"toc\\" href=\\"index.xhtml#toc\\">Table of Contents</a></li>
       </ol>
@@ -212,6 +214,7 @@ exports[`generate EPUB from single HTML with pub manifest > index.xhtml 1`] = `
     <script src=\\"https://example.com/remote-script.js\\"></script>
 
     <nav epub:type=\\"landmarks\\" id=\\"landmarks\\" hidden=\\"\\">
+      <h2>Landmarks</h2>
       <ol>
         <li><a epub:type=\\"toc\\" href=\\"index.xhtml#toc\\">Table of Contents</a></li>
       </ol>

--- a/tests/__snapshots__/epub.test.ts.snap
+++ b/tests/__snapshots__/epub.test.ts.snap
@@ -42,16 +42,16 @@ exports[`generate EPUB from series of HTML files > src/index.xhtml 1`] = `
     <a href=\\"a\\">2</a>
     <a href=\\"b/c/d\\">3</a>
 
-    <nav epub:type=\\"landmarks\\" id=\\"landmarks\\" hidden=\\"\\">
-      <ol>
-        <li><a epub:type=\\"toc\\" href=\\"index.xhtml#toc\\">Table of Contents</a></li>
-      </ol>
-    </nav>
     <nav id=\\"toc\\" role=\\"doc-toc\\" epub:type=\\"toc\\" hidden=\\"\\">
       <ol>
         <li><a href=\\"index.xhtml\\">My book</a></li>
         <li><a href=\\"a/index.xhtml\\">yuno</a></li>
         <li><a href=\\"b/c/d.xhtml\\">yunocchi</a></li>
+      </ol>
+    </nav>
+    <nav epub:type=\\"landmarks\\" id=\\"landmarks\\" hidden=\\"\\">
+      <ol>
+        <li><a epub:type=\\"toc\\" href=\\"index.xhtml#toc\\">Table of Contents</a></li>
       </ol>
     </nav>
   </body>


### PR DESCRIPTION
#469

* Disable insertion of the generated nav elements if `nav[epub:type]` exists in the original document.
* Changed so that `<nav epub:type="toc">` is inserted before `<nav epub:type="landmarks">`.
* Added headings within each `<nav epub:type="...">` element. ex: `<h2>Table of Contents</h2>`, `<h2>Landmarks</h2>`
