### PR TITLE
feat: Update Vivliostyle.js to 2.29.0: Update CSS text-spacing support

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@npmcli/arborist": "^6.1.3",
     "@vivliostyle/jsdom": "22.1.0-vivliostyle-cli.1",
     "@vivliostyle/vfm": "2.2.1",
-    "@vivliostyle/viewer": "2.28.1",
+    "@vivliostyle/viewer": "2.29.0",
     "ajv": "^8.11.2",
     "ajv-formats": "^2.1.1",
     "archiver": "^5.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1051,10 +1051,10 @@
     loupe "^2.3.6"
     pretty-format "^29.5.0"
 
-"@vivliostyle/core@^2.28.1":
-  version "2.28.1"
-  resolved "https://registry.yarnpkg.com/@vivliostyle/core/-/core-2.28.1.tgz#0fe6ed6d8b85210a640b610caec35ef96426397b"
-  integrity sha512-VCqatfb69+WZuRE2L13kC/d6qupPEDNoEK+R8gWJkanDHhC6Rq0Rz4P0WdGqqgwwKnSMlhGfjPliaK8+7FF7Mw==
+"@vivliostyle/core@^2.29.0":
+  version "2.29.0"
+  resolved "https://registry.yarnpkg.com/@vivliostyle/core/-/core-2.29.0.tgz#c57456c441597d523a4272be4bc5505df4dc6cbb"
+  integrity sha512-6Z5KjcQ73+5ffWrBXm9Y+fKLAgM/n0qMpEfJNJT44tsxiK+K/jpgMqgc+yzIVQJlK7wYUH8s5apJ79Ny5aGJXQ==
   dependencies:
     fast-diff "^1.2.0"
 
@@ -1126,12 +1126,12 @@
     unist-util-visit "^2.0.3"
     unist-util-visit-parents "^3.1.1"
 
-"@vivliostyle/viewer@2.28.1":
-  version "2.28.1"
-  resolved "https://registry.yarnpkg.com/@vivliostyle/viewer/-/viewer-2.28.1.tgz#acbcad995c68bd49d90ee5126d266f6d3307ca2a"
-  integrity sha512-ekExv0f0d8oUzjrvn7W0Cj/jLvsnOuorXXcSjQBerCy9w4HaJhWadSu6o47lNf+cMGSQ3x9V8Bb6W4/miQ9EEQ==
+"@vivliostyle/viewer@2.29.0":
+  version "2.29.0"
+  resolved "https://registry.yarnpkg.com/@vivliostyle/viewer/-/viewer-2.29.0.tgz#2f1e4c1bbcf0a27efa4230971694c1d5c52a8828"
+  integrity sha512-GoGSjVmV1p7mjQm1FlpO9UdYimOCUVhTqGp3wpC6KbVEL2I5Gj2T+1LOUouxO8/JXtSr8mXaSx6go5BXBI+tEw==
   dependencies:
-    "@vivliostyle/core" "^2.28.1"
+    "@vivliostyle/core" "^2.29.0"
     i18next-ko "^3.0.1"
     knockout "^3.5.0"
 


### PR DESCRIPTION
https://github.com/vivliostyle/vivliostyle.js/releases/tag/v2.29.0

### Bug Fixes

- Named page wrongly applied to blank pages
- layout precision problem on float boxes
- Wrong handling of shorthand properties with variables in conditional rules
- Unnecessary page break at footnote or page bottom float
- CSS font descriptors wrongly validated as font properties
- text-spacing-trim may not work properly between different font sizes

### Features

- Update CSS text-spacing-trim support: Rename trim-auto to trim-both