### PR TITLE
fix: do not log ERROR for HTTP 3xx status codes

### DIFF
--- a/.changeset/green-beers-stick.md
+++ b/.changeset/green-beers-stick.md
@@ -1,0 +1,5 @@
+---
+'@vivliostyle/cli': patch
+---
+
+fix: do not log ERROR for HTTP 3xx status codes

--- a/src/output/pdf.ts
+++ b/src/output/pdf.ts
@@ -114,7 +114,7 @@ export async function buildPDF({
 
         handleEntry(response);
 
-        if (300 > response.status() && 200 <= response.status()) return;
+        if (400 > response.status() && 200 <= response.status()) return;
         // file protocol doesn't have status code
         if (response.url().startsWith('file://') && response.ok()) return;
 


### PR DESCRIPTION
HTTP 304 (Not Modified) and other 3xx responses are not errors,
so they should not be logged as ERROR during PDF build.

Fixes #711.