### PR TITLE
ci: Add a release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,55 @@
+name: release
+
+on:
+  - workflow_dispatch
+
+permissions:
+  id-token: write # Required for OIDC
+  contents: write # For git operations
+
+jobs:
+  release-dry-run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+      - run: pnpm install
+      - run: pnpm build
+      - name: Release dry run
+        run: npx release-it --ci -VV --dry-run
+      - uses: actions/upload-artifact@v4
+        with:
+          path: dist/**
+
+  release:
+    needs: release-dry-run
+    runs-on: ubuntu-latest
+    environment: Production deployment
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+      - uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+      - run: pnpm install
+      - name: Set GitHub Actions user
+        run: |
+          git config --global user.name vivliostyle
+          git config --global user.email mail@vivliostyle.org
+      - name: Release
+        run: npx release-it --ci -VV
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.release-it.json
+++ b/.release-it.json
@@ -7,6 +7,9 @@
   "github": {
     "release": true
   },
+  "npm": {
+    "skipChecks": true
+  },
   "plugins": {
     "@release-it/conventional-changelog": {
       "preset": "angular",


### PR DESCRIPTION
Reference
- https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available/
- https://github.com/release-it/release-it/blob/main/docs/npm.md#trusted-publishing-oidc