### PR TITLE
fix: Drop legacy feature for EPUB 2

### DIFF
--- a/src/output/epub.ts
+++ b/src/output/epub.ts
@@ -20,7 +20,6 @@ import {
 } from '../const.js';
 import {
   PageListResourceTreeRoot,
-  TocResourceTreeItem,
   TocResourceTreeRoot,
   getJsdomFromUrlOrFile,
   parsePageListDocument,
@@ -343,25 +342,6 @@ export async function exportEpub({
   if (relManifestPath) {
     await remove(upath.join(tmpDir, 'EPUB', relManifestPath));
     delete manifestItem[relManifestPath];
-  }
-
-  // EPUB/toc.ncx
-  // note: NCX is not required for EPUB 3.0
-  if (tocResourceTree) {
-    fs.writeFileSync(
-      upath.join(tmpDir, 'EPUB/toc.ncx'),
-      buildNcx({
-        toc: tocResourceTree,
-        docTitle,
-        uid,
-        tocHtml,
-      }),
-      'utf8',
-    );
-    manifestItem['toc.ncx'] = {
-      href: 'toc.ncx',
-      mediaType: 'application/x-dtbncx+xml',
-    };
   }
 
   // META-INF/container.xml
@@ -710,10 +690,6 @@ function buildEpubPackageDocument({
         })),
       },
       spine: {
-        ...(() => {
-          const toc = manifestItems.find(({ href }) => href === 'toc.ncx');
-          return toc ? { _toc: itemIdMap.get(toc.href) } : {};
-        })(),
         ...(manifest.readingProgression
           ? { '_page-progression-direction': manifest.readingProgression }
           : {}),
@@ -729,80 +705,6 @@ function buildEpubPackageDocument({
           _href: href,
           _title: text,
         })),
-      },
-    },
-  });
-}
-
-function buildNcx({
-  toc,
-  docTitle,
-  uid,
-  tocHtml,
-}: {
-  toc: TocResourceTreeRoot;
-  docTitle: string;
-  uid: string;
-  tocHtml: string;
-}): string {
-  const slugger = new GithubSlugger();
-  slugger.reset();
-  // Dummy incremental to increase sequential counts
-  slugger.slug('navPoint');
-
-  const transformNavItem = (
-    item: TocResourceTreeItem,
-  ): Record<string, unknown> => {
-    return {
-      _id: slugger.slug('navPoint'),
-      navLabel: {
-        text: (item.label.textContent ?? '').trim(),
-      },
-      ...(item.label.tagName === 'A' && item.label.getAttribute('href')
-        ? {
-            content: {
-              _src: getRelativeHref(
-                item.label.getAttribute('href')!,
-                tocHtml,
-                '',
-              ),
-            },
-          }
-        : {}),
-      ...(item.children && item.children.length > 0
-        ? {
-            navPoint: item.children.map(transformNavItem),
-          }
-        : {}),
-    };
-  };
-
-  const builder = new XMLBuilder({
-    format: true,
-    ignoreAttributes: false,
-    attributeNamePrefix: '_',
-  });
-  return builder.build({
-    '?xml': {
-      _version: '1.0',
-      _encoding: 'UTF-8',
-    },
-    ncx: {
-      _xmlns: 'http://www.daisy.org/z3986/2005/ncx/',
-      _version: '2005-1',
-      head: {
-        meta: [
-          { _name: 'dtb:uid', _content: uid },
-          { _name: 'dtb:depth', _content: '1' },
-          { _name: 'dtb:totalPageCount', _content: '0' },
-          { _name: 'dtb:maxPageNumber', _content: '0' },
-        ],
-      },
-      docTitle: {
-        text: docTitle,
-      },
-      navMap: {
-        navPoint: toc.children.map(transformNavItem),
       },
     },
   });

--- a/src/output/epub.ts
+++ b/src/output/epub.ts
@@ -363,7 +363,6 @@ export async function exportEpub({
       manifest,
       spineItems,
       manifestItems: Object.values(manifestItem),
-      landmarks,
     }),
     'utf8',
   );
@@ -567,7 +566,6 @@ function buildEpubPackageDocument({
   docLanguages,
   spineItems,
   manifestItems,
-  landmarks,
 }: Pick<Parameters<typeof exportEpub>[0], 'epubVersion'> & {
   manifest: PublicationManifest;
   uid: string;
@@ -575,7 +573,6 @@ function buildEpubPackageDocument({
   docLanguages: string[];
   spineItems: SpineEntry[];
   manifestItems: ManifestEntry[];
-  landmarks: LandmarkEntry[];
 }): string {
   const slugger = new GithubSlugger();
   slugger.reset();
@@ -698,13 +695,6 @@ function buildEpubPackageDocument({
             _idref: itemIdMap.get(href),
           })),
         ],
-      },
-      guide: {
-        reference: landmarks.map(({ type, href, text }) => ({
-          _type: type,
-          _href: href,
-          _title: text,
-        })),
       },
     },
   });

