### PR TITLE
fix: Set timeout to Locator.focus

### DIFF
--- a/src/preview.ts
+++ b/src/preview.ts
@@ -176,7 +176,7 @@ export async function preview(cliFlags: PreviewCliFlags) {
     // Move focus from the address bar to the page
     await page.bringToFront();
     // Focus to the URL input box if available
-    await page.locator('#vivliostyle-input-url').focus();
+    await page.locator('#vivliostyle-input-url').focus({ timeout: 0 });
 
     watcher?.on('all', handleFileChange);
     reload = () => page.reload();


### PR DESCRIPTION
fix: #515 

`Locator.focus`に`timeout`を明示的に指定することで、ビルドにどれほど時間がかかるHTMLもプレビューできます。動作確認用のHTMLが必要であればIssueに添付したスクリプトから生成してください。

1点要確認事項があります。Playwrightでは[`timeout`の既定値は`0 - no timeout`](https://github.com/microsoft/playwright/blob/11014145ce37a8d44b6083fcf2c5f71453f018c7/packages/playwright-core/types/types.d.ts#L13072-L13080)とされており本PRの変更は不要なはずですが、少なくとも私の手元では挙動が変わります。他箇所での`browserContext.setDefaultTimeout`あるいは`page.setDefaultTimeout`の変更が影響しているか、Playwright側の不具合かもしれません。