### PR TITLE
fix: Update Vivliostyle.js to 2.34.1: Fix PDF internal link bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@npmcli/arborist": "8.0.0",
     "@vivliostyle/jsdom": "25.0.1-vivliostyle-cli.1",
     "@vivliostyle/vfm": "2.2.1",
-    "@vivliostyle/viewer": "2.34.0",
+    "@vivliostyle/viewer": "2.34.1",
     "ajv": "8.17.1",
     "ajv-formats": "3.0.1",
     "archiver": "7.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: 2.2.1
         version: 2.2.1
       '@vivliostyle/viewer':
-        specifier: 2.34.0
-        version: 2.34.0
+        specifier: 2.34.1
+        version: 2.34.1
       ajv:
         specifier: 8.17.1
         version: 8.17.1
@@ -257,10 +257,10 @@ importers:
         version: 4.19.3
       typedoc:
         specifier: ^0.28.3
-        version: 0.28.9(typescript@5.8.3)
+        version: 0.28.10(typescript@5.8.3)
       typedoc-plugin-markdown:
         specifier: 4.6.3
-        version: 4.6.3(typedoc@0.28.9(typescript@5.8.3))
+        version: 4.6.3(typedoc@0.28.10(typescript@5.8.3))
       typescript:
         specifier: 5.8.3
         version: 5.8.3
@@ -359,7 +359,7 @@ importers:
     dependencies:
       '@astrojs/mdx':
         specifier: ^4.2.5
-        version: 4.3.3(astro@5.12.8(@types/node@24.0.0)(encoding@0.1.13)(rollup@4.40.0)(tsx@4.19.3)(typescript@5.8.3)(yaml@2.8.0))
+        version: 4.3.3(astro@5.12.9(@types/node@24.0.0)(encoding@0.1.13)(rollup@4.40.0)(tsx@4.19.3)(typescript@5.8.3)(yaml@2.8.0))
       '@astrojs/rss':
         specifier: ^4.0.11
         version: 4.0.12
@@ -371,7 +371,7 @@ importers:
         version: file:(typescript@5.8.3)(vite@6.3.5(@types/node@24.0.0)(tsx@4.19.3)(yaml@2.8.0))
       astro:
         specifier: ^5.7.8
-        version: 5.12.8(@types/node@24.0.0)(encoding@0.1.13)(rollup@4.40.0)(tsx@4.19.3)(typescript@5.8.3)(yaml@2.8.0)
+        version: 5.12.9(@types/node@24.0.0)(encoding@0.1.13)(rollup@4.40.0)(tsx@4.19.3)(typescript@5.8.3)(yaml@2.8.0)
     devDependencies:
       cross-env:
         specifier: ^7.0.3
@@ -1616,8 +1616,8 @@ packages:
     peerDependencies:
       vite: '>=6'
 
-  '@vivliostyle/core@2.34.0':
-    resolution: {integrity: sha512-4TrCHjAQBGqMNxPLL8bEOGuNtxnH68I4u3Lygn5WJalg2ZYdOJbqEi+hCLHNaYriDdznp6gyv33kmmk7OuunHg==}
+  '@vivliostyle/core@2.34.1':
+    resolution: {integrity: sha512-dRs6a8c7IKzHMpJYZQaLZQ9GnzoCKRpjDOHzdfO2joGcPZCHY3WVFNFNHla/mdsKadSNuJesABW1POXwUBqj3Q==}
     engines: {node: '>=14'}
 
   '@vivliostyle/jsdom@25.0.1-vivliostyle-cli.1':
@@ -1634,8 +1634,8 @@ packages:
     engines: {node: '>= 12'}
     hasBin: true
 
-  '@vivliostyle/viewer@2.34.0':
-    resolution: {integrity: sha512-L75z7nFlwbu3C8lutFdKvqwcVGAgmIGesltJi+4c6OYt/bIOnYNhgrzzWfuD2ejL0YurMKLpvHSfk/cNyYJjiA==}
+  '@vivliostyle/viewer@2.34.1':
+    resolution: {integrity: sha512-tTEEmcKNE+o9ilxhaa3i92aWyZIpE8Y39W2zqQbJkq6CziuFbNq3Af7vIKRnwhPDmMFbVBL/9ta6R+EI27VjQA==}
     engines: {node: '>=14'}
 
   '@zachleat/heading-anchors@1.0.3':
@@ -1797,8 +1797,8 @@ packages:
     resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
     hasBin: true
 
