### PR TITLE
Fix behavior in non-interactive stdin environments on Windows

### DIFF
--- a/.changeset/smooth-carrots-push.md
+++ b/.changeset/smooth-carrots-push.md
@@ -1,0 +1,5 @@
+---
+'@vivliostyle/cli': patch
+---
+
+Fix behavior in non-interactive stdin environments on Windows

--- a/src/util.ts
+++ b/src/util.ts
@@ -14,7 +14,6 @@ import StreamZip from 'node-stream-zip';
 import childProcess, { type ExecFileOptions } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
-import readline from 'node:readline';
 import util from 'node:util';
 import { osLocale } from 'os-locale';
 import { titleCase } from 'title-case';
@@ -79,49 +78,27 @@ export async function runExitHandlers() {
   }
 }
 
-// Windows does not support SIGINT/SIGTERM signals natively, so only register 'exit'
-// On other platforms, register all signals
-const exitSignals =
-  process.platform === 'win32' ? ['exit'] : ['exit', 'SIGINT', 'SIGTERM'];
+let terminating = false;
 
-exitSignals.forEach((sig) => {
-  process.once(sig, async (signal?: string | number, exitCode?: number) => {
-    // For signals (not 'exit'), wait for handlers to complete
-    if (sig !== 'exit') {
+async function terminate(exitCode: number) {
+  if (terminating) return;
+  terminating = true;
+  try {
+    if (exitCode === 130 || exitCode === 143) {
       await runExitHandlers();
     } else {
-      // For 'exit' event, run handlers synchronously (non-blocking)
-      // as async operations cannot be awaited in 'exit' handler
-      void runExitHandlers();
+      runExitHandlers();
     }
-    if (process.exitCode === undefined) {
-      process.exitCode =
-        exitCode !== undefined ? 128 + exitCode : Number(signal);
-    }
-    // Only call process.exit() for signals, not for 'exit' event.
-    // Calling process.exit() inside 'exit' handler prevents other
-    // 'exit' listeners from being executed.
-    if (sig !== 'exit') {
-      process.exit();
-    }
-  });
-});
-
-if (process.platform === 'win32') {
-  // Windows does not support signals, so use readline interface
-  const rl = readline.createInterface({
-    input: process.stdin,
-    output: process.stdout,
-  });
-  rl.on('SIGINT', async () => {
-    await runExitHandlers();
-    // Exit code 130 = 128 + SIGINT (2)
-    process.exit(130);
-  });
-  registerExitHandler('Closing readline interface', () => {
-    rl.close();
-  });
+  } finally {
+    process.exit(exitCode);
+  }
 }
+
+process.once('SIGINT', () => void terminate(130));
+process.once('SIGTERM', () => void terminate(143));
+process.once('exit', (code) => {
+  void runExitHandlers();
+});
 
 export class DetailError extends Error {
   detail: string | undefined;


### PR DESCRIPTION
## Summary

This PR removes the Windows-specific `readline` workaround for `SIGINT` handling in `src/util.ts`.

In non-interactive Windows executions, creating a `readline.Interface` changes the stdin state and can immediately expose EOF on the child process stdin. That unexpected stdin state triggers premature shutdown behavior in downstream code, including Vite's preview-related logic.

## Changes

- remove the Windows-only `readline`-based `SIGINT` workaround
- use `process.once('SIGINT', ...)` and `process.once('SIGTERM', ...)` handlers on Windows
- keep running registered exit handlers so temporary resources and child processes are still cleaned up

## Testing

- `pnpm test`

Fixes #751
