### PR TITLE
fix: Add --disable-gpu option when running on WSL

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -4,6 +4,7 @@ import { registry } from 'playwright-core/lib/server';
 import type { BrowserType } from './input/schema.js';
 import {
   beforeExitHandlers,
+  isRunningOnWSL,
   logInfo,
   logSuccess,
   pathEquals,
@@ -46,6 +47,8 @@ export async function launchBrowser({
             disableDevShmUsage ? '--disable-dev-shm-usage' : '',
             // #357: Set devicePixelRatio=1 otherwise it causes layout issues in HiDPI displays
             headless ? '--force-device-scale-factor=1' : '',
+            // #565: Add --disable-gpu option when running on WSL
+            isRunningOnWSL() ? '--disable-gpu' : '',
             // set Chromium language to English to avoid locale-dependent issues (e.g. minimum font size)
             '--lang=en',
             ...(!headless && process.platform === 'darwin'

--- a/src/util.ts
+++ b/src/util.ts
@@ -328,6 +328,14 @@ export function checkContainerEnvironment(): boolean {
   return fs.existsSync('/opt/vivliostyle-cli/.vs-cli-version');
 }
 
+export function isRunningOnWSL(): boolean {
+  // Detection method based on microsoft/WSL#4071
+  return (
+    fs.existsSync('/proc/version') &&
+    fs.readFileSync('/proc/version', 'utf8').toLowerCase().includes('microsoft')
+  );
+}
+
 export async function openEpubToTmpDirectory(filePath: string): Promise<{
   dest: string;
   epubOpfPath: string;


### PR DESCRIPTION
fix: #565 

WSL内で実行されている場合のみ`--disable-gpu`を追加するようにしました。ただし、WSLの中で実行されていることを確実に判定する方法は存在しないようです。

WindowsとWSLで動作確認済みです。