--- a/tests/__snapshots__/epub.test.ts.snap
+++ b/tests/__snapshots__/epub.test.ts.snap
@@ -13,9 +13,8 @@ exports[`generate EPUB from series of HTML files > content.opf 1`] = `
     <item id=\\"srcindexxhtml\\" href=\\"src/index.xhtml\\" media-type=\\"application/xhtml+xml\\" properties=\\"nav\\"></item>
     <item id=\\"srcaindexxhtml\\" href=\\"src/a/index.xhtml\\" media-type=\\"application/xhtml+xml\\"></item>
     <item id=\\"srcbcdxhtml\\" href=\\"src/b/c/d.xhtml\\" media-type=\\"application/xhtml+xml\\"></item>
-    <item id=\\"tocncx\\" href=\\"toc.ncx\\" media-type=\\"application/x-dtbncx+xml\\"></item>
   </manifest>
-  <spine toc=\\"tocncx\\">
+  <spine>
     <itemref idref=\\"srcindexxhtml\\"></itemref>
     <itemref idref=\\"srcaindexxhtml\\"></itemref>
     <itemref idref=\\"srcbcdxhtml\\"></itemref>
@@ -61,56 +60,19 @@ exports[`generate EPUB from series of HTML files > src/index.xhtml 1`] = `
 "
 `;
 
-exports[`generate EPUB from series of HTML files > toc.ncx 1`] = `
-"<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
-<ncx xmlns=\\"http://www.daisy.org/z3986/2005/ncx/\\" version=\\"2005-1\\">
-  <head>
-    
-    <meta name=\\"dtb:depth\\" content=\\"1\\"></meta>
-    <meta name=\\"dtb:totalPageCount\\" content=\\"0\\"></meta>
-    <meta name=\\"dtb:maxPageNumber\\" content=\\"0\\"></meta>
-  </head>
-  <docTitle>
-    <text>My book</text>
-  </docTitle>
-  <navMap>
-    <navPoint id=\\"navpoint-1\\">
-      <navLabel>
-        <text>My book</text>
-      </navLabel>
-      <content src=\\"src/index.xhtml\\"></content>
-    </navPoint>
-    <navPoint id=\\"navpoint-2\\">
-      <navLabel>
-        <text>yuno</text>
-      </navLabel>
-      <content src=\\"src/a/index.xhtml\\"></content>
-    </navPoint>
-    <navPoint id=\\"navpoint-3\\">
-      <navLabel>
-        <text>yunocchi</text>
-      </navLabel>
-      <content src=\\"src/b/c/d.xhtml\\"></content>
-    </navPoint>
-  </navMap>
-</ncx>
-"
-`;
-
 exports[`generate EPUB from series of HTML files > tree 1`] = `
 "/
 ├─ tmp/
 │  └─ 1/
 │     ├─ EPUB/
 │     │  ├─ content.opf
-│     │  ├─ src/
-│     │  │  ├─ a/
-│     │  │  │  └─ index.xhtml
-│     │  │  ├─ b/
-│     │  │  │  └─ c/
-│     │  │  │     └─ d.xhtml
-│     │  │  └─ index.xhtml
-│     │  └─ toc.ncx
+│     │  └─ src/
+│     │     ├─ a/
+│     │     │  └─ index.xhtml
+│     │     ├─ b/
+│     │     │  └─ c/
+│     │     │     └─ d.xhtml
+│     │     └─ index.xhtml
 │     └─ META-INF/
 │        └─ container.xml
 └─ work/
@@ -164,9 +126,8 @@ exports[`generate EPUB from single HTML with pub manifest > content.opf 1`] = `
   <manifest>
     <item id=\\"coverpng\\" href=\\"cover.png\\" media-type=\\"image/png\\" properties=\\"cover-image\\"></item>
     <item id=\\"indexxhtml\\" href=\\"index.xhtml\\" media-type=\\"application/xhtml+xml\\" properties=\\"nav mathml remote-resources scripted svg\\"></item>
-    <item id=\\"tocncx\\" href=\\"toc.ncx\\" media-type=\\"application/x-dtbncx+xml\\"></item>
   </manifest>
-  <spine toc=\\"tocncx\\" page-progression-direction=\\"rtl\\">
+  <spine page-progression-direction=\\"rtl\\">
     <itemref idref=\\"indexxhtml\\"></itemref>
   </spine>
   <guide>
@@ -224,48 +185,6 @@ exports[`generate EPUB from single HTML with pub manifest > index.xhtml 1`] = `
 "
 `;
 
-exports[`generate EPUB from single HTML with pub manifest > toc.ncx 1`] = `
-"<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
-<ncx xmlns=\\"http://www.daisy.org/z3986/2005/ncx/\\" version=\\"2005-1\\">
-  <head>
-    
-    <meta name=\\"dtb:depth\\" content=\\"1\\"></meta>
-    <meta name=\\"dtb:totalPageCount\\" content=\\"0\\"></meta>
-    <meta name=\\"dtb:maxPageNumber\\" content=\\"0\\"></meta>
-  </head>
-  <docTitle>
-    <text>Document</text>
-  </docTitle>
-  <navMap>
-    <navPoint id=\\"navpoint-1\\">
-      <navLabel>
-        <text>Intro</text>
-      </navLabel>
-      <content src=\\"index.xhtml#intro\\"></content>
-    </navPoint>
-    <navPoint id=\\"navpoint-2\\">
-      <navLabel>
-        <text>Main</text>
-      </navLabel>
-      <content src=\\"index.xhtml#main\\"></content>
-      <navPoint id=\\"navpoint-3\\">
-        <navLabel>
-          <text>Main 1</text>
-        </navLabel>
-        <content src=\\"index.xhtml#main-1\\"></content>
-      </navPoint>
-      <navPoint id=\\"navpoint-4\\">
-        <navLabel>
-          <text>Main 2</text>
-        </navLabel>
-        <content src=\\"index.xhtml#main-2\\"></content>
-      </navPoint>
-    </navPoint>
-  </navMap>
-</ncx>
-"
-`;
-
 exports[`generate EPUB from single HTML with pub manifest > tree 1`] = `
 "/
 ├─ tmp/
