### PR TITLE
fix: Pass renderMode, preflight, preflightOption to inlineOptions in mergeInlineConfig

### DIFF
--- a/src/output/pdf-postprocess.ts
+++ b/src/output/pdf-postprocess.ts
@@ -49,9 +49,6 @@ export interface PageSizeData {
   bleedSize: number;
 }
 
-const CONTAINER_PRESS_READY_PATH =
-  '/opt/vivliostyle-cli/node_modules/.bin/press-ready';
-
 export async function pressReadyWithContainer({
   input,
   output,
@@ -65,7 +62,7 @@ export async function pressReadyWithContainer({
 }) {
   await runContainer({
     image,
-    entrypoint: CONTAINER_PRESS_READY_PATH,
+    entrypoint: 'press-ready',
     userVolumeArgs: collectVolumeArgs([
       upath.dirname(input),
       upath.dirname(output),


### PR DESCRIPTION
fix: #652 

`renderMode`, `preflight`, `preflightOption`が`inlineOptions`にマージされていませんでした。

```
examples/local-theme$ npx vivliostyle build --preflight press-ready-local
INFO Start building
INFO Launching PDF build environment
INFO Building pages
INFO Building PDF
INFO Processing PDF
INFO Running press-ready

==> Listing fonts in '/tmp/vivliostyle-cli-1739ba00-d0e6-11f0-b066-ffdb54cb5091.pdf'
name                         type          embedded  subset 
AAAAAA+LiberationSerif-Bold  CID TrueType  yes       yes    
==> Every font is properly embedded
==> Generating PDF
Input            /tmp/vivliostyle-cli-1739ba00-d0e6-11f0-b066-ffdb54cb5091.pdf          
Output           /home/mukai/Documents/vivliostyle-cli/examples/local-theme/example.pdf 
Color Mode       CMYK                                                                   
Enforce outline  no                                                                     
Boundary boxes   no                                                                     
==> Ghostscript: Done without error
==> Listing fonts in '/home/mukai/Documents/vivliostyle-cli/examples/local-theme/example.pdf'
==> No fonts found
==> Every font is properly embedded

SUCCESS Finished building example.pdf
📙 Built successfully!
```