### PR TITLE
fix: Update Vivliostyle.js to 2.30.5: Bug Fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@npmcli/arborist": "^6.1.3",
     "@vivliostyle/jsdom": "22.1.0-vivliostyle-cli.1",
     "@vivliostyle/vfm": "2.2.1",
-    "@vivliostyle/viewer": "2.30.4",
+    "@vivliostyle/viewer": "2.30.5",
     "ajv": "^8.11.2",
     "ajv-formats": "^2.1.1",
     "archiver": "^5.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1391,10 +1391,10 @@
     loupe "^3.1.1"
     tinyrainbow "^1.2.0"
 
-"@vivliostyle/core@^2.30.4":
-  version "2.30.4"
-  resolved "https://registry.yarnpkg.com/@vivliostyle/core/-/core-2.30.4.tgz#43f59b72f895c2ee691d3a1d03be5038fee14dcd"
-  integrity sha512-f2+k3KtzZnR60EKbhveOQYkmN8CdKhoyUIDcnxmwA/qptrGkq0ycPlcSRd9WeEo5y4tvDa66+x/AeHjw5PD0dQ==
+"@vivliostyle/core@^2.30.5":
+  version "2.30.5"
+  resolved "https://registry.yarnpkg.com/@vivliostyle/core/-/core-2.30.5.tgz#fc9412aa81b07bcb79932f46f82a044bb5c0c212"
+  integrity sha512-54/ZAxP5PK0lqkmUrOY7d9vL9rwvDSOiq8rbEA9YDQxiZJniLuQifqZt2Dtm1885e69yGXlfmztsZ3PWS8I4iw==
   dependencies:
     fast-diff "^1.2.0"
 
@@ -1466,12 +1466,12 @@
     unist-util-visit "^2.0.3"
     unist-util-visit-parents "^3.1.1"
 
-"@vivliostyle/viewer@2.30.4":
-  version "2.30.4"
-  resolved "https://registry.yarnpkg.com/@vivliostyle/viewer/-/viewer-2.30.4.tgz#c19413ebf44817f7561afd9b8827fa400b4fbdae"
-  integrity sha512-1UXtsA4fvpDTpw6+eXhA6SMZx0J0W7UCgnwlGHeCHzqVW1Bf2U366+Y++hRjfwIuXc3EiSGtoWU269np3L24gg==
+"@vivliostyle/viewer@2.30.5":
+  version "2.30.5"
+  resolved "https://registry.yarnpkg.com/@vivliostyle/viewer/-/viewer-2.30.5.tgz#d708212b7ac7852c7f5a4d7fbcd030c16ed15c1a"
+  integrity sha512-vffbyd3K1kQsBhOwqdBd9f5MMLvyIOqhUnFixLYriB1C6edjykEVfQTmd2iN+TSVOcPYpE4mJuc0kUL6Ffb57g==
   dependencies:
-    "@vivliostyle/core" "^2.30.4"
+    "@vivliostyle/core" "^2.30.5"
     i18next-ko "^3.0.1"
     knockout "^3.5.0"
 


### PR DESCRIPTION
https://github.com/vivliostyle/vivliostyle.js/releases/tag/v2.30.5

- Wrong processing order of counter-set and counter-increment
- CSS counter-reset scoping problem
- CSS counter-increment and counter-reset should be ignored for elements with `display: none`
- CSS implicit list-item counter
- CSS direction property ignored on margin boxes
- writing-mode on `@page` not inherited properly to margin boxes
- Float box inside inline element disappeared at page break
- Prevent "A network error occurred." in console when using web fonts
- "Failed to parse stylesheet" warning (Firefox and Safari)
- **viewer:** Deprecated meta tag "apple-mobile-web-app-capable"