### PR TITLE
feat: Update Playwright to 1.56.1 (Chromium 141.0.7390.37)

### DIFF
--- a/docs/api-javascript.md
+++ b/docs/api-javascript.md
@@ -54,7 +54,7 @@ build({
 
 ###### configData?
 
-`null` \| `object` & `object` \| `object` & `object`[] = `...`
+`object` & `object` \| `object` & `object`[] \| `null` = `...`
 
 ###### cropMarks?
 
@@ -248,7 +248,7 @@ build({
 
 ###### configData?
 
-`null` \| `object` & `object` \| `object` & `object`[] = `...`
+`object` & `object` \| `object` & `object`[] \| `null` = `...`
 
 ###### cropMarks?
 
@@ -444,7 +444,7 @@ Initialize a new vivliostyle.config.js file.
 
 ###### configData?
 
-`null` \| `object` & `object` \| `object` & `object`[] = `...`
+`object` & `object` \| `object` & `object`[] \| `null` = `...`
 
 ###### cropMarks?
 
@@ -640,7 +640,7 @@ Open a browser for previewing the publication.
 
 ###### configData?
 
-`null` \| `object` & `object` \| `object` & `object`[] = `...`
+`object` & `object` \| `object` & `object`[] \| `null` = `...`
 
 ###### cropMarks?
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "npm-package-arg": "12.0.2",
     "pdf-lib": "1.17.1",
     "picomatch": "4.0.2",
-    "playwright-core": "1.55.0",
+    "playwright-core": "1.56.1",
     "press-ready": "4.0.3",
     "resolve-pkg": "2.0.0",
     "semver": "7.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,8 +93,8 @@ importers:
         specifier: 4.0.2
         version: 4.0.2
       playwright-core:
-        specifier: 1.55.0
-        version: 1.55.0
+        specifier: 1.56.1
+        version: 1.56.1
       press-ready:
         specifier: 4.0.3
         version: 4.0.3
@@ -130,7 +130,7 @@ importers:
         version: 4.2.1
       vite:
         specifier: ^6.3.5
-        version: 6.3.6(@types/node@22.15.2)(tsx@4.19.3)(yaml@2.8.1)
+        version: 6.4.1(@types/node@22.15.2)(tsx@4.19.3)(yaml@2.8.1)
       w3c-xmlserializer:
         specifier: 5.0.0
         version: 5.0.0
@@ -275,13 +275,13 @@ importers:
     dependencies:
       '@vivliostyle/cli':
         specifier: file:../../
-        version: file:(typescript@5.8.3)(vite@6.3.6(@types/node@24.7.1)(tsx@4.19.3)(yaml@2.8.1))
+        version: file:(typescript@5.8.3)(vite@6.4.1(@types/node@24.7.1)(tsx@4.19.3)(yaml@2.8.1))
 
   examples/customize-processor:
     dependencies:
       '@vivliostyle/cli':
         specifier: file:../../
-        version: file:(typescript@5.8.3)(vite@6.3.6(@types/node@24.7.1)(tsx@4.19.3)(yaml@2.8.1))
+        version: file:(typescript@5.8.3)(vite@6.4.1(@types/node@24.7.1)(tsx@4.19.3)(yaml@2.8.1))
       rehype-expressive-code:
         specifier: ^0.37.0
         version: 0.37.1
@@ -305,61 +305,61 @@ importers:
     dependencies:
       '@vivliostyle/cli':
         specifier: file:../../
-        version: file:(typescript@5.8.3)(vite@6.3.6(@types/node@24.7.1)(tsx@4.19.3)(yaml@2.8.1))
+        version: file:(typescript@5.8.3)(vite@6.4.1(@types/node@24.7.1)(tsx@4.19.3)(yaml@2.8.1))
 
   examples/multiple-input-and-output:
     dependencies:
       '@vivliostyle/cli':
         specifier: file:../../
-        version: file:(typescript@5.8.3)(vite@6.3.6(@types/node@24.7.1)(tsx@4.19.3)(yaml@2.8.1))
+        version: file:(typescript@5.8.3)(vite@6.4.1(@types/node@24.7.1)(tsx@4.19.3)(yaml@2.8.1))
 
   examples/preflight:
     dependencies:
       '@vivliostyle/cli':
         specifier: file:../../
-        version: file:(typescript@5.8.3)(vite@6.3.6(@types/node@24.7.1)(tsx@4.19.3)(yaml@2.8.1))
+        version: file:(typescript@5.8.3)(vite@6.4.1(@types/node@24.7.1)(tsx@4.19.3)(yaml@2.8.1))
 
   examples/render-on-docker:
     dependencies:
       '@vivliostyle/cli':
         specifier: file:../../
-        version: file:(typescript@5.8.3)(vite@6.3.6(@types/node@24.7.1)(tsx@4.19.3)(yaml@2.8.1))
+        version: file:(typescript@5.8.3)(vite@6.4.1(@types/node@24.7.1)(tsx@4.19.3)(yaml@2.8.1))
 
   examples/single-html:
     dependencies:
       '@vivliostyle/cli':
         specifier: file:../../
-        version: file:(typescript@5.8.3)(vite@6.3.6(@types/node@24.7.1)(tsx@4.19.3)(yaml@2.8.1))
+        version: file:(typescript@5.8.3)(vite@6.4.1(@types/node@24.7.1)(tsx@4.19.3)(yaml@2.8.1))
 
   examples/single-markdown:
     dependencies:
       '@vivliostyle/cli':
         specifier: file:../../
-        version: file:(typescript@5.8.3)(vite@6.3.6(@types/node@24.7.1)(tsx@4.19.3)(yaml@2.8.1))
+        version: file:(typescript@5.8.3)(vite@6.4.1(@types/node@24.7.1)(tsx@4.19.3)(yaml@2.8.1))
 
   examples/table-of-contents:
     dependencies:
       '@vivliostyle/cli':
         specifier: file:../../
-        version: file:(typescript@5.8.3)(vite@6.3.6(@types/node@24.7.1)(tsx@4.19.3)(yaml@2.8.1))
+        version: file:(typescript@5.8.3)(vite@6.4.1(@types/node@24.7.1)(tsx@4.19.3)(yaml@2.8.1))
 
   examples/theme-css:
     dependencies:
       '@vivliostyle/cli':
         specifier: file:../../
-        version: file:(typescript@5.8.3)(vite@6.3.6(@types/node@24.7.1)(tsx@4.19.3)(yaml@2.8.1))
+        version: file:(typescript@5.8.3)(vite@6.4.1(@types/node@24.7.1)(tsx@4.19.3)(yaml@2.8.1))
 
   examples/theme-preset:
     dependencies:
       '@vivliostyle/cli':
         specifier: file:../../
-        version: file:(typescript@5.8.3)(vite@6.3.6(@types/node@24.7.1)(tsx@4.19.3)(yaml@2.8.1))
+        version: file:(typescript@5.8.3)(vite@6.4.1(@types/node@24.7.1)(tsx@4.19.3)(yaml@2.8.1))
 
   examples/with-astro:
     dependencies:
       '@astrojs/mdx':
         specifier: ^4.2.5
-        version: 4.3.7(astro@5.14.3(@types/node@24.7.1)(rollup@4.40.0)(tsx@4.19.3)(typescript@5.8.3)(yaml@2.8.1))
+        version: 4.3.7(astro@5.14.7(@types/node@24.7.1)(rollup@4.40.0)(tsx@4.19.3)(typescript@5.8.3)(yaml@2.8.1))
       '@astrojs/rss':
         specifier: ^4.0.11
         version: 4.0.12
@@ -368,10 +368,10 @@ importers:
         version: 3.6.0
       '@vivliostyle/cli':
         specifier: file:../../
-        version: file:(typescript@5.8.3)(vite@6.3.6(@types/node@24.7.1)(tsx@4.19.3)(yaml@2.8.1))
+        version: file:(typescript@5.8.3)(vite@6.4.1(@types/node@24.7.1)(tsx@4.19.3)(yaml@2.8.1))
       astro:
         specifier: ^5.7.8
-        version: 5.14.3(@types/node@24.7.1)(rollup@4.40.0)(tsx@4.19.3)(typescript@5.8.3)(yaml@2.8.1)
+        version: 5.14.7(@types/node@24.7.1)(rollup@4.40.0)(tsx@4.19.3)(typescript@5.8.3)(yaml@2.8.1)
     devDependencies:
       cross-env:
         specifier: ^7.0.3
@@ -403,7 +403,7 @@ importers:
         version: 6.0.0(@types/node@24.7.1)(tsx@4.19.3)(yaml@2.8.1)
       '@vivliostyle/cli':
         specifier: file:../..
-        version: file:(typescript@5.8.3)(vite@6.3.6(@types/node@24.7.1)(tsx@4.19.3)(yaml@2.8.1))
+        version: file:(typescript@5.8.3)(vite@6.4.1(@types/node@24.7.1)(tsx@4.19.3)(yaml@2.8.1))
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -424,7 +424,7 @@ importers:
     dependencies:
       '@vivliostyle/cli':
         specifier: file:../../
-        version: file:(typescript@5.8.3)(vite@6.3.6(@types/node@24.7.1)(tsx@4.19.3)(yaml@2.8.1))
+        version: file:(typescript@5.8.3)(vite@6.4.1(@types/node@24.7.1)(tsx@4.19.3)(yaml@2.8.1))
 
 packages:
 
@@ -2092,8 +2092,8 @@ packages:
     resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
     hasBin: true
 
-  astro@5.14.3:
-    resolution: {integrity: sha512-iRvl3eEYYdSYA195eNREjh43hqMMwKY1uoHYiKfLCB9G+bjFtaBtDe8R0ip7AbTD69wyOKgUCOtMad+lkOnT/w==}
+  astro@5.14.7:
+    resolution: {integrity: sha512-vdZmRN2MFf60ZTjFkZNrQQkrmeeZzTI1c6N3ZRQN55rPGHjywM2VplJwJ68q496DfpaoDoAroDBpdm+eTgHUtQ==}
     engines: {node: 18.20.8 || ^20.3.0 || >=22.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0'}
     hasBin: true
 
@@ -4871,8 +4871,8 @@ packages:
     resolution: {integrity: sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==}
     engines: {node: '>= 6'}
 
-  playwright-core@1.55.0:
-    resolution: {integrity: sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==}
+  playwright-core@1.56.1:
+    resolution: {integrity: sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -6295,8 +6295,8 @@ packages:
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
-  vite@6.3.6:
-    resolution: {integrity: sha512-0msEVHJEScQbhkbVTb/4iHZdJ6SXp/AvxL2sjwYQFfBqleHtnCqv1J3sa9zbWz/6kW1m9Tfzn92vW+kZ1WV6QA==}
+  vite@6.4.1:
+    resolution: {integrity: sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
@@ -6693,7 +6693,7 @@ snapshots:
   '@11ty/eleventy-plugin-vite@6.0.0(@types/node@24.7.1)(tsx@4.19.3)(yaml@2.8.1)':
     dependencies:
       '@11ty/eleventy-utils': 2.0.5
-      vite: 6.3.6(@types/node@24.7.1)(tsx@4.19.3)(yaml@2.8.1)
+      vite: 6.4.1(@types/node@24.7.1)(tsx@4.19.3)(yaml@2.8.1)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -6810,12 +6810,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/mdx@4.3.7(astro@5.14.3(@types/node@24.7.1)(rollup@4.40.0)(tsx@4.19.3)(typescript@5.8.3)(yaml@2.8.1))':
+  '@astrojs/mdx@4.3.7(astro@5.14.7(@types/node@24.7.1)(rollup@4.40.0)(tsx@4.19.3)(typescript@5.8.3)(yaml@2.8.1))':
     dependencies:
       '@astrojs/markdown-remark': 6.3.8
       '@mdx-js/mdx': 3.1.1
       acorn: 8.15.0
-      astro: 5.14.3(@types/node@24.7.1)(rollup@4.40.0)(tsx@4.19.3)(typescript@5.8.3)(yaml@2.8.1)
+      astro: 5.14.7(@types/node@24.7.1)(rollup@4.40.0)(tsx@4.19.3)(typescript@5.8.3)(yaml@2.8.1)
       es-module-lexer: 1.7.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
@@ -8099,13 +8099,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.1.2(vite@6.3.6(@types/node@22.15.2)(tsx@4.19.3)(yaml@2.8.1))':
+  '@vitest/mocker@3.1.2(vite@6.4.1(@types/node@22.15.2)(tsx@4.19.3)(yaml@2.8.1))':
     dependencies:
       '@vitest/spy': 3.1.2
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.3.6(@types/node@22.15.2)(tsx@4.19.3)(yaml@2.8.1)
+      vite: 6.4.1(@types/node@22.15.2)(tsx@4.19.3)(yaml@2.8.1)
 
   '@vitest/pretty-format@3.1.2':
     dependencies:
@@ -8132,7 +8132,7 @@ snapshots:
       loupe: 3.1.3
       tinyrainbow: 2.0.0
 
-  '@vivliostyle/cli@file:(typescript@5.8.3)(vite@6.3.6(@types/node@24.7.1)(tsx@4.19.3)(yaml@2.8.1))':
+  '@vivliostyle/cli@file:(typescript@5.8.3)(vite@6.4.1(@types/node@24.7.1)(tsx@4.19.3)(yaml@2.8.1))':
     dependencies:
       '@babel/code-frame': 7.26.2
       '@humanwhocodes/momoa': 3.3.8
@@ -8162,7 +8162,7 @@ snapshots:
       npm-package-arg: 12.0.2
       pdf-lib: 1.17.1
       picomatch: 4.0.2
-      playwright-core: 1.55.0
+      playwright-core: 1.56.1
       press-ready: 4.0.3
       resolve-pkg: 2.0.0
       semver: 7.7.1
@@ -8174,7 +8174,7 @@ snapshots:
       uuid: 11.1.0
       valibot: 1.0.0(typescript@5.8.3)
       vfile: 4.2.1
-      vite: 6.3.6(@types/node@24.7.1)(tsx@4.19.3)(yaml@2.8.1)
+      vite: 6.4.1(@types/node@24.7.1)(tsx@4.19.3)(yaml@2.8.1)
       w3c-xmlserializer: 5.0.0
       whatwg-mimetype: 4.0.0
       yocto-spinner: 0.2.2
@@ -8405,7 +8405,7 @@ snapshots:
 
   astring@1.9.0: {}
 
-  astro@5.14.3(@types/node@24.7.1)(rollup@4.40.0)(tsx@4.19.3)(typescript@5.8.3)(yaml@2.8.1):
+  astro@5.14.7(@types/node@24.7.1)(rollup@4.40.0)(tsx@4.19.3)(typescript@5.8.3)(yaml@2.8.1):
     dependencies:
       '@astrojs/compiler': 2.13.0
       '@astrojs/internal-helpers': 0.7.4
@@ -8461,8 +8461,8 @@ snapshots:
       unist-util-visit: 5.0.0
       unstorage: 1.17.1
       vfile: 6.0.3
-      vite: 6.3.6(@types/node@24.7.1)(tsx@4.19.3)(yaml@2.8.1)
-      vitefu: 1.1.1(vite@6.3.6(@types/node@24.7.1)(tsx@4.19.3)(yaml@2.8.1))
+      vite: 6.4.1(@types/node@24.7.1)(tsx@4.19.3)(yaml@2.8.1)
+      vitefu: 1.1.1(vite@6.4.1(@types/node@24.7.1)(tsx@4.19.3)(yaml@2.8.1))
       xxhash-wasm: 1.1.0
       yargs-parser: 21.1.1
       yocto-spinner: 0.2.3
@@ -11873,7 +11873,7 @@ snapshots:
 
   pirates@4.0.6: {}
 
-  playwright-core@1.55.0: {}
+  playwright-core@1.56.1: {}
 
   please-upgrade-node@3.2.0:
     dependencies:
@@ -13579,7 +13579,7 @@ snapshots:
       debug: 4.4.0
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.3.6(@types/node@22.15.2)(tsx@4.19.3)(yaml@2.8.1)
+      vite: 6.4.1(@types/node@22.15.2)(tsx@4.19.3)(yaml@2.8.1)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -13594,7 +13594,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@6.3.6(@types/node@22.15.2)(tsx@4.19.3)(yaml@2.8.1):
+  vite@6.4.1(@types/node@22.15.2)(tsx@4.19.3)(yaml@2.8.1):
     dependencies:
       esbuild: 0.25.3
       fdir: 6.4.4(picomatch@4.0.2)
@@ -13608,7 +13608,7 @@ snapshots:
       tsx: 4.19.3
       yaml: 2.8.1
 
-  vite@6.3.6(@types/node@24.7.1)(tsx@4.19.3)(yaml@2.8.1):
+  vite@6.4.1(@types/node@24.7.1)(tsx@4.19.3)(yaml@2.8.1):
     dependencies:
       esbuild: 0.25.3
       fdir: 6.4.4(picomatch@4.0.2)
@@ -13622,14 +13622,14 @@ snapshots:
       tsx: 4.19.3
       yaml: 2.8.1
 
-  vitefu@1.1.1(vite@6.3.6(@types/node@24.7.1)(tsx@4.19.3)(yaml@2.8.1)):
+  vitefu@1.1.1(vite@6.4.1(@types/node@24.7.1)(tsx@4.19.3)(yaml@2.8.1)):
     optionalDependencies:
-      vite: 6.3.6(@types/node@24.7.1)(tsx@4.19.3)(yaml@2.8.1)
+      vite: 6.4.1(@types/node@24.7.1)(tsx@4.19.3)(yaml@2.8.1)
 
   vitest@3.1.2(@types/debug@4.1.12)(@types/node@22.15.2)(tsx@4.19.3)(yaml@2.8.1):
     dependencies:
       '@vitest/expect': 3.1.2
-      '@vitest/mocker': 3.1.2(vite@6.3.6(@types/node@22.15.2)(tsx@4.19.3)(yaml@2.8.1))
+      '@vitest/mocker': 3.1.2(vite@6.4.1(@types/node@22.15.2)(tsx@4.19.3)(yaml@2.8.1))
       '@vitest/pretty-format': 3.1.2
       '@vitest/runner': 3.1.2
       '@vitest/snapshot': 3.1.2
@@ -13646,7 +13646,7 @@ snapshots:
       tinyglobby: 0.2.13
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 6.3.6(@types/node@22.15.2)(tsx@4.19.3)(yaml@2.8.1)
+      vite: 6.4.1(@types/node@22.15.2)(tsx@4.19.3)(yaml@2.8.1)
       vite-node: 3.1.2(@types/node@22.15.2)(tsx@4.19.3)(yaml@2.8.1)
       why-is-node-running: 2.3.0
     optionalDependencies:


### PR DESCRIPTION
This Chromium update solves the issue that the previous version (Chromium 140) fails to find fonts on Linux.  
(Chromium issue: https://issues.chromium.org/issues/442747781)

- fixes #646