@@ -273,8 +192,7 @@ exports[`generate EPUB from single HTML with pub manifest > tree 1`] = `
 │     ├─ EPUB/
 │     │  ├─ content.opf
 │     │  ├─ cover.png
-│     │  ├─ index.xhtml
-│     │  └─ toc.ncx
+│     │  └─ index.xhtml
 │     └─ META-INF/
 │        └─ container.xml
 └─ work/
@@ -294,8 +212,7 @@ exports[`generate EPUB from single Markdown input > tree 1`] = `
 │  └─ 2/
 │     ├─ EPUB/
 │     │  ├─ content.opf
-│     │  ├─ index.xhtml
-│     │  └─ toc.ncx
+│     │  └─ index.xhtml
 │     └─ META-INF/
 │        └─ container.xml
 └─ work/
@@ -319,8 +236,7 @@ exports[`generate EPUB from vivliostyle.config.js > tree 1`] = `
 │     │  ├─ content.opf
 │     │  ├─ index.xhtml
 │     │  ├─ manuscript.xhtml
-│     │  ├─ my-theme.css
-│     │  └─ toc.ncx
+│     │  └─ my-theme.css
 │     └─ META-INF/
 │        └─ container.xml
 └─ work/

--- a/tests/__snapshots__/epub.test.ts.snap
+++ b/tests/__snapshots__/epub.test.ts.snap
@@ -19,9 +19,6 @@ exports[`generate EPUB from series of HTML files > content.opf 1`] = `
     <itemref idref=\\"srcaindexxhtml\\"></itemref>
     <itemref idref=\\"srcbcdxhtml\\"></itemref>
   </spine>
-  <guide>
-    <reference type=\\"toc\\" href=\\"src/index.xhtml#toc\\" title=\\"Table of Contents\\"></reference>
-  </guide>
 </package>
 "
 `;
@@ -130,9 +127,6 @@ exports[`generate EPUB from single HTML with pub manifest > content.opf 1`] = `
   <spine page-progression-direction=\\"rtl\\">
     <itemref idref=\\"indexxhtml\\"></itemref>
   </spine>
-  <guide>
-    <reference type=\\"toc\\" href=\\"index.xhtml#toc\\" title=\\"Table of Contents\\"></reference>
-  </guide>
 </package>
 "
 `;

--- a/tests/epub.test.ts
+++ b/tests/epub.test.ts
@@ -157,12 +157,6 @@ it('generate EPUB from single HTML with pub manifest', async () => {
       ?.replace(/<dc:identifier id="bookid">.+<\/dc:identifier>/g, '')
       .replace(/<meta property="dcterms:modified">.+<\/meta>/g, ''),
   ).toMatchSnapshot('content.opf');
-  expect(
-    file['/tmp/1/EPUB/toc.ncx']?.replace(
-      /<meta name="dtb:uid" content=".+"><\/meta>/g,
-      '',
-    ),
-  ).toMatchSnapshot('toc.ncx');
   const entry = file['/tmp/1/EPUB/index.xhtml'];
   expect(format(entry as string, { parser: 'html' })).toMatchSnapshot(
     'index.xhtml',
@@ -222,12 +216,6 @@ it('generate EPUB from series of HTML files', async () => {
       ?.replace(/<dc:identifier id="bookid">.+<\/dc:identifier>/g, '')
       .replace(/<meta property="dcterms:modified">.+<\/meta>/g, ''),
   ).toMatchSnapshot('content.opf');
-  expect(
-    file['/tmp/1/EPUB/toc.ncx']?.replace(
-      /<meta name="dtb:uid" content=".+"><\/meta>/g,
-      '',
-    ),
-  ).toMatchSnapshot('toc.ncx');
   const first = file['/tmp/1/EPUB/src/index.xhtml'];
   expect(format(first as string, { parser: 'html' })).toMatchSnapshot(
     'src/index.xhtml',


### PR DESCRIPTION
https://github.com/vivliostyle/vivliostyle-cli/pull/470#issuecomment-1956354238

* Drop support exporting a legacy NCX document
* Drop support setting a legacy `guide` element in EPUB OPF