### PR TITLE
chore: Fix preview error "Arguments can not specify page to be opened" on macOS

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -43,18 +43,18 @@ export async function launchBrowser({
           headless,
           args: [
             '--allow-file-access-from-files',
-            disableWebSecurity ? '--disable-web-security' : '',
-            disableDevShmUsage ? '--disable-dev-shm-usage' : '',
+            ...(disableWebSecurity ? ['--disable-web-security'] : []),
+            ...(disableDevShmUsage ? ['--disable-dev-shm-usage'] : []),
             // #357: Set devicePixelRatio=1 otherwise it causes layout issues in HiDPI displays
-            headless ? '--force-device-scale-factor=1' : '',
+            ...(headless ? ['--force-device-scale-factor=1'] : []),
             // #565: Add --disable-gpu option when running on WSL
-            isRunningOnWSL() ? '--disable-gpu' : '',
-            // set Chromium language to English to avoid locale-dependent issues (e.g. minimum font size)
+            ...(isRunningOnWSL() ? ['--disable-gpu'] : []),
+            // set Chromium language to English to avoid locale-dependent issues
             '--lang=en',
             ...(!headless && process.platform === 'darwin'
-              ? ['-AppleLanguages', '(en)']
+              ? ['', '-AppleLanguages', '(en)'] // Fix for issue #570
               : []),
-          ].filter(Boolean),
+          ],
           env: { ...process.env, LANG: 'en.UTF-8' },
           proxy: proxy,
         }


### PR DESCRIPTION
- fix #570