### PR TITLE
fix: Update Vivliostyle.js to 2.30.1: Bug Fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@npmcli/arborist": "^6.1.3",
     "@vivliostyle/jsdom": "22.1.0-vivliostyle-cli.1",
     "@vivliostyle/vfm": "2.2.1",
-    "@vivliostyle/viewer": "2.30.0",
+    "@vivliostyle/viewer": "2.30.1",
     "ajv": "^8.11.2",
     "ajv-formats": "^2.1.1",
     "archiver": "^5.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1087,10 +1087,10 @@
     loupe "^2.3.6"
     pretty-format "^29.5.0"
 
-"@vivliostyle/core@^2.30.0":
-  version "2.30.0"
-  resolved "https://registry.yarnpkg.com/@vivliostyle/core/-/core-2.30.0.tgz#d4c61d5c2221a252577848665218d1e7d99d205f"
-  integrity sha512-DDpsH0lmNRSow4Hq3aBlW46cC0K9pPTK00YYzgfin+dEg4uVY0jpt1V1Ne5+yim49U5kyrCLCs+s6LxrPx6Vyg==
+"@vivliostyle/core@^2.30.1":
+  version "2.30.1"
+  resolved "https://registry.yarnpkg.com/@vivliostyle/core/-/core-2.30.1.tgz#4277c1e0bbf77de9e986ee5191e249dfd5143ca1"
+  integrity sha512-DGLCq098yeW6jevQ0NTMFUBw/rfxzdyx0SmnPrdydHymMAmR4FRE6aTTBfQOglbeRlB1TIC3zivSLyRJigcnhg==
   dependencies:
     fast-diff "^1.2.0"
 
@@ -1162,12 +1162,12 @@
     unist-util-visit "^2.0.3"
     unist-util-visit-parents "^3.1.1"
 
-"@vivliostyle/viewer@2.30.0":
-  version "2.30.0"
-  resolved "https://registry.yarnpkg.com/@vivliostyle/viewer/-/viewer-2.30.0.tgz#0406edd0920b989c9aee07f8e361cb1610a62b21"
-  integrity sha512-SC3fHogmGcOAqpAiCvr6YI2UwTz7jDmRcKWym0tt4tSg01pf259/uzj4FWm6Uw/0HQnVjBDT3CRHc5stxSM/fg==
+"@vivliostyle/viewer@2.30.1":
+  version "2.30.1"
+  resolved "https://registry.yarnpkg.com/@vivliostyle/viewer/-/viewer-2.30.1.tgz#bba62be03ff614d82ce6df2a9b43c75f903f9775"
+  integrity sha512-GmUwah5PrZchI9VsTLkFrLdIYbJzGOyh50QvHS+2D5znAVAzH4eXUt0m3x7HuJGFlkZ2AfZUZMkHUNzkEIfhPg==
   dependencies:
-    "@vivliostyle/core" "^2.30.0"
+    "@vivliostyle/core" "^2.30.1"
     i18next-ko "^3.0.1"
     knockout "^3.5.0"
 


### PR DESCRIPTION
https://github.com/vivliostyle/vivliostyle.js/releases/tag/v2.30.1

### Bug Fix

- InvalidNodeTypeError may happen during table pagination (Regression in v2.30.0)