### PR TITLE
fix: Chromium processes and tmp files remain after preview/build exit with Ctrl+C on Windows

### DIFF
--- a/src/init.ts
+++ b/src/init.ts
@@ -18,6 +18,7 @@ export async function init(cliFlags: InitCliFlags) {
   const vivliostyleConfigPath = upath.join(cwd, 'vivliostyle.config.js');
 
   if (fs.existsSync(vivliostyleConfigPath)) {
+    runExitHandlers();
     return log(
       `${chalk.yellow('vivliostyle.config.js already exists. aborting.')}`,
     );


### PR DESCRIPTION
fix #479

Windows上でpreviewをCtrl+Cで終了させたとき、`runExitHandler()` が呼ばれない（そのためChromiumのプロセスが残る、また、一時ファイルが削除されない）不具合を修正しました。

previewだけでなくbuildの場合でも後処理がされない不具合は同じでした（一時ファイルが削除されない）。

問題はWindowsではsignal eventsがサポートされず、`process.on('SIGINT', …)` が機能しないことだったので、代わりにreadline interfaceを使うようにしました。
参考: https://stackoverflow.com/questions/10021373/what-is-the-windows-equivalent-of-process-onsigint-in-node-js

また、`process.on(sig, () => { … }` で、`sig !== 'exit'` の場合だけ `process.exit(1)` を呼ぶようにしました。そうしないとChromiumが残ってしまう問題が解消しなかったためです。問題あるでしょうか？

