### PR TITLE
feat: Update Playwright to 1.49.0 (Chromium 131.0.6778.33)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
       - run: yarn install
-      - run: yarn playwright-core install chromium
+      - run: yarn playwright-core install chromium --no-shell
       - run: yarn build
       - run: yarn test
   build-and-push-image:

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "node-stream-zip": "^1.14.0",
     "ora": "^5.4.1",
     "pdf-lib": "^1.16.0",
-    "playwright-core": "1.48.1",
+    "playwright-core": "1.49.0",
     "portfinder": "^1.0.28",
     "press-ready": "^4.0.3",
     "prettier": "^3.3.3",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "clean": "shx rm -rf dist tmp",
     "dev": "tsc -w --preserveWatchOutput",
     "example": "yarn --cwd example build",
-    "pretest": "playwright-core install chromium",
+    "pretest": "playwright-core install chromium --no-shell",
     "release": "release-it",
     "release:pre": "release-it --preRelease --npm.tag=next",
     "test": "vitest run --coverage",

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -81,9 +81,9 @@ export function checkBrowserAvailability(path: string): boolean {
 }
 
 export function isPlaywrightExecutable(path: string): boolean {
-  return registry
-    .executables()
-    .some((exe) => pathEquals(exe.executablePath() ?? '', path));
+  return [playwright.chromium, playwright.firefox, playwright.webkit].some(
+    (exe) => pathEquals(exe.executablePath() ?? '', path),
+  );
 }
 
 export async function downloadBrowser(

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -44,6 +44,8 @@ export async function launchBrowser({
             '--allow-file-access-from-files',
             disableWebSecurity ? '--disable-web-security' : '',
             disableDevShmUsage ? '--disable-dev-shm-usage' : '',
+            // #357: Set devicePixelRatio=1 otherwise it causes layout issues in HiDPI displays
+            headless ? '--force-device-scale-factor=1' : '',
             // set Chromium language to English to avoid locale-dependent issues (e.g. minimum font size)
             '--lang=en',
             ...(!headless && process.platform === 'darwin'

--- a/yarn.lock
+++ b/yarn.lock
@@ -6390,10 +6390,10 @@ pify@^3.0.0:
   resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
   integrity sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==
 
-playwright-core@1.48.1:
-  version "1.48.1"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.48.1.tgz#5fe28fb9a9326dae88d4608c35e819163cceeb23"
-  integrity sha512-Yw/t4VAFX/bBr1OzwCuOMZkY1Cnb4z/doAFSwf4huqAGWmf9eMNjmK7NiOljCdLmxeRYcGPPmcDgU0zOlzP0YA==
+playwright-core@1.49.0:
+  version "1.49.0"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.49.0.tgz#8e69ffed3f41855b854982f3632f2922c890afcb"
+  integrity sha512-R+3KKTQF3npy5GTiKH/T+kdhoJfJojjHESR1YEWhYuEKRVfVaxH3+4+GvXE5xyCngCxhxnykk0Vlah9v8fs3jA==
 
 portfinder@^1.0.28:
   version "1.0.28"


### PR DESCRIPTION
- feat: Update Playwright to 1.49.0 (Chromium 131.0.6778.33) (eadf6da)

- fix: Use chromium-headless-shell rather than chromium in new headless mode (44737f3)

  In [Playwright v1.49.0](https://github.com/microsoft/playwright/releases/tag/v1.49.0), new Chromium headless mode is introduced, and old headless mode is separated as "chromium-headless-shell".

  Unfortunately, the new headless mode has a problem (see Issue #357), so we need to use "chromium-headless-shell".
