### PR TITLE
chore: Update asciidoc-processor example to v10 config style

### DIFF
--- a/examples/asciidoc-processor/README.md
+++ b/examples/asciidoc-processor/README.md
@@ -9,10 +9,3 @@ This example demonstrates how to mix AsciiDoc and Markdown files in a single pub
 ├── chapter2.md             # Markdown (default VFM)
 └── vivliostyle.config.js
 ```
-
-## Usage
-
-```bash
-npm install
-npm run build
-```

--- a/examples/asciidoc-processor/vivliostyle.config.js
+++ b/examples/asciidoc-processor/vivliostyle.config.js
@@ -1,3 +1,5 @@
+// @ts-check
+import { defineConfig } from '@vivliostyle/cli';
 import Asciidoctor from '@asciidoctor/core';
 
 const asciidoctor = Asciidoctor();
@@ -35,8 +37,7 @@ function readAsciidocMetadata(content) {
   };
 }
 
-/** @type {import('@vivliostyle/cli').VivliostyleConfigSchema} */
-const config = {
+const config = defineConfig({
   title: 'Mixed Format Example',
   author: 'Vivliostyle',
   language: 'en',
@@ -49,6 +50,6 @@ const config = {
     'chapter2.md',
   ],
   output: 'output.pdf',
-};
+});
 
 export default config;


### PR DESCRIPTION
この例だけv10の`defineConfig`に書き換えられていないので更新します。