### PR TITLE
Replace mupdf with @u1f992/mupdf to fix PDF name truncation (temporary until upstream 1.28.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "hastscript": "9.0.1",
     "lcid": "5.0.0",
     "mime-types": "3.0.1",
-    "mupdf": "1.26.4",
+    "mupdf": "npm:@u1f992/mupdf@1.27.0-patched.1",
     "node-fetch-native": "1.6.7",
     "node-stream-zip": "1.15.0",
     "npm-package-arg": "12.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,8 +102,8 @@ importers:
         specifier: 3.0.1
         version: 3.0.1
       mupdf:
-        specifier: 1.26.4
-        version: 1.26.4
+        specifier: npm:@u1f992/mupdf@1.27.0-patched.1
+        version: '@u1f992/mupdf@1.27.0-patched.1'
       node-fetch-native:
         specifier: 1.6.7
         version: 1.6.7
@@ -2121,6 +2121,9 @@ packages:
 
   '@types/yauzl@2.10.3':
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
+
+  '@u1f992/mupdf@1.27.0-patched.1':
+    resolution: {integrity: sha512-8M/9OteTc2ISddCin0VMojlHC3GJqnfjVm7A9HscyyTgO2jmE8aGRaSEe9pF/rJidoJ5mJR10sniouYGfgSvOQ==}
 
   '@ungap/structured-clone@1.2.0':
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
@@ -4359,9 +4362,6 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
-
-  mupdf@1.26.4:
-    resolution: {integrity: sha512-lv+0KCowetjXu/80h1WKDsELnvHvt7zAE4cs3TC92gwbbJk8AJifMpPLRHMWFovvsWXdFZ6KKCGRds3EzA9TlQ==}
 
   mustache@4.1.0:
     resolution: {integrity: sha512-0FsgP/WVq4mKyjolIyX+Z9Bd+3WS8GOwoUTyKXT5cTYMGeauNTi2HPCwERqseC1IHAy0Z7MDZnJBfjabd4O8GQ==}
@@ -8029,6 +8029,8 @@ snapshots:
       '@types/node': 22.15.2
     optional: true
 
+  '@u1f992/mupdf@1.27.0-patched.1': {}
+
   '@ungap/structured-clone@1.2.0': {}
 
   '@vitest/coverage-v8@3.1.2(vitest@3.1.2(@types/debug@4.1.12)(@types/node@22.15.2)(tsx@4.19.3)(yaml@2.8.1))':
@@ -10904,8 +10906,6 @@ snapshots:
   ms@2.0.0: {}
 
   ms@2.1.3: {}
-
-  mupdf@1.26.4: {}
 
   mustache@4.1.0: {}
 


### PR DESCRIPTION
refs: #732 

この問題はかなり深刻で、実際に書籍を制作した際に目次や索引が壊れるトラブルが発生しました。改善は1.27.x系には取り込まれず、1.28.x系で取り込まれるようです。MuPDFの平時のリリースサイクルだと1.28.0のリリースは2026年6月以降になると思われ、Wasmバインディングのnpm上での公開はさらに遅れるため、今年の後半まで問題が残ってしまいます。私が`@u1f992/mupdf`でパッチ版をリリースするのでしばらくの間これを使っていただくことは可能でしょうか。

https://github.com/ArtifexSoftware/mupdf/compare/master...u1f992:mupdf:patched-1.27.0

この形で問題なければ`@u1f992/mupdf`をリリースします。その後にVivliostyle CLIのビルドに問題ないか再確認してマージに進める流れになります。