### PR TITLE
feat: Do not add a trailing slash to webbook URL

### DIFF
--- a/src/config/resolve.ts
+++ b/src/config/resolve.ts
@@ -869,14 +869,6 @@ function resolveSingleInputConfig({
     let webbookPath: string | undefined;
     if (isValidUri(sourcePath)) {
       const url = new URL(sourcePath);
-      // Ensures trailing slash or explicit extensions
-      if (
-        /^https?:/i.test(url.protocol) &&
-        !url.pathname.endsWith('/') &&
-        !/\.\w+$/.test(url.pathname)
-      ) {
-        url.pathname = `${url.pathname}/`;
-      }
       webbookEntryUrl = url.href;
     } else {
       const rootFileUrl = pathToFileURL(workspaceDir).href;

--- a/tests/webbook.test.ts
+++ b/tests/webbook.test.ts
@@ -217,7 +217,7 @@ it('generate webpub from remote HTML documents with publication manifest', async
     '/assets/日本語.png': 'image',
   });
   await runCommand(
-    ['build', 'https://example.com/remote/dir', '-o', 'output'],
+    ['build', 'https://example.com/remote/dir/', '-o', 'output'],
     { cwd: '/work' },
   );
   expect(toTree(vol, { dir: '/work/output' })).toMatchSnapshot();


### PR DESCRIPTION
fix #603

The webbook URL no longer automatically adds a trailing slash. If the remote server requires one, you may need to update your input accordingly.

```
vivliostyle build https://example.com/subpath
↓
vivliostyle build https://example.com/subpath/
```