### PR TITLE
fix: Update config to use another port for build

### DIFF
--- a/src/core/build.ts
+++ b/src/core/build.ts
@@ -5,7 +5,7 @@ import { PreviewServer, build as viteBuild } from 'vite';
 import { cyan, gray } from 'yoctocolors';
 import { setupConfigFromFlags } from '../commands/cli-flags.js';
 import { loadVivliostyleConfig, warnDeprecatedConfig } from '../config/load.js';
-import { mergeInlineConfig } from '../config/merge.js';
+import { mergeConfig, mergeInlineConfig } from '../config/merge.js';
 import { isWebPubConfig, resolveTaskConfig } from '../config/resolve.js';
 import { ParsedVivliostyleInlineConfig } from '../config/schema.js';
 import { resolveViteConfig } from '../config/vite.js';
@@ -47,7 +47,7 @@ export async function build(
   for (let [i, task] of vivliostyleConfig.tasks.entries()) {
     using _ = Logger.startLogging('Start building');
 
-    const config = resolveTaskConfig(task, inlineOptions);
+    let config = resolveTaskConfig(task, inlineOptions);
     Logger.debug('build > config %O', config);
     const viteConfig = await resolveViteConfig({
       ...config,
@@ -73,6 +73,24 @@ export async function build(
           inlineConfig,
           mode: 'build',
         });
+
+        if (server.httpServer) {
+          const addressInfo = server.httpServer.address();
+          if (addressInfo && typeof addressInfo !== 'string') {
+            const actualPort = addressInfo.port;
+            vivliostyleConfig = mergeConfig(vivliostyleConfig, {
+              temporaryFilePrefix: config.temporaryFilePrefix,
+              server: {
+                ...server.config.preview,
+                port: actualPort,
+              },
+            });
+            config = resolveTaskConfig(
+              vivliostyleConfig.tasks[i],
+              vivliostyleConfig.inlineOptions,
+            );
+          }
+        }
       }
 
       // build artifacts


### PR DESCRIPTION
fix: #630

この問題の原因は、[src/core/build.ts:70](https://github.com/vivliostyle/vivliostyle-cli/blob/e0c81aaeceb57db3ac3311dd74d76c8d7d7ac8c4/src/core/build.ts#L70)で`createViteServer`が別のポートを使用した際に、`config`にポートの変更を反映しそびれていることです。

`vivliostyle preview`では[src/core/preview.ts:45-55](https://github.com/vivliostyle/vivliostyle-cli/blob/e0c81aaeceb57db3ac3311dd74d76c8d7d7ac8c4/src/core/preview.ts#L45-L55)で`config`を作り直しており、変更されたポートが以降の処理に反映されています。同じ処理が`vivliostyle build`にも必要です。

ただし`vivliostyle build`で使用するViteのプレビューサーバー（[備考：src/config/vite.ts:15-17](https://github.com/vivliostyle/vivliostyle-cli/blob/e0c81aaeceb57db3ac3311dd74d76c8d7d7ac8c4/src/config/vite.ts#L15-L17)）では`server.httpServer.address()`からポート番号を取り出さなくてはならず、マージは`preview.ts`での実装と同一にはならないと認識しています。