-  astro@5.12.8:
-    resolution: {integrity: sha512-KkJ7FR+c2SyZYlpakm48XBiuQcRsrVtdjG5LN5an0givI/tLik+ePJ4/g3qrAVhYMjJOxBA2YgFQxANPiWB+Mw==}
+  astro@5.12.9:
+    resolution: {integrity: sha512-cZ7kZ61jyE5nwSrFKSRyf5Gds+uJELqQxJFqMkcgiWQvhWZJUSShn8Uz3yc9WLyLw5Kim5P5un9SkJSGogfEZQ==}
     engines: {node: 18.20.8 || ^20.3.0 || >=22.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0'}
     hasBin: true
 
@@ -5700,8 +5700,8 @@ packages:
     peerDependencies:
       typedoc: 0.28.x
 
-  typedoc@0.28.9:
-    resolution: {integrity: sha512-aw45vwtwOl3QkUAmWCnLV9QW1xY+FSX2zzlit4MAfE99wX+Jij4ycnpbAWgBXsRrxmfs9LaYktg/eX5Bpthd3g==}
+  typedoc@0.28.10:
+    resolution: {integrity: sha512-zYvpjS2bNJ30SoNYfHSRaFpBMZAsL7uwKbWwqoCNFWjcPnI3e/mPLh2SneH9mX7SJxtDpvDgvd9/iZxGbo7daw==}
     engines: {node: '>= 18', pnpm: '>= 10'}
     hasBin: true
     peerDependencies:
@@ -6536,12 +6536,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/mdx@4.3.3(astro@5.12.8(@types/node@24.0.0)(encoding@0.1.13)(rollup@4.40.0)(tsx@4.19.3)(typescript@5.8.3)(yaml@2.8.0))':
+  '@astrojs/mdx@4.3.3(astro@5.12.9(@types/node@24.0.0)(encoding@0.1.13)(rollup@4.40.0)(tsx@4.19.3)(typescript@5.8.3)(yaml@2.8.0))':
     dependencies:
       '@astrojs/markdown-remark': 6.3.5
       '@mdx-js/mdx': 3.1.0(acorn@8.14.1)
       acorn: 8.14.1
-      astro: 5.12.8(@types/node@24.0.0)(encoding@0.1.13)(rollup@4.40.0)(tsx@4.19.3)(typescript@5.8.3)(yaml@2.8.0)
+      astro: 5.12.9(@types/node@24.0.0)(encoding@0.1.13)(rollup@4.40.0)(tsx@4.19.3)(typescript@5.8.3)(yaml@2.8.0)
       es-module-lexer: 1.7.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
@@ -7697,7 +7697,7 @@ snapshots:
       '@npmcli/arborist': 8.0.0
       '@vivliostyle/jsdom': 25.0.1-vivliostyle-cli.1(@napi-rs/canvas@0.1.69)
       '@vivliostyle/vfm': 2.2.1
-      '@vivliostyle/viewer': 2.34.0
+      '@vivliostyle/viewer': 2.34.1
       ajv: 8.17.1
       ajv-formats: 3.0.1(ajv@8.17.1)
       archiver: 7.0.1
@@ -7742,7 +7742,7 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@vivliostyle/core@2.34.0':
+  '@vivliostyle/core@2.34.1':
     dependencies:
       fast-diff: 1.3.0
 
@@ -7814,9 +7814,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vivliostyle/viewer@2.34.0':
+  '@vivliostyle/viewer@2.34.1':
     dependencies:
-      '@vivliostyle/core': 2.34.0
+      '@vivliostyle/core': 2.34.1
       i18next-ko: 3.0.1
       knockout: 3.5.1
 
@@ -7962,7 +7962,7 @@ snapshots:
 
   astring@1.9.0: {}
 
-  astro@5.12.8(@types/node@24.0.0)(encoding@0.1.13)(rollup@4.40.0)(tsx@4.19.3)(typescript@5.8.3)(yaml@2.8.0):
+  astro@5.12.9(@types/node@24.0.0)(encoding@0.1.13)(rollup@4.40.0)(tsx@4.19.3)(typescript@5.8.3)(yaml@2.8.0):
     dependencies:
       '@astrojs/compiler': 2.12.2
       '@astrojs/internal-helpers': 0.7.1
@@ -12778,11 +12778,11 @@ snapshots:
 
   typedarray@0.0.6: {}
 
-  typedoc-plugin-markdown@4.6.3(typedoc@0.28.9(typescript@5.8.3)):
+  typedoc-plugin-markdown@4.6.3(typedoc@0.28.10(typescript@5.8.3)):
     dependencies:
-      typedoc: 0.28.9(typescript@5.8.3)
+      typedoc: 0.28.10(typescript@5.8.3)
 
-  typedoc@0.28.9(typescript@5.8.3):
+  typedoc@0.28.10(typescript@5.8.3):
     dependencies:
       '@gerrit0/mini-shiki': 3.9.1
       lunr: 2.3.9


### PR DESCRIPTION
https://github.com/vivliostyle/vivliostyle.js/releases/tag/v2.34.1

### Bug Fixes

- Fix broken internal links in output PDF (workaround for Chromium>=138 bug)