### PR TITLE
fix: Update Vivliostyle.js to 2.30.8: Bug Fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@npmcli/arborist": "^6.1.3",
     "@vivliostyle/jsdom": "22.1.0-vivliostyle-cli.1",
     "@vivliostyle/vfm": "2.2.1",
-    "@vivliostyle/viewer": "2.30.7",
+    "@vivliostyle/viewer": "2.30.8",
     "ajv": "^8.11.2",
     "ajv-formats": "^2.1.1",
     "archiver": "^5.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1271,10 +1271,10 @@
     loupe "^3.1.1"
     tinyrainbow "^1.2.0"
 
-"@vivliostyle/core@^2.30.7":
-  version "2.30.7"
-  resolved "https://registry.yarnpkg.com/@vivliostyle/core/-/core-2.30.7.tgz#7ea8e45067b20031748d69d2591f649ac9023082"
-  integrity sha512-4BOtX4olH48NhljInvtDmwj5QSwcU6zjfH5ZsYSncXByljsBYQXVKrmjPMZrmHpjXNYXvk0+JQzd6qp65VVVTQ==
+"@vivliostyle/core@^2.30.8":
+  version "2.30.8"
+  resolved "https://registry.yarnpkg.com/@vivliostyle/core/-/core-2.30.8.tgz#22c84d25377fb89478e5c43298334d65b6134d5e"
+  integrity sha512-UhHxIwH/lHY0l3Z8Cjl6wX94gKewatDXFanJ6p6j890svBy/tDR9tooBg76p6Cjr/+pXl42ToLPCRWVfdFn8lA==
   dependencies:
     fast-diff "^1.2.0"
 
@@ -1346,12 +1346,12 @@
     unist-util-visit "^2.0.3"
     unist-util-visit-parents "^3.1.1"
 
-"@vivliostyle/viewer@2.30.7":
-  version "2.30.7"
-  resolved "https://registry.yarnpkg.com/@vivliostyle/viewer/-/viewer-2.30.7.tgz#76095131403be0dc89a050a3e07cdec64288fd9d"
-  integrity sha512-RwER9A2qzDP27CRHfYm3tLE1ySRYkQDBMk8zSMoe2srPoxwSqaGSk+Zk9NOEskb+AZPuccaAWAuZ2Hp90+0nEg==
+"@vivliostyle/viewer@2.30.8":
+  version "2.30.8"
+  resolved "https://registry.yarnpkg.com/@vivliostyle/viewer/-/viewer-2.30.8.tgz#b14774541f384c6a78d09ba7caa8cdb197ed6b65"
+  integrity sha512-6cabEaRmC+y2RwGv6viHnw9oDdsOZKNWsu8MoLLnALTNqy+f2z2hs1pJm5H3/VH9dihzNWLATSKnX5WragtQNA==
   dependencies:
-    "@vivliostyle/core" "^2.30.7"
+    "@vivliostyle/core" "^2.30.8"
     i18next-ko "^3.0.1"
     knockout "^3.5.0"
 


### PR DESCRIPTION
https://github.com/vivliostyle/vivliostyle.js/releases/tag/v2.30.8

### Bug Fixes

- fix broken table layout when table row has id attribute
- fix calc() not working for unitless values
- fix named page not applied at first page with running element
- fix wrong cascading with -webkit-box-sizing and box-sizing
- prevent running elements and absolutely positioned elements from being broken
- prevent wrong page/column break at ruby
- Table cell with rowspan may disappear after page break
- Text-decoration-line should not be skipped at space inserted by text-spacing