### PR TITLE
fix: Do not call process.exit() inside 'exit' event handler

### DIFF
--- a/.changeset/fifty-trees-love.md
+++ b/.changeset/fifty-trees-love.md
@@ -1,0 +1,5 @@
+---
+'@vivliostyle/cli': patch
+---
+
+Do not call process.exit() inside 'exit' event handler

--- a/src/util.ts
+++ b/src/util.ts
@@ -83,7 +83,12 @@ exitSignals.forEach((sig) => {
       process.exitCode =
         exitCode !== undefined ? 128 + exitCode : Number(signal);
     }
-    process.exit();
+    // Only call process.exit() for signals, not for 'exit' event.
+    // Calling process.exit() inside 'exit' handler prevents other
+    // 'exit' listeners from being executed.
+    if (sig !== 'exit') {
+      process.exit();
+    }
   });
 });
 


### PR DESCRIPTION
`process.once('exit', () => { ... })`の内部で`process.exit()`を使用すると、`process.on('exit', ...)`で登録したハンドラーが実行されなくなるようです（Node.js 22, Linux）。vivliostyle.config.jsでexitハンドラーを登録しても実行されないことで気づきました。

```javascript
process.once('exit', () => {
  console.log('once exit handler');
  process.exit();
});

process.on('exit', () => {
  console.log('on exit handler');
});

console.log('main: done');

// main: done
// once exit handler

// 「on exit handler」が表示されない
```

なおSIGINT/SIGTERMについては修正不要です。

```javascript
process.once('SIGINT', () => {
  console.log('once SIGINT handler');
  process.exit();
});

process.on('exit', () => {
  console.log('on exit handler');
});

console.log('main: SIGINT');
process.emit('SIGINT');

throw new Error('this should not be reached');

// main: SIGINT
// once SIGINT handler
// on exit handler
```