### PR TITLE
fix: Allow asset extensions defined in copyAsset

### DIFF
--- a/src/output/webbook.ts
+++ b/src/output/webbook.ts
@@ -415,6 +415,7 @@ export async function copyWebPublicationAssets({
     themesDir,
     entries,
     manifestPath,
+    copyAsset,
   });
   const allFiles = new Set([
     ...(await assetMatcher.glob()),

--- a/src/processor/asset.ts
+++ b/src/processor/asset.ts
@@ -83,7 +83,11 @@ export function getWebPubResourceMatcher({
   entries,
   cwd,
   manifestPath,
-}: Pick<ResolvedTaskConfig, 'outputs' | 'themesDir' | 'entries'> & {
+  copyAsset: { fileExtensions },
+}: Pick<
+  ResolvedTaskConfig,
+  'outputs' | 'themesDir' | 'entries' | 'copyAsset'
+> & {
   cwd: string;
   manifestPath: string;
 }) {
@@ -91,7 +95,8 @@ export function getWebPubResourceMatcher({
     {
       patterns: [
         `**/${upath.relative(cwd, manifestPath)}`,
-        '**/*.{html,htm,xhtml,xht,css}',
+        '**/*.{html,htm,xhtml,xht}',
+        `**/*.{${fileExtensions.join(',')}}`,
       ],
       ignore: [
         ...getIgnoreAssetPatterns({

--- a/src/vite/vite-plugin-dev-server.ts
+++ b/src/vite/vite-plugin-dev-server.ts
@@ -73,6 +73,7 @@ function getWorkspaceMatcher({
   themeIndexes,
   entries,
   outputs,
+  copyAsset,
 }: ResolvedTaskConfig) {
   if (viewerInput.type === 'webpub') {
     return getWebPubResourceMatcher({
@@ -81,6 +82,7 @@ function getWorkspaceMatcher({
       entries,
       cwd: workspaceDir,
       manifestPath: viewerInput.manifestPath,
+      copyAsset,
     });
   }
 


### PR DESCRIPTION
fix: #625 

この問題は元のIssueで指摘したローカルディレクトリに作成したテーマだけでなく、npmレジストリに公開済みのテーマでも発生するはずです。

テーマ内のファイルは通常[src/vite/vite-plugin-dev-server.ts:377](https://github.com/vivliostyle/vivliostyle-cli/blob/e0c81aaeceb57db3ac3311dd74d76c8d7d7ac8c4/src/vite/vite-plugin-dev-server.ts#L377)でマッチします。例：`serveWorkspaceMatcher.match("themes/node_modules/@vivliostyle/theme-base/theme-all.css") === true`

問題は、`getWebPubResourceMatcher`が拡張子を制限していることです。[src/processor/assert.ts:80](https://github.com/vivliostyle/vivliostyle-cli/blob/e0c81aaeceb57db3ac3311dd74d76c8d7d7ac8c4/src/processor/asset.ts#L94)

[W3C Web Publication Manifest](https://www.w3.org/TR/pub-manifest/)の仕様を確認すると、[`readingOrder`](https://www.w3.org/TR/pub-manifest/#default-reading-order)と[`resources`](https://www.w3.org/TR/pub-manifest/#resource-list)で使用できる[`string|LinkedResource`](https://www.w3.org/TR/pub-manifest/#value-linked-resource)には、特に拡張子の制限がないようにみえます。

> Example 6 : Resource list that includes one link using a relative URL as a string ('datatypes.svg') and two that display the various properties of the a LinkedResource object.
> 
> ```
> {
>     …
>     "resources" : [
>         "datatypes.svg",
>         {
>             "type"            : "LinkedResource",
>             "url"             : "test-utf8.csv",
>             "encodingFormat"  : "text/csv",
>             "name"            : "Test Results",
>             "description"     : "CSV file containing the full data set used."
>         },
>         {
>             "type"            : "LinkedResource",
>             "url"             : "terminology.html",
>             "encodingFormat"  : "text/html",
>             "rel"             : "glossary"
>         }
>     ],
>     …
> }
> ```

`getWebPubResourceMatcher`で`html,htm,xhtml,xht,css`に制限する必要はなく、安全側に倒して制限するにしても`copyAsset: { fileExtensions }`の内容は含めるのが妥当と考えられます。なお`fileExtensions`のデフォルト値には[`DEFAULT_ASSET_EXTENSIONS`](https://github.com/vivliostyle/vivliostyle-cli/blob/e0c81aaeceb57db3ac3311dd74d76c8d7d7ac8c4/src/config/resolve.ts#L279)が使用されるためCSSは重複しており、一覧から外しています。