### PR TITLE
fix(docker): add xz-utils for Firefox browser installation

### DIFF
--- a/.changeset/funky-memes-sin.md
+++ b/.changeset/funky-memes-sin.md
@@ -1,0 +1,5 @@
+---
+'@vivliostyle/cli': patch
+---
+
+fix(docker): add xz-utils for Firefox browser installation

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,8 @@ RUN set -x \
     git openssh-client \
     # dependencies for press-ready
     ghostscript poppler-utils \
+    # for Puppeteer Firefox installation
+    xz-utils \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* `npm config get cache`/_npx
 
 # Install fonts


### PR DESCRIPTION
Add xz-utils package to Dockerfile to enable unpacking Firefox archives (.tar.xz format) when using --render-mode docker with --browser firefox.

Fixes #694