### PR TITLE
feat: Update Vivliostyle.js to 2.39.0: Extend CSS nth-* selectors support

### DIFF
--- a/.changeset/fluffy-tigers-smell.md
+++ b/.changeset/fluffy-tigers-smell.md
@@ -1,0 +1,5 @@
+---
+'@vivliostyle/cli': minor
+---
+
+feat: Update Vivliostyle.js to 2.39.0: Extend CSS nth-\* selectors support

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@puppeteer/browsers": "2.10.5",
     "@vivliostyle/jsdom": "25.0.1-vivliostyle-cli.1",
     "@vivliostyle/vfm": "2.5.0",
-    "@vivliostyle/viewer": "2.38.0",
+    "@vivliostyle/viewer": "2.39.0",
     "ajv": "8.17.1",
     "ajv-formats": "3.0.1",
     "archiver": "7.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: 2.5.0
         version: 2.5.0
       '@vivliostyle/viewer':
-        specifier: 2.38.0
-        version: 2.38.0
+        specifier: 2.39.0
+        version: 2.39.0
       ajv:
         specifier: 8.17.1
         version: 8.17.1
@@ -2148,8 +2148,8 @@ packages:
   '@vitest/utils@3.1.2':
     resolution: {integrity: sha512-5GGd0ytZ7BH3H6JTj9Kw7Prn1Nbg0wZVrIvou+UWxm54d+WoXXgAgjFJ8wn3LdagWLFSEfpPeyYrByZaGEZHLg==}
 
-  '@vivliostyle/core@2.38.0':
-    resolution: {integrity: sha512-WLDAAzQ214o56YKioZh8j9dnbaQ6reJCpthuWWSI6xCKAO7jBuAP4Ua+P49riZagyQx0/2FyKQtgpEFqoUW1xg==}
+  '@vivliostyle/core@2.39.0':
+    resolution: {integrity: sha512-a89ilE/XyI6it4p2cUrEJ5mO21sn7AjIcucILc04AQR0d1stUtXywIXFEb78DM34T352OeRWuFTkp+44XR3xKA==}
     engines: {node: '>=20'}
 
   '@vivliostyle/jsdom@25.0.1-vivliostyle-cli.1':
@@ -2166,8 +2166,8 @@ packages:
     engines: {node: '>= 20'}
     hasBin: true
 
-  '@vivliostyle/viewer@2.38.0':
-    resolution: {integrity: sha512-bBBWNSW384W1/KvIWuZ5qHY7e8C0zeFcyXyEH8m30ngy0iQ3Kgt4X+XyiL7Hw/AGpfVUStufvhwQkD5eRpl0+Q==}
+  '@vivliostyle/viewer@2.39.0':
+    resolution: {integrity: sha512-vtrzK+jJvVGnGgyusD9yu9lRoTEiB0NAwmiQDn0o9yncyCPn0mpHJuLgFQKflstI4dLVCo01U7U1X3/7M4jpfg==}
     engines: {node: '>=20'}
 
   '@zachleat/heading-anchors@1.0.5':
@@ -8068,7 +8068,7 @@ snapshots:
       loupe: 3.1.3
       tinyrainbow: 2.0.0
 
-  '@vivliostyle/core@2.38.0':
+  '@vivliostyle/core@2.39.0':
     dependencies:
       fast-diff: 1.3.0
 
@@ -8143,9 +8143,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vivliostyle/viewer@2.38.0':
+  '@vivliostyle/viewer@2.39.0':
     dependencies:
-      '@vivliostyle/core': 2.38.0
+      '@vivliostyle/core': 2.39.0
       i18next-ko: 3.0.1
       knockout: 3.5.1
 


### PR DESCRIPTION
https://github.com/vivliostyle/vivliostyle.js/releases/tag/v2.39.0

### Features

- Support CSS :nth-child(An+B of S) selectors
- Support CSS :nth(An+B of C) page selector