### PR TITLE
feat: Update Playwright to 1.45.2 (Chromium 127.0.6533.17)

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "node-stream-zip": "^1.14.0",
     "ora": "^5.4.1",
     "pdf-lib": "^1.16.0",
-    "playwright-core": "1.44.1",
+    "playwright-core": "1.45.2",
     "portfinder": "^1.0.28",
     "press-ready": "^4.0.3",
     "prettier": "^2.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6289,10 +6289,10 @@ pkg-types@^1.0.3:
     mlly "^1.2.0"
     pathe "^1.1.0"
 
-playwright-core@1.44.1:
-  version "1.44.1"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.44.1.tgz#53ec975503b763af6fc1a7aa995f34bc09ff447c"
-  integrity sha512-wh0JWtYTrhv1+OSsLPgFzGzt67Y7BE/ZS3jEqgGBlp2ppp1ZDj8c+9IARNW4dwf1poq5MgHreEM2KV/GuR4cFA==
+playwright-core@1.45.2:
+  version "1.45.2"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.45.2.tgz#c8b8b7f66eda47fb2bd24e5435c92d1163022df8"
+  integrity sha512-ha175tAWb0dTK0X4orvBIqi3jGEt701SMxMhyujxNrgd8K0Uy5wMSwwcQHtyB4om7INUkfndx02XnQ2p6dvLDw==
 
 please-upgrade-node@^3.2.0:
   version "3.2.0"


### PR DESCRIPTION
Note: The Chromium version found in the [Playwright v1.45.2 release note](https://github.com/microsoft/playwright/releases/tag/v1.45.2) is 127.0.6533.5 but I found that the actual version is 127.0.6533.17.