### PR TITLE
fix: Update Vivliostyle.js to 2.31.1: Bug Fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@npmcli/arborist": "^6.1.3",
     "@vivliostyle/jsdom": "22.1.0-vivliostyle-cli.1",
     "@vivliostyle/vfm": "2.2.1",
-    "@vivliostyle/viewer": "2.31.0",
+    "@vivliostyle/viewer": "2.31.1",
     "ajv": "^8.11.2",
     "ajv-formats": "^2.1.1",
     "archiver": "^5.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1271,10 +1271,10 @@
     loupe "^3.1.1"
     tinyrainbow "^1.2.0"
 
-"@vivliostyle/core@^2.31.0":
-  version "2.31.0"
-  resolved "https://registry.yarnpkg.com/@vivliostyle/core/-/core-2.31.0.tgz#acdaea08417ea840cddd182184a666b979231cec"
-  integrity sha512-Wvam0xaN2BqYyVm5A1KsLaHcJOH/hax0ZN6r68Ic9Dq79fEzBAWBgyhOm4TB69FOTdwfDrBgxp2OIAbNR+aQ3g==
+"@vivliostyle/core@^2.31.1":
+  version "2.31.1"
+  resolved "https://registry.yarnpkg.com/@vivliostyle/core/-/core-2.31.1.tgz#cd105546433029d0c029331539f49dc154f88ecc"
+  integrity sha512-bfMMQuD7d1jyoAeddBd4im5Fx9BSoLsfogc0s/ZjfUXkBMVbt2rJS5Wy7sokiB6S0wKSk2UdNzcHorzxQiUTJg==
   dependencies:
     fast-diff "^1.2.0"
 
@@ -1346,12 +1346,12 @@
     unist-util-visit "^2.0.3"
     unist-util-visit-parents "^3.1.1"
 
-"@vivliostyle/viewer@2.31.0":
-  version "2.31.0"
-  resolved "https://registry.yarnpkg.com/@vivliostyle/viewer/-/viewer-2.31.0.tgz#8d2bed1f7ce3ac7b889aa1da731a6da05671ec79"
-  integrity sha512-BuEqBtkbT5Qeg2F50twPEmJ2rq3UMSwyv9FDK1rUPx4QPPXCuXK8kdSkDAeBm8A+/NygdGdRtZd/8QwwC8yHRg==
+"@vivliostyle/viewer@2.31.1":
+  version "2.31.1"
+  resolved "https://registry.yarnpkg.com/@vivliostyle/viewer/-/viewer-2.31.1.tgz#37209998d274e3189aefc52cef208f2447bd56f0"
+  integrity sha512-m7hp6V1D9WjkJh/7rPhuOBfTwt0Hh5MLH9sbzn5pfrV+XMv2m0KRgnypzWMAleuxrteaERwwm6+QsgkVO4tUvw==
   dependencies:
-    "@vivliostyle/core" "^2.31.0"
+    "@vivliostyle/core" "^2.31.1"
     i18next-ko "^3.0.1"
     knockout "^3.5.0"
 


### PR DESCRIPTION
https://github.com/vivliostyle/vivliostyle.js/releases/tag/v2.31.1

### Bug Fixes

- Do not remove table top border with thead and bottom border with tfoot at page
- Fix `break-inside: avoid` ignored in table cells
- Fix auto spread view behavior when page size changes
- Fix incorrect column balancing in vertical writing mode
- Fix named page not applied after a spread break