### PR TITLE
feat: allow functions in overrideMap for programmatic color conversion

### DIFF
--- a/.changeset/eight-colors-convert.md
+++ b/.changeset/eight-colors-convert.md
@@ -1,0 +1,5 @@
+---
+"@vivliostyle/cli": minor
+---
+
+Allow functions in `cmyk.overrideMap`. A function entry receives each RGB color not covered by the static entries and returns the CMYK values to use, serving as a programmatic fallback.

--- a/.changeset/young-colors-blend.md
+++ b/.changeset/young-colors-blend.md
@@ -1,0 +1,5 @@
+---
+"@vivliostyle/cli": minor
+---
+
+Add `builtinCmykConversion`, `builtinGrayConversion`, and `iccConversion`, which return `cmyk.overrideMap` functions that convert colors using mupdf's built-in color spaces or an ICC profile.

--- a/docs/api-javascript.md
+++ b/docs/api-javascript.md
@@ -23,6 +23,7 @@
 
 ### Type Aliases
 
+- [`CmykConvertFunction`](#cmykconvertfunction)
 - [`Metadata`](#metadata)
 - [`ReplaceFunction`](#replacefunction)
 - [`StructuredDocument`](#structureddocument)
@@ -69,7 +70,7 @@ build({
 
 ###### cmyk?
 
-`boolean` \| \{ `ifUnmappedColorsFound?`: `"warn"` \| `"error"` \| `"ignore"`; `ifUnreplacedImagesFound?`: `"warn"` \| `"error"` \| `"ignore"`; `mapOutput?`: `string`; `overrideMap?`: \[`string` \| \{ `b`: `number`; `g`: `number`; `r`: `number`; \}, \{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \}\][]; `reserveMap?`: \[`string` \| \{ `b`: `number`; `g`: `number`; `r`: `number`; \}, \{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \}\][]; `warnUnmapped?`: `boolean`; \} = `CmykSchema`
+`boolean` \| \{ `ifUnmappedColorsFound?`: `"warn"` \| `"error"` \| `"ignore"`; `ifUnreplacedImagesFound?`: `"warn"` \| `"error"` \| `"ignore"`; `mapOutput?`: `string`; `overrideMap?`: (((`rgb`) => \{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \} \| `Promise`\<\{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \}\>) \| \[`string` \| \{ `b`: `number`; `g`: `number`; `r`: `number`; \}, \{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \}\])[]; `reserveMap?`: \[`string` \| \{ `b`: `number`; `g`: `number`; `r`: `number`; \}, \{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \}\][]; `warnUnmapped?`: `boolean`; \} = `CmykSchema`
 
 ###### config?
 
@@ -327,7 +328,7 @@ Scaffold a new Vivliostyle project.
 
 ###### cmyk?
 
-`boolean` \| \{ `ifUnmappedColorsFound?`: `"warn"` \| `"error"` \| `"ignore"`; `ifUnreplacedImagesFound?`: `"warn"` \| `"error"` \| `"ignore"`; `mapOutput?`: `string`; `overrideMap?`: \[`string` \| \{ `b`: `number`; `g`: `number`; `r`: `number`; \}, \{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \}\][]; `reserveMap?`: \[`string` \| \{ `b`: `number`; `g`: `number`; `r`: `number`; \}, \{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \}\][]; `warnUnmapped?`: `boolean`; \} = `CmykSchema`
+`boolean` \| \{ `ifUnmappedColorsFound?`: `"warn"` \| `"error"` \| `"ignore"`; `ifUnreplacedImagesFound?`: `"warn"` \| `"error"` \| `"ignore"`; `mapOutput?`: `string`; `overrideMap?`: (((`rgb`) => \{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \} \| `Promise`\<\{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \}\>) \| \[`string` \| \{ `b`: `number`; `g`: `number`; `r`: `number`; \}, \{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \}\])[]; `reserveMap?`: \[`string` \| \{ `b`: `number`; `g`: `number`; `r`: `number`; \}, \{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \}\][]; `warnUnmapped?`: `boolean`; \} = `CmykSchema`
 
 ###### config?
 
@@ -557,7 +558,7 @@ Scaffold a new Vivliostyle project.
 
 ###### cmyk?
 
-`boolean` \| \{ `ifUnmappedColorsFound?`: `"warn"` \| `"error"` \| `"ignore"`; `ifUnreplacedImagesFound?`: `"warn"` \| `"error"` \| `"ignore"`; `mapOutput?`: `string`; `overrideMap?`: \[`string` \| \{ `b`: `number`; `g`: `number`; `r`: `number`; \}, \{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \}\][]; `reserveMap?`: \[`string` \| \{ `b`: `number`; `g`: `number`; `r`: `number`; \}, \{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \}\][]; `warnUnmapped?`: `boolean`; \} = `CmykSchema`
+`boolean` \| \{ `ifUnmappedColorsFound?`: `"warn"` \| `"error"` \| `"ignore"`; `ifUnreplacedImagesFound?`: `"warn"` \| `"error"` \| `"ignore"`; `mapOutput?`: `string`; `overrideMap?`: (((`rgb`) => \{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \} \| `Promise`\<\{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \}\>) \| \[`string` \| \{ `b`: `number`; `g`: `number`; `r`: `number`; \}, \{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \}\])[]; `reserveMap?`: \[`string` \| \{ `b`: `number`; `g`: `number`; `r`: `number`; \}, \{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \}\][]; `warnUnmapped?`: `boolean`; \} = `CmykSchema`
 
 ###### config?
 
@@ -830,7 +831,7 @@ Open a browser for previewing the publication.
 
 ###### cmyk?
 
-`boolean` \| \{ `ifUnmappedColorsFound?`: `"warn"` \| `"error"` \| `"ignore"`; `ifUnreplacedImagesFound?`: `"warn"` \| `"error"` \| `"ignore"`; `mapOutput?`: `string`; `overrideMap?`: \[`string` \| \{ `b`: `number`; `g`: `number`; `r`: `number`; \}, \{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \}\][]; `reserveMap?`: \[`string` \| \{ `b`: `number`; `g`: `number`; `r`: `number`; \}, \{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \}\][]; `warnUnmapped?`: `boolean`; \} = `CmykSchema`
+`boolean` \| \{ `ifUnmappedColorsFound?`: `"warn"` \| `"error"` \| `"ignore"`; `ifUnreplacedImagesFound?`: `"warn"` \| `"error"` \| `"ignore"`; `mapOutput?`: `string`; `overrideMap?`: (((`rgb`) => \{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \} \| `Promise`\<\{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \}\>) \| \[`string` \| \{ `b`: `number`; `g`: `number`; `r`: `number`; \}, \{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \}\])[]; `reserveMap?`: \[`string` \| \{ `b`: `number`; `g`: `number`; `r`: `number`; \}, \{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \}\][]; `warnUnmapped?`: `boolean`; \} = `CmykSchema`
 
 ###### config?
 
@@ -1138,7 +1139,7 @@ interface to the schema, so a drift in either direction is rejected.
 | `browser.tag?` | `string` |
 | `browser.type` | `"chrome"` \| `"chromium"` \| `"firefox"` |
 | <a id="property-cliversion"></a> `cliVersion` | `string` |
-| <a id="property-cmyk"></a> `cmyk?` | `boolean` \| \{ `ifUnmappedColorsFound?`: `"warn"` \| `"error"` \| `"ignore"`; `ifUnreplacedImagesFound?`: `"warn"` \| `"error"` \| `"ignore"`; `mapOutput?`: `string`; `overrideMap?`: \[`string` \| \{ `b`: `number`; `g`: `number`; `r`: `number`; \}, \{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \}\][]; `reserveMap?`: \[`string` \| \{ `b`: `number`; `g`: `number`; `r`: `number`; \}, \{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \}\][]; `warnUnmapped?`: `boolean`; \} |
+| <a id="property-cmyk"></a> `cmyk?` | `boolean` \| \{ `ifUnmappedColorsFound?`: `"warn"` \| `"error"` \| `"ignore"`; `ifUnreplacedImagesFound?`: `"warn"` \| `"error"` \| `"ignore"`; `mapOutput?`: `string`; `overrideMap?`: (((`rgb`) => \{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \} \| `Promise`\<\{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \}\>) \| \[`string` \| \{ `b`: `number`; `g`: `number`; `r`: `number`; \}, \{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \}\])[]; `reserveMap?`: \[`string` \| \{ `b`: `number`; `g`: `number`; `r`: `number`; \}, \{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \}\][]; `warnUnmapped?`: `boolean`; \} |
 | <a id="property-config"></a> `config?` | `string` |
 | <a id="property-configdata"></a> `configData?` | [`VivliostyleConfigSchema`](#vivliostyleconfigschema) \| `null` |
 | <a id="property-coreversion"></a> `coreVersion` | `string` |
@@ -1195,6 +1196,32 @@ interface to the schema, so a drift in either direction is rejected.
 | <a id="property-viteconfigfile"></a> `viteConfigFile?` | `string` \| `boolean` |
 
 ## Type Aliases
+
+### CmykConvertFunction
+
+> **CmykConvertFunction** = (`rgb`) => `CMYKValue` \| `Promise`\<`CMYKValue`\>
+
+#### Parameters
+
+##### rgb
+
+###### b
+
+`number`
+
+###### g
+
+`number`
+
+###### r
+
+`number`
+
+#### Returns
+
+`CMYKValue` \| `Promise`\<`CMYKValue`\>
+
+***
 
 ### Metadata
 

--- a/docs/api-javascript.md
+++ b/docs/api-javascript.md
@@ -6,11 +6,14 @@
 ### Functions
 
 - [`build`](#build)
+- [`builtinCmykConversion`](#builtincmykconversion)
 - [`builtinCmykReplacement`](#builtincmykreplacement)
+- [`builtinGrayConversion`](#builtingrayconversion)
 - [`builtinGrayReplacement`](#builtingrayreplacement)
 - [`create`](#create)
 - [`createVitePlugin`](#createviteplugin)
 - [`defineConfig`](#defineconfig)
+- [`iccConversion`](#iccconversion)
 - [`iccReplacement`](#iccreplacement)
 - [`preview`](#preview)
 - [`VFM`](#vfm)
@@ -278,6 +281,19 @@ build({
 
 ***
 
+### builtinCmykConversion()
+
+> **builtinCmykConversion**(): [`CmykConvertFunction`](#cmykconvertfunction)
+
+Returns a CmykConvertFunction for cmyk.overrideMap that converts RGB colors
+to CMYK using mupdf's DeviceCMYK color space.
+
+#### Returns
+
+[`CmykConvertFunction`](#cmykconvertfunction)
+
+***
+
 ### builtinCmykReplacement()
 
 > **builtinCmykReplacement**(): [`ReplaceFunction`](#replacefunction)
@@ -288,6 +304,19 @@ using mupdf's DeviceCMYK color space.
 #### Returns
 
 [`ReplaceFunction`](#replacefunction)
+
+***
+
+### builtinGrayConversion()
+
+> **builtinGrayConversion**(): [`CmykConvertFunction`](#cmykconvertfunction)
+
+Returns a CmykConvertFunction for cmyk.overrideMap that converts RGB colors
+to grayscale, mapped to the K channel.
+
+#### Returns
+
+[`CmykConvertFunction`](#cmykconvertfunction)
 
 ***
 
@@ -781,6 +810,28 @@ Define the configuration for Vivliostyle CLI.
 #### Returns
 
 [`VivliostyleConfigSchema`](#vivliostyleconfigschema)
+
+***
+
+### iccConversion()
+
+> **iccConversion**(`outputProfile`): [`CmykConvertFunction`](#cmykconvertfunction)
+
+Returns a CmykConvertFunction for cmyk.overrideMap that converts RGB colors
+through the given ICC profile. The profile alone determines the conversion;
+the profile data is passed to mupdf without inspection. Profiles whose data
+color space is CMYK yield full CMYK values, and grayscale profiles are
+mapped to the K channel.
+
+#### Parameters
+
+##### outputProfile
+
+`Uint8Array`
+
+#### Returns
+
+[`CmykConvertFunction`](#cmykconvertfunction)
 
 ***
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -462,9 +462,9 @@ type PdfPostprocessConfig = {
 
 - `CmykConfig`
 
-  - `overrideMap`: ("{tuple(Array)}")[]  
+  - `overrideMap`: ("{tuple(Array)}" | ((rgb: { r: number; g: number; b: number }) => { c: number; m: number; y: number; k: number } | Promise<{ c: number; m: number; y: number; k: number }>))[]  
     Custom RGB to CMYK color mapping.
-    Each entry is a tuple of [rgb, {c, m, y, k}].
+    Each entry is either a tuple of [rgb, {c, m, y, k}] or a function that converts unmapped RGB colors to CMYK (used as a fallback).
     RGB can be an object {r, g, b} with integers (0-10000) or a hex color string (e.g. "#ff0000").
 
   - `reserveMap`: ("{tuple(Array)}")[]  
@@ -492,7 +492,26 @@ type PdfPostprocessConfig = {
 
 ```ts
 type CmykConfig = {
-  overrideMap?: "{tuple(Array)}"[];
+  overrideMap?: (
+    | "{tuple(Array)}"
+    | ((rgb: {
+        r: number;
+        g: number;
+        b: number;
+      }) =>
+        | {
+            c: number;
+            m: number;
+            y: number;
+            k: number;
+          }
+        | Promise<{
+            c: number;
+            m: number;
+            y: number;
+            k: number;
+          }>)
+  )[];
   reserveMap?: "{tuple(Array)}"[];
   warnUnmapped?: boolean;
   ifUnmappedColorsFound?:

--- a/examples/cmyk/README.md
+++ b/examples/cmyk/README.md
@@ -48,17 +48,23 @@ A `ReplaceFunction` can also be used as the `replacement` in a `{ source, replac
 
 `builtinCmykReplacement()` and `builtinGrayReplacement()` return `ReplaceFunction` implementations that convert RGB images to CMYK or grayscale using mupdf's built-in color spaces. For profile-based conversion, `iccReplacement()` takes ICC profile data (as `Uint8Array`) and converts RGB images to the color space of that profile. The conversion applies to pixel values only; the replaced image is stored with mupdf's default profile for the resulting color space, not with the given profile.
 
+## `cmyk.overrideMap`
+
+This CMYK feature assumes that you are aware of and in control of every colored element in your document. For complex documents, that may not always be the case. `cmyk.overrideMap` is a last resort for keeping the output fully CMYK: it forcibly replaces any remaining RGB values in the PDF with the specified CMYK values.
+
+Building this example produces unmapped color warnings from the `<hr>` element in the footnote section (`#2b2b2b`, `#9a9a9a`, `#eeeeee`). The correct fix would be to style `hr` with `device-cmyk()`, but here we use `cmyk.overrideMap` to replace these colors, as shown in the example config.
+
+Like `replaceImage`, `cmyk.overrideMap` also accepts functions, which are tried in order for colors not covered by the static entries. `builtinCmykConversion()` and `builtinGrayConversion()` are provided for automatic conversion, and `iccConversion()` converts colors through an ICC profile.
+
+These functions make it possible to produce a CMYK PDF without any explicit `device-cmyk()` declarations, but you should not do this. What print actually requires is a PDF with an output intent (which is why PDF/X-4 can accept RGB PDFs in the first place). If you are going to run automatic CMYK conversion, you would cause fewer problems by submitting the RGB PDF directly to the print shop. Chromium's PDFs do not carry an output intent, but treating them as sRGB is good enough. In any case, `cmyk.overrideMap` is a tool for assisting intentional CMYK workflows, not for converting everything automatically.
+
 ## Other options
 
 By design, this feature cannot produce PDFs that freely mix RGB and CMYK colors (more precisely, it can produce a PDF with unconverted RGB values left in place, but it cannot guarantee that arbitrary RGB and CMYK values will coexist correctly). Since stray RGB elements are usually undesirable in a CMYK workflow, `cmyk.ifUnmappedColorsFound` (default: `'warn'`) logs a warning for RGB colors in content streams that have not been mapped to CMYK; set it to `'error'` to fail the build instead, or `'ignore'` to do nothing.
 
 Similarly, `cmyk.ifUnreplacedImagesFound` (default: `'warn'`) reports any non-CMYK image remaining in the PDF after image replacement.
 
-Building this example produces unmapped color warnings from the `<hr>` element in the footnote section (`#2b2b2b`, `#9a9a9a`, `#eeeeee`). The correct fix would be to style `hr` with `device-cmyk()`, but here we use `cmyk.overrideMap` to demonstrate how to forcibly replace unmapped RGB colors with CMYK values and keep the output fully CMYK.
-
-This CMYK feature assumes that you are aware of and in control of every colored element in your document. For complex documents, that may not always be the case. `cmyk.overrideMap` is a last resort for silencing unmapped color warnings: it forcibly replaces any remaining RGB values in the PDF with the specified CMYK values.
-
-`mapOutput` is primarily a debugging tool. It writes the internal color mapping table to a file.
+`cmyk.mapOutput` is primarily a debugging tool. It writes the internal color mapping table to a file.
 
 ```shellsession
 $ npm run build && gs -dQUIET -dBATCH -dNOPAUSE -sOutputFile=- -sDEVICE=ink_cov output.pdf

--- a/src/config/replace-image.ts
+++ b/src/config/replace-image.ts
@@ -17,3 +17,11 @@ export interface ReplaceImageEntry {
 
 export type ReplaceImageConfigItem = ReplaceImageEntry | ReplaceFunction;
 export type ReplaceImageConfig = ReplaceImageConfigItem[];
+
+export type CmykConvertFunction = (rgb: {
+  r: number;
+  g: number;
+  b: number;
+}) =>
+  | import('../global-viewer.js').CMYKValue
+  | Promise<import('../global-viewer.js').CMYKValue>;

--- a/src/config/resolve.ts
+++ b/src/config/resolve.ts
@@ -54,10 +54,13 @@ import {
   touchTmpFile,
 } from '../util.js';
 import type {
+  CmykConvertFunction,
   ReplaceFunction,
   ReplaceImageConfig,
   ReplaceImageConfigItem,
 } from './replace-image.js';
+
+export type { CmykConvertFunction } from './replace-image.js';
 import type { InlineOptions, ParsedBuildTask } from './schema.js';
 
 export type ParsedTheme = UriTheme | FileTheme | PackageTheme;
@@ -268,7 +271,7 @@ function resolveMapEntries(
 export interface CmykConfig {
   ifUnmappedColorsFound: 'warn' | 'error' | 'ignore';
   ifUnreplacedImagesFound: 'warn' | 'error' | 'ignore';
-  overrideMap: CmykMapEntry[];
+  overrideMap: (CmykMapEntry | CmykConvertFunction)[];
   reserveMap: CmykMapEntry[];
   mapOutput: string | undefined;
 }
@@ -702,7 +705,10 @@ export function resolveTaskConfig(
             // oxlint-disable-next-line typescript/no-deprecated -- fall back to the deprecated warnUnmapped option
             (cmykOption.warnUnmapped === false ? 'ignore' : 'warn'),
           ifUnreplacedImagesFound: cmykOption.ifUnreplacedImagesFound ?? 'warn',
-          overrideMap: resolveMapEntries(cmykOption.overrideMap ?? []),
+          overrideMap: (cmykOption.overrideMap ?? []).flatMap(
+            (item): (CmykMapEntry | CmykConvertFunction)[] =>
+              typeof item === 'function' ? [item] : resolveMapEntries([item]),
+          ),
           reserveMap: resolveMapEntries(cmykOption.reserveMap ?? []),
           mapOutput: cmykOption.mapOutput
             ? upath.resolve(context, cmykOption.mapOutput)

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -279,14 +279,32 @@ const CMYKValueSchema = v.pipe(
 
 const CmykMapEntrySchema = v.tuple([RGBValueSchema, CMYKValueSchema]);
 
+const CmykConvertFunctionSchema = v.pipe(
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- valibot's v.function() cannot express the CmykConvertFunction signature
+  v.function() as v.GenericSchema<
+    (rgb: {
+      r: number;
+      g: number;
+      b: number;
+    }) =>
+      | { c: number; m: number; y: number; k: number }
+      | Promise<{ c: number; m: number; y: number; k: number }>
+  >,
+  v.metadata({
+    typeString:
+      '((rgb: { r: number; g: number; b: number }) => { c: number; m: number; y: number; k: number } | Promise<{ c: number; m: number; y: number; k: number }>)',
+  }),
+  v.description('Function that converts any unmapped RGB color to CMYK.'),
+);
+
 const CmykConfigSchema = v.pipe(
   v.partial(
     v.object({
       overrideMap: v.pipe(
-        v.array(CmykMapEntrySchema),
+        v.array(v.union([CmykMapEntrySchema, CmykConvertFunctionSchema])),
         v.description($`
           Custom RGB to CMYK color mapping.
-          Each entry is a tuple of [rgb, {c, m, y, k}].
+          Each entry is either a tuple of [rgb, {c, m, y, k}] or a function that converts unmapped RGB colors to CMYK (used as a fallback).
           RGB can be an object {r, g, b} with integers (0-10000) or a hex color string (e.g. "#ff0000").
         `),
       ),

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,8 +27,11 @@ export type {
 } from './config/replace-image.js';
 export type { TemplateVariable } from './create-template.js';
 export {
+  builtinCmykConversion,
   builtinCmykReplacement,
+  builtinGrayConversion,
   builtinGrayReplacement,
+  iccConversion,
   iccReplacement,
 } from './output/image.js';
 export { createVitePlugin } from './vite-adapter.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,11 @@ export type {
   VivliostyleConfigSchema,
   VivliostylePackageMetadata,
 } from './config/schema.js';
-export type { ImageContext, ReplaceFunction } from './config/replace-image.js';
+export type {
+  CmykConvertFunction,
+  ImageContext,
+  ReplaceFunction,
+} from './config/replace-image.js';
 export type { TemplateVariable } from './create-template.js';
 export {
   builtinCmykReplacement,

--- a/src/output/cmyk.ts
+++ b/src/output/cmyk.ts
@@ -1,8 +1,10 @@
 import type * as mupdfType from 'mupdf';
 
-import type { CmykMap } from '../global-viewer.js';
 import { importNodeModule } from '../node-modules.js';
-import { convertStreamColors } from './pdf-stream.js';
+import {
+  type InternalColorConverter,
+  convertStreamColors,
+} from './pdf-stream.js';
 
 interface Destroyable {
   destroy(): void;
@@ -16,40 +18,46 @@ function disposable<T extends Destroyable>(obj: T): T & Disposable {
   });
 }
 
-function processStream(
+async function processStream(
   stream: mupdfType.PDFObject,
-  colorMap: CmykMap,
+  convert: InternalColorConverter,
   unmappedColors: Set<string> | null,
   mupdf: typeof import('mupdf'),
-): void {
+): Promise<void> {
   const buffer = stream.readStream();
   const content = buffer.asString();
-  const converted = convertStreamColors(content, colorMap, unmappedColors);
+  const converted = await convertStreamColors(content, convert, unmappedColors);
   stream.writeStream(new mupdf.Buffer(converted));
 }
 
-function processFormXObjects(
+async function processFormXObjects(
   resources: mupdfType.PDFObject,
-  colorMap: CmykMap,
+  convert: InternalColorConverter,
   unmappedColors: Set<string> | null,
   mupdf: typeof import('mupdf'),
   processed: Set<number>,
-): void {
+): Promise<void> {
   const xobjects = resources.get('XObject');
   if (!xobjects || !xobjects.isDictionary()) {
     return;
   }
 
+  // Collect entries first because forEach callbacks cannot await
+  const entries: mupdfType.PDFObject[] = [];
   xobjects.forEach((xobj) => {
+    entries.push(xobj);
+  });
+
+  for (const xobj of entries) {
     if (!xobj || !xobj.isStream()) {
-      return;
+      continue;
     }
 
     // Use original indirect reference for stream operations (see #735)
     const objNum = xobj.asIndirect();
     if (objNum && processed.has(objNum)) {
       // Avoid circular references
-      return;
+      continue;
     }
     if (objNum) {
       processed.add(objNum);
@@ -57,51 +65,77 @@ function processFormXObjects(
 
     const subtype = xobj.get('Subtype');
     if (!subtype || subtype.toString() !== '/Form') {
-      return;
+      continue;
     }
 
-    processStream(xobj, colorMap, unmappedColors, mupdf);
+    await processStream(xobj, convert, unmappedColors, mupdf);
     const nestedResources = xobj.get('Resources');
     if (nestedResources && nestedResources.isDictionary()) {
-      processFormXObjects(
+      await processFormXObjects(
         nestedResources,
-        colorMap,
+        convert,
         unmappedColors,
         mupdf,
         processed,
       );
     }
-  });
+  }
 }
 
-function processContents(
+async function processContents(
   contents: mupdfType.PDFObject,
-  colorMap: CmykMap,
+  convert: InternalColorConverter,
   unmappedColors: Set<string> | null,
   mupdf: typeof import('mupdf'),
-): void {
+): Promise<void> {
   if (contents.isArray()) {
     // Multiple content streams
     for (let i = 0; i < contents.length; i++) {
       const streamObj = contents.get(i);
       // Use original indirect reference for stream operations (see #735)
       if (streamObj && streamObj.isStream()) {
-        processStream(streamObj, colorMap, unmappedColors, mupdf);
+        await processStream(streamObj, convert, unmappedColors, mupdf);
       }
     }
   } else if (contents.isStream()) {
     // Single content stream
-    processStream(contents, colorMap, unmappedColors, mupdf);
+    await processStream(contents, convert, unmappedColors, mupdf);
+  }
+}
+
+async function processAppearanceStreams(
+  appearance: mupdfType.PDFObject,
+  convert: InternalColorConverter,
+  unmappedColors: Set<string> | null,
+  mupdf: typeof import('mupdf'),
+): Promise<void> {
+  if (appearance.isStream()) {
+    await processStream(appearance, convert, unmappedColors, mupdf);
+    return;
+  }
+  if (!appearance.isDictionary()) {
+    return;
+  }
+  // Multiple appearance states
+  // Collect entries first because forEach callbacks cannot await
+  const states: mupdfType.PDFObject[] = [];
+  appearance.forEach((val) => {
+    states.push(val);
+  });
+  for (const val of states) {
+    if (val?.isStream()) {
+      await processStream(val, convert, unmappedColors, mupdf);
+    }
   }
 }
 
 export async function convertCmykColors({
   pdf,
-  colorMap,
+  convert,
   unmappedColors,
 }: {
   pdf: Uint8Array;
-  colorMap: CmykMap;
+  convert: InternalColorConverter;
   unmappedColors: Set<string> | null;
 }): Promise<Uint8Array> {
   const mupdf = await importNodeModule('mupdf');
@@ -117,19 +151,19 @@ export async function convertCmykColors({
 
   const pageCount = doc.countPages();
   for (let i = 0; i < pageCount; i++) {
-    const page = doc.loadPage(i);
+    using page = disposable(doc.loadPage(i));
     const pageObj = page.getObject().resolve();
 
     const contents = pageObj.get('Contents');
     if (contents) {
-      processContents(contents, colorMap, unmappedColors, mupdf);
+      await processContents(contents, convert, unmappedColors, mupdf);
     }
 
     const resources = pageObj.get('Resources');
     if (resources && resources.isDictionary()) {
-      processFormXObjects(
+      await processFormXObjects(
         resources,
-        colorMap,
+        convert,
         unmappedColors,
         mupdf,
         processedXObjects,
@@ -155,16 +189,7 @@ export async function convertCmykColors({
       if (!n) {
         continue;
       }
-      if (n.isStream()) {
-        processStream(n, colorMap, unmappedColors, mupdf);
-      } else if (n.isDictionary()) {
-        // Multiple appearance states
-        n.forEach((val) => {
-          if (val?.isStream()) {
-            processStream(val, colorMap, unmappedColors, mupdf);
-          }
-        });
-      }
+      await processAppearanceStreams(n, convert, unmappedColors, mupdf);
     }
   }
 

--- a/src/output/image.ts
+++ b/src/output/image.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import type * as mupdfType from 'mupdf';
 
 import type {
+  CmykConvertFunction,
   ImageContext,
   ReplaceFunction,
   ReplaceImageConfig,
@@ -226,6 +227,74 @@ export function builtinGrayReplacement(): ReplaceFunction {
  */
 export function iccReplacement(outputProfile: Uint8Array): ReplaceFunction {
   return (image) => convertWithICC(image.asPNG(), outputProfile);
+}
+
+function createColorConversion(
+  replaceFn: ReplaceFunction,
+): CmykConvertFunction {
+  return async (rgb) => {
+    const mupdf = await importNodeModule('mupdf');
+    using pixmap = disposable(
+      new mupdf.Pixmap(mupdf.ColorSpace.DeviceRGB, [0, 0, 1, 1], false),
+    );
+    const pixels = pixmap.getPixels();
+    pixels[0] = Math.round((rgb.r / 10000) * 255);
+    pixels[1] = Math.round((rgb.g / 10000) * 255);
+    pixels[2] = Math.round((rgb.b / 10000) * 255);
+
+    const resultBytes = await replaceFn(createImageContext(pixmap));
+
+    using resultImage = disposable(new mupdf.Image(resultBytes));
+    using resultPixmap = disposable(resultImage.toPixmap());
+    const colorSpace = resultPixmap.getColorSpace();
+    const resultPixels = resultPixmap.getPixels();
+    if (colorSpace?.isCMYK()) {
+      return {
+        c: Math.round((resultPixels[0] / 255) * 10000),
+        m: Math.round((resultPixels[1] / 255) * 10000),
+        y: Math.round((resultPixels[2] / 255) * 10000),
+        k: Math.round((resultPixels[3] / 255) * 10000),
+      };
+    }
+    if (colorSpace?.isGray()) {
+      return {
+        c: 0,
+        m: 0,
+        y: 0,
+        k: Math.round(((255 - resultPixels[0]) / 255) * 10000),
+      };
+    }
+    throw new Error(
+      `Cannot derive CMYK values from a ${String(colorSpace)} image`,
+    );
+  };
+}
+
+/**
+ * Returns a CmykConvertFunction for cmyk.overrideMap that converts RGB colors
+ * to CMYK using mupdf's DeviceCMYK color space.
+ */
+export function builtinCmykConversion(): CmykConvertFunction {
+  return createColorConversion(builtinCmykReplacement());
+}
+
+/**
+ * Returns a CmykConvertFunction for cmyk.overrideMap that converts RGB colors
+ * to grayscale, mapped to the K channel.
+ */
+export function builtinGrayConversion(): CmykConvertFunction {
+  return createColorConversion(builtinGrayReplacement());
+}
+
+/**
+ * Returns a CmykConvertFunction for cmyk.overrideMap that converts RGB colors
+ * through the given ICC profile. The profile alone determines the conversion;
+ * the profile data is passed to mupdf without inspection. Profiles whose data
+ * color space is CMYK yield full CMYK values, and grayscale profiles are
+ * mapped to the K channel.
+ */
+export function iccConversion(outputProfile: Uint8Array): CmykConvertFunction {
+  return createColorConversion(iccReplacement(outputProfile));
 }
 
 export interface NonCmykImage {

--- a/src/output/pdf-postprocess.ts
+++ b/src/output/pdf-postprocess.ts
@@ -22,6 +22,12 @@ import {
 } from '../util.js';
 import { convertCmykColors } from './cmyk.js';
 import { findNonCmykImages, replaceImages } from './image.js';
+import {
+  type InternalColorConverter,
+  composeColorConverters,
+  guardConvertFunction,
+  mapToConverter,
+} from './pdf-stream.js';
 
 export type SaveOption = Pick<
   PdfOutput,
@@ -126,18 +132,25 @@ export class PostProcess {
 
     const failures: string[] = [];
     if (cmyk) {
+      const converters: InternalColorConverter[] = [];
       const mergedMap: CmykMap = { ...cmykMap };
-      for (const [rgb, cmykValue] of cmyk.overrideMap) {
+      for (const item of cmyk.overrideMap) {
+        if (typeof item === 'function') {
+          converters.push(guardConvertFunction(item));
+          continue;
+        }
+        const [rgb, cmykValue] = item;
         const key = JSON.stringify([rgb.r, rgb.g, rgb.b]);
         mergedMap[key] = cmykValue;
       }
+      converters.unshift(mapToConverter(mergedMap));
 
       Logger.logInfo('Converting CMYK colors');
       const unmappedColors =
         cmyk.ifUnmappedColorsFound === 'ignore' ? null : new Set<string>();
       pdf = await convertCmykColors({
         pdf,
-        colorMap: mergedMap,
+        convert: composeColorConverters(converters),
         unmappedColors,
       });
       if (unmappedColors) {

--- a/src/output/pdf-stream.ts
+++ b/src/output/pdf-stream.ts
@@ -1,4 +1,6 @@
-import type { CmykMap } from '../global-viewer.js';
+import type { CmykConvertFunction, RGBValue } from '../config/resolve.js';
+import type { CMYKValue, CmykMap } from '../global-viewer.js';
+import { Logger } from '../logger.js';
 
 /**
  * `SRGBValue.MAX`
@@ -174,28 +176,66 @@ function* tokenize(content: string): Generator<Token> {
   }
 }
 
-function formatRgbKey(r: number, g: number, b: number): string {
-  const ri = Math.round(r * SRGB_MAX);
-  const gi = Math.round(g * SRGB_MAX);
-  const bi = Math.round(b * SRGB_MAX);
-  return JSON.stringify([ri, gi, bi]);
+/**
+ * Converts an RGB color to CMYK, or returns null when it does not handle the
+ * color so that the next converter in the chain is tried.
+ */
+export type InternalColorConverter = (
+  rgb: RGBValue,
+) => CMYKValue | null | Promise<CMYKValue | null>;
+
+export function mapToConverter(map: CmykMap): InternalColorConverter {
+  return (rgb) => map[JSON.stringify([rgb.r, rgb.g, rgb.b])] ?? null;
 }
 
-function formatUnmappedRgbKey(r: number, g: number, b: number): string {
-  const ri = Math.round(r * SRGB_MAX);
-  const gi = Math.round(g * SRGB_MAX);
-  const bi = Math.round(b * SRGB_MAX);
-  return JSON.stringify({ r: ri, g: gi, b: bi });
+export function guardConvertFunction(
+  fn: CmykConvertFunction,
+): InternalColorConverter {
+  const warnedErrors = new Set<string>();
+  return async (rgb) => {
+    try {
+      return await fn(rgb);
+    } catch (error) {
+      const message = String(error);
+      if (!warnedErrors.has(message)) {
+        warnedErrors.add(message);
+        Logger.logWarn(`Failed to apply overrideMap function: ${message}`);
+      }
+      return null;
+    }
+  };
+}
+
+export function composeColorConverters(
+  converters: InternalColorConverter[],
+): InternalColorConverter {
+  const cache = new Map<string, CMYKValue | null>();
+  return async (rgb) => {
+    const key = JSON.stringify([rgb.r, rgb.g, rgb.b]);
+    const cached = cache.get(key);
+    if (cached !== undefined || cache.has(key)) {
+      return cached ?? null;
+    }
+    let result: CMYKValue | null = null;
+    for (const convert of converters) {
+      result = await convert(rgb);
+      if (result !== null) {
+        break;
+      }
+    }
+    cache.set(key, result);
+    return result;
+  };
 }
 
 /**
  * Convert RGB color operators to CMYK in a content stream
  */
-export function convertStreamColors(
+export async function convertStreamColors(
   content: string,
-  colorMap: CmykMap,
+  convert: InternalColorConverter,
   unmappedColors: Set<string> | null,
-): string {
+): Promise<string> {
   const result: string[] = [];
   const pendingNumbers: { value: number; raw: string }[] = [];
 
@@ -206,10 +246,10 @@ export function convertStreamColors(
     pendingNumbers.length = 0;
   };
 
-  const convertRgbOperator = (
+  const convertRgbOperator = async (
     cmykOp: 'k' | 'K',
     token: OperatorToken,
-  ): void => {
+  ): Promise<void> => {
     const b = pendingNumbers.pop();
     const g = pendingNumbers.pop();
     const r = pendingNumbers.pop();
@@ -219,8 +259,12 @@ export function convertStreamColors(
     }
     flushPendingNumbers();
 
-    const key = formatRgbKey(r.value, g.value, b.value);
-    const cmyk = colorMap[key];
+    const rgb: RGBValue = {
+      r: Math.round(r.value * SRGB_MAX),
+      g: Math.round(g.value * SRGB_MAX),
+      b: Math.round(b.value * SRGB_MAX),
+    };
+    const cmyk = await convert(rgb);
 
     if (cmyk) {
       const c = (cmyk.c / CMYK_MAX).toString();
@@ -231,7 +275,7 @@ export function convertStreamColors(
       return;
     }
     result.push(r.raw, g.raw, b.raw, token.raw);
-    unmappedColors?.add(formatUnmappedRgbKey(r.value, g.value, b.value));
+    unmappedColors?.add(JSON.stringify(rgb));
   };
 
   for (const token of tokenize(content)) {
@@ -243,7 +287,7 @@ export function convertStreamColors(
       // RGB color: r g b rg (non-stroking) or r g b RG (stroking)
       const cmykOp = op === 'rg' ? 'k' : op === 'RG' ? 'K' : null;
       if (cmykOp && pendingNumbers.length >= 3) {
-        convertRgbOperator(cmykOp, token);
+        await convertRgbOperator(cmykOp, token);
       } else {
         flushPendingNumbers();
         result.push(token.raw);

--- a/tests/cmyk.test.ts
+++ b/tests/cmyk.test.ts
@@ -5,6 +5,10 @@ import { describe, expect, it } from 'vitest';
 
 import type { CmykMap } from '../src/global-viewer.js';
 import { convertCmykColors } from '../src/output/cmyk.js';
+import {
+  composeColorConverters,
+  mapToConverter,
+} from '../src/output/pdf-stream.js';
 
 const fixturesDir = path.join(import.meta.dirname, 'fixtures', 'cmyk');
 
@@ -90,7 +94,7 @@ describe('convertCmykColors', () => {
 
     const destPdf = await convertCmykColors({
       pdf: srcPdf,
-      colorMap,
+      convert: mapToConverter(colorMap),
       unmappedColors: null,
     });
 
@@ -116,7 +120,7 @@ describe('convertCmykColors', () => {
     // This should not throw "object is not a stream" error
     const destPdf = await convertCmykColors({
       pdf: srcPdf,
-      colorMap,
+      convert: mapToConverter(colorMap),
       unmappedColors: null,
     });
 
@@ -130,7 +134,7 @@ describe('convertCmykColors', () => {
     const unmappedColors = new Set<string>();
     await convertCmykColors({
       pdf: srcPdf,
-      colorMap: {},
+      convert: mapToConverter({}),
       unmappedColors,
     });
 
@@ -144,13 +148,64 @@ describe('convertCmykColors', () => {
     }
   });
 
+  it('converts colors using a converter function fallback', async () => {
+    const srcPdf = fs.readFileSync(path.join(fixturesDir, 'text.pdf'));
+
+    const srcContents = await extractPdfContentStream(srcPdf);
+    expect(srcContents.some((content) => containsRgbOperators(content))).toBe(
+      true,
+    );
+
+    const destPdf = await convertCmykColors({
+      pdf: srcPdf,
+      convert: () => ({ c: 0, m: 0, y: 0, k: 10000 }),
+      unmappedColors: null,
+    });
+
+    const destContents = await extractPdfContentStream(destPdf);
+    expect(destContents.some((content) => containsCmykOperators(content))).toBe(
+      true,
+    );
+    expect(destContents.some((content) => containsRgbOperators(content))).toBe(
+      false,
+    );
+  });
+
+  it('lets static map entries take priority over function fallback', async () => {
+    const srcPdf = fs.readFileSync(path.join(fixturesDir, 'text.pdf'));
+
+    const staticCmyk = { c: 0, m: 0, y: 0, k: 10000 };
+    const fallbackCmyk = { c: 5000, m: 5000, y: 5000, k: 0 };
+    const seenByFallback: string[] = [];
+    const destPdf = await convertCmykColors({
+      pdf: srcPdf,
+      convert: composeColorConverters([
+        mapToConverter({ '[0,0,0]': staticCmyk }),
+        (rgb) => {
+          seenByFallback.push(JSON.stringify([rgb.r, rgb.g, rgb.b]));
+          return fallbackCmyk;
+        },
+      ]),
+      unmappedColors: null,
+    });
+
+    expect(seenByFallback).not.toContain('[0,0,0]');
+    const destContents = await extractPdfContentStream(destPdf);
+    expect(destContents.some((content) => containsRgbOperators(content))).toBe(
+      false,
+    );
+    expect(destContents.some((content) => containsCmykOperators(content))).toBe(
+      true,
+    );
+  });
+
   it('preserves unmapped RGB colors', async () => {
     const srcPdf = fs.readFileSync(path.join(fixturesDir, 'text.pdf'));
 
     const destPdf = await convertCmykColors({
       pdf: srcPdf,
       // no colors will be converted
-      colorMap: {},
+      convert: mapToConverter({}),
       unmappedColors: null,
     });
 

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -607,6 +607,42 @@ it('supports pdfPostprocess configuration', async () => {
   });
 });
 
+it('resolves overrideMap function entries preserving order', async () => {
+  const convert = () => ({ c: 0, m: 0, y: 0, k: 10000 });
+  const config = await getTaskConfig(['build'], resolveFixture('config'), {
+    entry: 'manuscript.md',
+    output: 'output.pdf',
+    pdfPostprocess: {
+      cmyk: {
+        overrideMap: [
+          ['#ff0000', { c: 0, m: 10000, y: 10000, k: 0 }],
+          convert,
+          [
+            { r: 0, g: 0, b: 0 },
+            { c: 0, m: 0, y: 0, k: 10000 },
+          ],
+        ],
+      },
+    },
+  });
+  expect(config.outputs[0]).toMatchObject({
+    format: 'pdf',
+    cmyk: {
+      overrideMap: [
+        [
+          { r: 10000, g: 0, b: 0 },
+          { c: 0, m: 10000, y: 10000, k: 0 },
+        ],
+        convert,
+        [
+          { r: 0, g: 0, b: 0 },
+          { c: 0, m: 0, y: 0, k: 10000 },
+        ],
+      ],
+    },
+  });
+});
+
 it('excludes node_modules files from replaceImage RegExp matching', async () => {
   const config = await getTaskConfig(
     ['build'],

--- a/tests/image.test.ts
+++ b/tests/image.test.ts
@@ -9,9 +9,12 @@ import type {
 } from '../src/config/replace-image.js';
 import { Logger } from '../src/logger.js';
 import {
+  builtinCmykConversion,
   builtinCmykReplacement,
+  builtinGrayConversion,
   builtinGrayReplacement,
   findNonCmykImages,
+  iccConversion,
   iccReplacement,
   replaceImages,
 } from '../src/output/image.js';
@@ -984,6 +987,61 @@ describe('replaceImages', () => {
       Buffer.compare(Buffer.from(builtinPixels), Buffer.from(iccPixels)),
     ).not.toBe(0);
     spy.mockRestore();
+  });
+});
+
+describe('builtinCmykConversion', () => {
+  it('converts black to mostly K', async () => {
+    const convert = builtinCmykConversion();
+    const result = await convert({ r: 0, g: 0, b: 0 });
+    expect(result.k).toBeGreaterThan(5000);
+  });
+
+  it('converts white to near-zero CMYK', async () => {
+    const convert = builtinCmykConversion();
+    const result = await convert({ r: 10000, g: 10000, b: 10000 });
+    expect(result.c).toBeLessThan(500);
+    expect(result.m).toBeLessThan(500);
+    expect(result.y).toBeLessThan(500);
+    expect(result.k).toBeLessThan(500);
+  });
+});
+
+describe('builtinGrayConversion', () => {
+  it('converts black to high K', async () => {
+    const convert = builtinGrayConversion();
+    const result = await convert({ r: 0, g: 0, b: 0 });
+    expect(result).toMatchObject({ c: 0, m: 0, y: 0 });
+    expect(result.k).toBeGreaterThan(5000);
+  });
+
+  it('converts white to near-zero K', async () => {
+    const convert = builtinGrayConversion();
+    const result = await convert({ r: 10000, g: 10000, b: 10000 });
+    expect(result).toMatchObject({ c: 0, m: 0, y: 0 });
+    expect(result.k).toBeLessThan(500);
+  });
+});
+
+describe('iccConversion', () => {
+  it('converts colors through a CMYK profile', async () => {
+    const profile = fs.readFileSync(path.join(fixturesDir, 'ps_cmyk.icc'));
+    const convert = iccConversion(profile);
+    const black = await convert({ r: 0, g: 0, b: 0 });
+    expect(black.c + black.m + black.y + black.k).toBeGreaterThan(10000);
+    const white = await convert({ r: 10000, g: 10000, b: 10000 });
+    expect(white.c).toBeLessThan(500);
+    expect(white.m).toBeLessThan(500);
+    expect(white.y).toBeLessThan(500);
+    expect(white.k).toBeLessThan(500);
+  });
+
+  it('maps grayscale profiles to the K channel', async () => {
+    const profile = fs.readFileSync(path.join(fixturesDir, 'ps_gray.icc'));
+    const convert = iccConversion(profile);
+    const black = await convert({ r: 0, g: 0, b: 0 });
+    expect(black).toMatchObject({ c: 0, m: 0, y: 0 });
+    expect(black.k).toBeGreaterThan(5000);
   });
 });
 

--- a/tests/pdf-postprocess.test.ts
+++ b/tests/pdf-postprocess.test.ts
@@ -103,6 +103,23 @@ it('fails the build without writing output when ifUnmappedColorsFound is error',
   );
 });
 
+it('does not treat colors converted by an overrideMap function as unmapped', async () => {
+  const pdf = fs.readFileSync(path.join(fixturesDir, 'text.pdf'));
+
+  const { thrown, written, warns } = await runSave(
+    pdf,
+    cmykConfig({
+      ifUnmappedColorsFound: 'error',
+      ifUnreplacedImagesFound: 'ignore',
+      overrideMap: [() => ({ c: 0, m: 0, y: 0, k: 10000 })],
+    }),
+  );
+
+  expect(thrown).toBeNull();
+  expect(written).toBe(true);
+  expect(warns).toEqual([]);
+});
+
 it('combines failures from both categories into a single error', async () => {
   const pdf = fs.readFileSync(path.join(fixturesDir, 'image.pdf'));
 

--- a/tests/pdf-stream.test.ts
+++ b/tests/pdf-stream.test.ts
@@ -1,7 +1,14 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import type { CmykMap } from '../src/global-viewer.js';
-import { convertStreamColors } from '../src/output/pdf-stream.js';
+import { Logger } from '../src/logger.js';
+import type { InternalColorConverter } from '../src/output/pdf-stream.js';
+import {
+  composeColorConverters,
+  convertStreamColors,
+  guardConvertFunction,
+  mapToConverter,
+} from '../src/output/pdf-stream.js';
 
 /**
  * Helper to create a color map from RGB (0-10000 scale) to CMYK values
@@ -22,79 +29,95 @@ function createColorMap(
   return map;
 }
 
+function convertWithMap(
+  content: string,
+  map: CmykMap,
+  unmappedColors: Set<string> | null,
+): Promise<string> {
+  return convertStreamColors(content, mapToConverter(map), unmappedColors);
+}
+
 describe('convertStreamColors', () => {
   describe('RGB to CMYK conversion', () => {
     describe('rg operator (non-stroking)', () => {
-      it('converts mapped RGB color to CMYK', () => {
+      it('converts mapped RGB color to CMYK', async () => {
         const colorMap = createColorMap([
           [0, 0, 0, { c: 0, m: 0, y: 0, k: 10000 }],
         ]);
-        const result = convertStreamColors('0 0 0 rg', colorMap, null);
+        const result = await convertWithMap('0 0 0 rg', colorMap, null);
         expect(result).toBe('0 0 0 1 k');
       });
 
-      it('converts 50% gray correctly', () => {
+      it('converts 50% gray correctly', async () => {
         const colorMap = createColorMap([
           [5000, 5000, 5000, { c: 0, m: 0, y: 0, k: 5000 }],
         ]);
-        const result = convertStreamColors('0.5 0.5 0.5 rg', colorMap, null);
+        const result = await convertWithMap('0.5 0.5 0.5 rg', colorMap, null);
         expect(result).toBe('0 0 0 0.5 k');
       });
 
-      it('preserves unmapped RGB colors', () => {
-        const result = convertStreamColors('0.1 0.2 0.3 rg', {}, null);
+      it('preserves unmapped RGB colors', async () => {
+        const result = await convertWithMap('0.1 0.2 0.3 rg', {}, null);
         expect(result).toBe('0.1 0.2 0.3 rg');
       });
 
-      it('handles fractional CMYK values', () => {
+      it('handles fractional CMYK values', async () => {
         const colorMap = createColorMap([
           [5000, 3000, 2000, { c: 1234, m: 5678, y: 9012, k: 3456 }],
         ]);
-        const result = convertStreamColors('0.5 0.3 0.2 rg', colorMap, null);
+        const result = await convertWithMap('0.5 0.3 0.2 rg', colorMap, null);
         expect(result).toBe('0.1234 0.5678 0.9012 0.3456 k');
       });
 
-      it('handles insufficient arguments gracefully', () => {
-        const result = convertStreamColors('0.5 0.5 rg', {}, null);
+      it('handles insufficient arguments gracefully', async () => {
+        const result = await convertWithMap('0.5 0.5 rg', {}, null);
         expect(result).toBe('0.5 0.5 rg');
       });
     });
 
     describe('RG operator (stroking)', () => {
-      it('converts mapped RGB stroking color to CMYK', () => {
+      it('converts mapped RGB stroking color to CMYK', async () => {
         const colorMap = createColorMap([
           [10000, 0, 0, { c: 0, m: 10000, y: 10000, k: 0 }],
         ]);
-        const result = convertStreamColors('1 0 0 RG', colorMap, null);
+        const result = await convertWithMap('1 0 0 RG', colorMap, null);
         expect(result).toBe('0 1 1 0 K');
       });
 
-      it('preserves unmapped RGB stroking colors', () => {
-        const result = convertStreamColors('0.9 0.8 0.7 RG', {}, null);
+      it('preserves unmapped RGB stroking colors', async () => {
+        const result = await convertWithMap('0.9 0.8 0.7 RG', {}, null);
         expect(result).toBe('0.9 0.8 0.7 RG');
       });
 
-      it('handles insufficient arguments gracefully', () => {
-        const result = convertStreamColors('0.5 RG', {}, null);
+      it('handles insufficient arguments gracefully', async () => {
+        const result = await convertWithMap('0.5 RG', {}, null);
         expect(result).toBe('0.5 RG');
       });
     });
 
     describe('mixed operators', () => {
-      it('converts both rg and RG in same stream', () => {
+      it('converts both rg and RG in same stream', async () => {
         const colorMap = createColorMap([
           [0, 0, 0, { c: 0, m: 0, y: 0, k: 10000 }],
         ]);
-        const result = convertStreamColors('0 0 0 rg 0 0 0 RG', colorMap, null);
+        const result = await convertWithMap(
+          '0 0 0 rg 0 0 0 RG',
+          colorMap,
+          null,
+        );
         expect(result).toBe('0 0 0 1 k 0 0 0 1 K');
       });
 
-      it('handles multiple color changes', () => {
+      it('handles multiple color changes', async () => {
         const colorMap = createColorMap([
           [0, 0, 0, { c: 0, m: 0, y: 0, k: 10000 }],
           [10000, 10000, 10000, { c: 0, m: 0, y: 0, k: 0 }],
         ]);
-        const result = convertStreamColors('0 0 0 rg 1 1 1 rg', colorMap, null);
+        const result = await convertWithMap(
+          '0 0 0 rg 1 1 1 rg',
+          colorMap,
+          null,
+        );
         expect(result).toBe('0 0 0 1 k 0 0 0 0 k');
       });
     });
@@ -102,52 +125,52 @@ describe('convertStreamColors', () => {
 
   describe('content preservation', () => {
     describe('existing CMYK and gray colors', () => {
-      it('preserves k operator', () => {
-        const result = convertStreamColors('0 0 0 1 k', {}, null);
+      it('preserves k operator', async () => {
+        const result = await convertWithMap('0 0 0 1 k', {}, null);
         expect(result).toBe('0 0 0 1 k');
       });
 
-      it('preserves K operator', () => {
-        const result = convertStreamColors('1 0 0 0 K', {}, null);
+      it('preserves K operator', async () => {
+        const result = await convertWithMap('1 0 0 0 K', {}, null);
         expect(result).toBe('1 0 0 0 K');
       });
 
-      it('preserves g operator', () => {
-        const result = convertStreamColors('0.5 g', {}, null);
+      it('preserves g operator', async () => {
+        const result = await convertWithMap('0.5 g', {}, null);
         expect(result).toBe('0.5 g');
       });
 
-      it('preserves G operator', () => {
-        const result = convertStreamColors('0.5 G', {}, null);
+      it('preserves G operator', async () => {
+        const result = await convertWithMap('0.5 G', {}, null);
         expect(result).toBe('0.5 G');
       });
     });
 
     describe('PDF operators', () => {
-      it('preserves text operators', () => {
-        const result = convertStreamColors('BT /F1 12 Tf ET', {}, null);
+      it('preserves text operators', async () => {
+        const result = await convertWithMap('BT /F1 12 Tf ET', {}, null);
         expect(result).toBe('BT /F1 12 Tf ET');
       });
 
-      it('preserves path operators', () => {
-        const result = convertStreamColors('100 200 m 300 400 l S', {}, null);
+      it('preserves path operators', async () => {
+        const result = await convertWithMap('100 200 m 300 400 l S', {}, null);
         expect(result).toBe('100 200 m 300 400 l S');
       });
 
-      it('preserves graphics state operators', () => {
-        const result = convertStreamColors('q 1 0 0 1 50 50 cm Q', {}, null);
+      it('preserves graphics state operators', async () => {
+        const result = await convertWithMap('q 1 0 0 1 50 50 cm Q', {}, null);
         expect(result).toBe('q 1 0 0 1 50 50 cm Q');
       });
     });
 
     describe('PDF syntax elements', () => {
-      it('preserves string literals', () => {
-        const result = convertStreamColors('(Hello World) Tj', {}, null);
+      it('preserves string literals', async () => {
+        const result = await convertWithMap('(Hello World) Tj', {}, null);
         expect(result).toBe('(Hello World) Tj');
       });
 
-      it('preserves nested parentheses in strings', () => {
-        const result = convertStreamColors(
+      it('preserves nested parentheses in strings', async () => {
+        const result = await convertWithMap(
           '(test (nested) string) Tj',
           {},
           null,
@@ -155,13 +178,13 @@ describe('convertStreamColors', () => {
         expect(result).toBe('(test (nested) string) Tj');
       });
 
-      it('preserves escaped characters in strings', () => {
-        const result = convertStreamColors('(line1\\nline2) Tj', {}, null);
+      it('preserves escaped characters in strings', async () => {
+        const result = await convertWithMap('(line1\\nline2) Tj', {}, null);
         expect(result).toBe('(line1\\nline2) Tj');
       });
 
-      it('preserves escaped parentheses in strings', () => {
-        const result = convertStreamColors(
+      it('preserves escaped parentheses in strings', async () => {
+        const result = await convertWithMap(
           '(test\\(escaped\\)parens) Tj',
           {},
           null,
@@ -169,218 +192,222 @@ describe('convertStreamColors', () => {
         expect(result).toBe('(test\\(escaped\\)parens) Tj');
       });
 
-      it('preserves empty strings', () => {
-        const result = convertStreamColors('() Tj', {}, null);
+      it('preserves empty strings', async () => {
+        const result = await convertWithMap('() Tj', {}, null);
         expect(result).toBe('() Tj');
       });
 
-      it('preserves hex strings', () => {
-        const result = convertStreamColors('<48454C4C4F> Tj', {}, null);
+      it('preserves hex strings', async () => {
+        const result = await convertWithMap('<48454C4C4F> Tj', {}, null);
         expect(result).toBe('<48454C4C4F> Tj');
       });
 
-      it('preserves hex strings with spaces', () => {
-        const result = convertStreamColors('<48 65 6C 6C 6F> Tj', {}, null);
+      it('preserves hex strings with spaces', async () => {
+        const result = await convertWithMap('<48 65 6C 6C 6F> Tj', {}, null);
         expect(result).toBe('<48 65 6C 6C 6F> Tj');
       });
 
-      it('preserves empty hex strings', () => {
-        const result = convertStreamColors('<> Tj', {}, null);
+      it('preserves empty hex strings', async () => {
+        const result = await convertWithMap('<> Tj', {}, null);
         expect(result).toBe('<> Tj');
       });
 
-      it('preserves names', () => {
-        const result = convertStreamColors('/DeviceCMYK cs', {}, null);
+      it('preserves names', async () => {
+        const result = await convertWithMap('/DeviceCMYK cs', {}, null);
         expect(result).toBe('/DeviceCMYK cs');
       });
 
-      it('preserves names with special characters', () => {
-        const result = convertStreamColors('/sRGB-IEC61966-2.1 cs', {}, null);
+      it('preserves names with special characters', async () => {
+        const result = await convertWithMap('/sRGB-IEC61966-2.1 cs', {}, null);
         expect(result).toBe('/sRGB-IEC61966-2.1 cs');
       });
 
-      it('preserves inline dictionaries', () => {
-        const result = convertStreamColors('/Span << /MCID 0 >> BDC', {}, null);
+      it('preserves inline dictionaries', async () => {
+        const result = await convertWithMap(
+          '/Span << /MCID 0 >> BDC',
+          {},
+          null,
+        );
         expect(result).toBe('/Span << /MCID 0 >> BDC');
       });
 
-      it('distinguishes hex strings from dictionary markers', () => {
-        const result = convertStreamColors('<< /Key <ABCD> >>', {}, null);
+      it('distinguishes hex strings from dictionary markers', async () => {
+        const result = await convertWithMap('<< /Key <ABCD> >>', {}, null);
         expect(result).toBe('<< /Key <ABCD> >>');
       });
 
-      it('preserves arrays', () => {
-        const result = convertStreamColors('[1 2 3] TJ', {}, null);
+      it('preserves arrays', async () => {
+        const result = await convertWithMap('[1 2 3] TJ', {}, null);
         expect(result).toBe('[ 1 2 3 ] TJ');
       });
 
-      it('preserves comments', () => {
-        const result = convertStreamColors('% comment\n0.5 g', {}, null);
+      it('preserves comments', async () => {
+        const result = await convertWithMap('% comment\n0.5 g', {}, null);
         expect(result).toBe('% comment 0.5 g');
       });
     });
 
     describe('number formats', () => {
-      it('handles integers', () => {
-        const result = convertStreamColors('42 g', {}, null);
+      it('handles integers', async () => {
+        const result = await convertWithMap('42 g', {}, null);
         expect(result).toBe('42 g');
       });
 
-      it('handles floating point numbers', () => {
-        const result = convertStreamColors('3.14159 g', {}, null);
+      it('handles floating point numbers', async () => {
+        const result = await convertWithMap('3.14159 g', {}, null);
         expect(result).toBe('3.14159 g');
       });
 
-      it('handles negative numbers', () => {
-        const result = convertStreamColors('-123 0 m', {}, null);
+      it('handles negative numbers', async () => {
+        const result = await convertWithMap('-123 0 m', {}, null);
         expect(result).toBe('-123 0 m');
       });
 
-      it('handles positive numbers with explicit sign', () => {
-        const result = convertStreamColors('+456 0 m', {}, null);
+      it('handles positive numbers with explicit sign', async () => {
+        const result = await convertWithMap('+456 0 m', {}, null);
         expect(result).toBe('+456 0 m');
       });
 
-      it('handles numbers starting with decimal point', () => {
-        const result = convertStreamColors('.5 g', {}, null);
+      it('handles numbers starting with decimal point', async () => {
+        const result = await convertWithMap('.5 g', {}, null);
         expect(result).toBe('.5 g');
       });
 
-      it('handles numbers ending with decimal point', () => {
-        const result = convertStreamColors('5. g', {}, null);
+      it('handles numbers ending with decimal point', async () => {
+        const result = await convertWithMap('5. g', {}, null);
         expect(result).toBe('5. g');
       });
     });
 
     describe('whitespace handling', () => {
-      it('handles various whitespace characters', () => {
-        const result = convertStreamColors('1\t2\n3\r4 re', {}, null);
+      it('handles various whitespace characters', async () => {
+        const result = await convertWithMap('1\t2\n3\r4 re', {}, null);
         expect(result).toBe('1 2 3 4 re');
       });
 
-      it('handles empty input', () => {
-        const result = convertStreamColors('', {}, null);
+      it('handles empty input', async () => {
+        const result = await convertWithMap('', {}, null);
         expect(result).toBe('');
       });
 
-      it('handles whitespace-only input', () => {
-        const result = convertStreamColors('   \t\n   ', {}, null);
+      it('handles whitespace-only input', async () => {
+        const result = await convertWithMap('   \t\n   ', {}, null);
         expect(result).toBe('');
       });
     });
   });
 
   describe('complex content streams', () => {
-    it('converts colors within text block', () => {
+    it('converts colors within text block', async () => {
       const colorMap = createColorMap([
         [0, 0, 0, { c: 0, m: 0, y: 0, k: 10000 }],
       ]);
       const input = 'BT 0 0 0 rg /F1 12 Tf (Hello) Tj ET';
-      const result = convertStreamColors(input, colorMap, null);
+      const result = await convertWithMap(input, colorMap, null);
       expect(result).toBe('BT 0 0 0 1 k /F1 12 Tf (Hello) Tj ET');
     });
 
-    it('converts colors within graphics state', () => {
+    it('converts colors within graphics state', async () => {
       const colorMap = createColorMap([
         [10000, 0, 0, { c: 0, m: 10000, y: 10000, k: 0 }],
       ]);
       const input = 'q 1 0 0 RG 100 100 200 200 re S Q';
-      const result = convertStreamColors(input, colorMap, null);
+      const result = await convertWithMap(input, colorMap, null);
       expect(result).toBe('q 0 1 1 0 K 100 100 200 200 re S Q');
     });
 
-    it('handles multiple color changes with other operators', () => {
+    it('handles multiple color changes with other operators', async () => {
       const colorMap = createColorMap([
         [0, 0, 0, { c: 0, m: 0, y: 0, k: 10000 }],
         [10000, 0, 0, { c: 0, m: 10000, y: 10000, k: 0 }],
       ]);
       const input =
         '0 0 0 rg 50 50 m 100 100 l S 1 0 0 rg 150 150 m 200 200 l S';
-      const result = convertStreamColors(input, colorMap, null);
+      const result = await convertWithMap(input, colorMap, null);
       expect(result).toBe(
         '0 0 0 1 k 50 50 m 100 100 l S 0 1 1 0 k 150 150 m 200 200 l S',
       );
     });
 
-    it('handles Vivliostyle-generated content with BDC markers', () => {
+    it('handles Vivliostyle-generated content with BDC markers', async () => {
       const colorMap = createColorMap([
         [0, 0, 0, { c: 0, m: 0, y: 0, k: 10000 }],
       ]);
       const input =
         '/NonStruct << /MCID 0 >> BDC BT 0 0 0 rg /F4 127 Tf ET EMC';
-      const result = convertStreamColors(input, colorMap, null);
+      const result = await convertWithMap(input, colorMap, null);
       expect(result).toBe(
         '/NonStruct << /MCID 0 >> BDC BT 0 0 0 1 k /F4 127 Tf ET EMC',
       );
     });
 
-    it('handles crop marks with CMYK colors (no conversion needed)', () => {
+    it('handles crop marks with CMYK colors (no conversion needed)', async () => {
       const input = 'q 1 0 0 1 K 0 49.133858 m 37.795277 49.133858 l S Q';
-      const result = convertStreamColors(input, {}, null);
+      const result = await convertWithMap(input, {}, null);
       expect(result).toBe(
         'q 1 0 0 1 K 0 49.133858 m 37.795277 49.133858 l S Q',
       );
     });
 
-    it('handles ExtGState references', () => {
+    it('handles ExtGState references', async () => {
       const colorMap = createColorMap([
         [0, 0, 0, { c: 0, m: 0, y: 0, k: 10000 }],
       ]);
       const input = '/G3 gs 0 0 0 rg';
-      const result = convertStreamColors(input, colorMap, null);
+      const result = await convertWithMap(input, colorMap, null);
       expect(result).toBe('/G3 gs 0 0 0 1 k');
     });
   });
 
   describe('collecting unmapped colors', () => {
-    it('collects unmapped rg colors', () => {
+    it('collects unmapped rg colors', async () => {
       const unmappedColors = new Set<string>();
-      convertStreamColors('0.1 0.2 0.3 rg', {}, unmappedColors);
+      await convertWithMap('0.1 0.2 0.3 rg', {}, unmappedColors);
       expect([...unmappedColors]).toEqual(['{"r":1000,"g":2000,"b":3000}']);
     });
 
-    it('collects unmapped RG colors', () => {
+    it('collects unmapped RG colors', async () => {
       const unmappedColors = new Set<string>();
-      convertStreamColors('0.1 0.2 0.3 RG', {}, unmappedColors);
+      await convertWithMap('0.1 0.2 0.3 RG', {}, unmappedColors);
       expect([...unmappedColors]).toEqual(['{"r":1000,"g":2000,"b":3000}']);
     });
 
-    it('does not collect when unmappedColors is null', () => {
-      const result = convertStreamColors('0.1 0.2 0.3 rg', {}, null);
+    it('does not collect when unmappedColors is null', async () => {
+      const result = await convertWithMap('0.1 0.2 0.3 rg', {}, null);
       expect(result).toBe('0.1 0.2 0.3 rg');
     });
 
-    it('collects each color once', () => {
+    it('collects each color once', async () => {
       const unmappedColors = new Set<string>();
-      convertStreamColors('0.1 0.2 0.3 rg 0.1 0.2 0.3 rg', {}, unmappedColors);
+      await convertWithMap('0.1 0.2 0.3 rg 0.1 0.2 0.3 rg', {}, unmappedColors);
       expect(unmappedColors.size).toBe(1);
     });
 
-    it('collects different colors separately', () => {
+    it('collects different colors separately', async () => {
       const unmappedColors = new Set<string>();
-      convertStreamColors('0.1 0.2 0.3 rg 0.4 0.5 0.6 rg', {}, unmappedColors);
+      await convertWithMap('0.1 0.2 0.3 rg 0.4 0.5 0.6 rg', {}, unmappedColors);
       expect(unmappedColors.size).toBe(2);
     });
 
-    it('deduplicates colors across multiple calls', () => {
+    it('deduplicates colors across multiple calls', async () => {
       const unmappedColors = new Set<string>();
-      convertStreamColors('0.1 0.2 0.3 rg', {}, unmappedColors);
-      convertStreamColors('0.1 0.2 0.3 rg', {}, unmappedColors);
+      await convertWithMap('0.1 0.2 0.3 rg', {}, unmappedColors);
+      await convertWithMap('0.1 0.2 0.3 rg', {}, unmappedColors);
       expect(unmappedColors.size).toBe(1);
     });
 
-    it('shares the collection between rg and RG operators', () => {
+    it('shares the collection between rg and RG operators', async () => {
       const unmappedColors = new Set<string>();
-      convertStreamColors('0.1 0.2 0.3 rg 0.1 0.2 0.3 RG', {}, unmappedColors);
+      await convertWithMap('0.1 0.2 0.3 rg 0.1 0.2 0.3 RG', {}, unmappedColors);
       expect(unmappedColors.size).toBe(1);
     });
   });
 
   describe('inline images', () => {
-    it('skips binary data between ID and EI', () => {
+    it('skips binary data between ID and EI', async () => {
       // Binary data could contain byte sequences that look like "0.5 0.5 0.5 rg"
       const input = 'BI /W 10 /H 10 ID binary0.5 0.5 0.5 rgdata EI';
-      const result = convertStreamColors(input, {}, null);
+      const result = await convertWithMap(input, {}, null);
       // The binary data should pass through unchanged
       expect(result).toContain('ID');
       expect(result).toContain('EI');
@@ -388,45 +415,173 @@ describe('convertStreamColors', () => {
       expect(result).not.toContain('k');
     });
 
-    it('handles inline image followed by real color operator', () => {
+    it('handles inline image followed by real color operator', async () => {
       const colorMap = createColorMap([
         [5000, 5000, 5000, { c: 0, m: 0, y: 0, k: 5000 }],
       ]);
       const input = 'BI /W 1 /H 1 ID x EI 0.5 0.5 0.5 rg';
-      const result = convertStreamColors(input, colorMap, null);
+      const result = await convertWithMap(input, colorMap, null);
       expect(result).toContain('0 0 0 0.5 k');
     });
 
-    it('handles inline image with EI-like bytes in data', () => {
+    it('handles inline image with EI-like bytes in data', async () => {
       // "EI" without proper whitespace context should not end the image
       const input = 'BI /W 1 /H 1 ID xEIy EI';
-      const result = convertStreamColors(input, {}, null);
+      const result = await convertWithMap(input, {}, null);
       expect(result).toContain('EI');
     });
   });
 
   describe('edge cases', () => {
-    it('handles negative color values (out of range)', () => {
-      const result = convertStreamColors('-0.1 0.2 0.3 rg', {}, null);
+    it('handles negative color values (out of range)', async () => {
+      const result = await convertWithMap('-0.1 0.2 0.3 rg', {}, null);
       expect(result).toBe('-0.1 0.2 0.3 rg');
     });
 
-    it('handles color values > 1 (out of range)', () => {
-      const result = convertStreamColors('1.5 0.5 0.5 rg', {}, null);
+    it('handles color values > 1 (out of range)', async () => {
+      const result = await convertWithMap('1.5 0.5 0.5 rg', {}, null);
       expect(result).toBe('1.5 0.5 0.5 rg');
     });
 
-    it('handles rounding at color map boundaries', () => {
+    it('handles rounding at color map boundaries', async () => {
       // 0.12345 * 10000 = 1234.5 -> rounds to 1235
       const colorMap = createColorMap([
         [1235, 6789, 10000, { c: 1000, m: 2000, y: 3000, k: 4000 }],
       ]);
-      const result = convertStreamColors(
+      const result = await convertWithMap(
         '0.12345 0.6789 0.99999 rg',
         colorMap,
         null,
       );
       expect(result).toBe('0.1 0.2 0.3 0.4 k');
     });
+  });
+});
+
+describe('mapToConverter', () => {
+  it('converts mapped colors and returns null for missing ones', async () => {
+    const convert = mapToConverter({
+      '[0,0,0]': { c: 0, m: 0, y: 0, k: 10000 },
+    });
+    expect(await convert({ r: 0, g: 0, b: 0 })).toEqual({
+      c: 0,
+      m: 0,
+      y: 0,
+      k: 10000,
+    });
+    expect(await convert({ r: 1, g: 2, b: 3 })).toBeNull();
+  });
+});
+
+describe('composeColorConverters', () => {
+  it('tries converters in order until one returns a value', async () => {
+    const first = vi.fn<InternalColorConverter>().mockReturnValue(null);
+    const second = vi
+      .fn<InternalColorConverter>()
+      .mockReturnValue({ c: 0, m: 0, y: 0, k: 10000 });
+    const third = vi
+      .fn<InternalColorConverter>()
+      .mockReturnValue({ c: 10000, m: 0, y: 0, k: 0 });
+    const convert = composeColorConverters([first, second, third]);
+
+    expect(await convert({ r: 1, g: 2, b: 3 })).toEqual({
+      c: 0,
+      m: 0,
+      y: 0,
+      k: 10000,
+    });
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledTimes(1);
+    expect(third).not.toHaveBeenCalled();
+  });
+
+  it('supports converters returning promises', async () => {
+    const convert = composeColorConverters([
+      () => Promise.resolve(null),
+      () => Promise.resolve({ c: 0, m: 0, y: 0, k: 5000 }),
+    ]);
+    expect(await convert({ r: 1, g: 2, b: 3 })).toEqual({
+      c: 0,
+      m: 0,
+      y: 0,
+      k: 5000,
+    });
+  });
+
+  it('returns null when no converter handles the color', async () => {
+    const convert = composeColorConverters([() => null]);
+    expect(await convert({ r: 1, g: 2, b: 3 })).toBeNull();
+  });
+
+  it('caches the result per color', async () => {
+    const fn = vi
+      .fn<InternalColorConverter>()
+      .mockReturnValue({ c: 0, m: 0, y: 0, k: 10000 });
+    const miss = vi.fn<InternalColorConverter>().mockReturnValue(null);
+    const convert = composeColorConverters([fn]);
+    const convertMiss = composeColorConverters([miss]);
+
+    await convert({ r: 1, g: 2, b: 3 });
+    await convert({ r: 1, g: 2, b: 3 });
+    await convert({ r: 4, g: 5, b: 6 });
+    expect(fn).toHaveBeenCalledTimes(2);
+
+    await convertMiss({ r: 1, g: 2, b: 3 });
+    await convertMiss({ r: 1, g: 2, b: 3 });
+    expect(miss).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('guardConvertFunction', () => {
+  it('passes through successful conversions', async () => {
+    const convert = guardConvertFunction(() => ({ c: 0, m: 0, y: 0, k: 1 }));
+    expect(await convert({ r: 1, g: 2, b: 3 })).toEqual({
+      c: 0,
+      m: 0,
+      y: 0,
+      k: 1,
+    });
+  });
+
+  it('returns null and warns once per distinct error when the function throws', async () => {
+    const spy = vi.spyOn(Logger, 'logWarn').mockImplementation(() => {});
+    const convert = guardConvertFunction(() => {
+      throw new Error('conversion failed');
+    });
+
+    expect(await convert({ r: 1, g: 2, b: 3 })).toBeNull();
+    expect(await convert({ r: 4, g: 5, b: 6 })).toBeNull();
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to apply overrideMap function'),
+    );
+    spy.mockRestore();
+  });
+});
+
+describe('converter chain in convertStreamColors', () => {
+  it('converts colors through a fallback function without collecting them as unmapped', async () => {
+    const unmappedColors = new Set<string>();
+    const result = await convertStreamColors(
+      '0.1 0.2 0.3 rg',
+      composeColorConverters([
+        mapToConverter({}),
+        () => ({ c: 0, m: 0, y: 0, k: 10000 }),
+      ]),
+      unmappedColors,
+    );
+    expect(result).toBe('0 0 0 1 k');
+    expect(unmappedColors.size).toBe(0);
+  });
+
+  it('collects colors as unmapped when every converter declines', async () => {
+    const unmappedColors = new Set<string>();
+    const result = await convertStreamColors(
+      '0.1 0.2 0.3 rg',
+      composeColorConverters([mapToConverter({}), () => null]),
+      unmappedColors,
+    );
+    expect(result).toBe('0.1 0.2 0.3 rg');
+    expect(unmappedColors.size).toBe(1);
   });
 });


### PR DESCRIPTION
#766 を大きな変更なしにマージしてもらえることを前提に作成した、色置換側のフォールバック機能を追加するPRです。この機能は1x1pxの画像に対する #766 の変換として実装されているので、こちらを先にご確認ください。

使い方もほぼ同じです。

```javascript
// @ts-check
import { builtinCmykConversion, defineConfig } from '@vivliostyle/cli';

export default defineConfig({
  pdfPostprocess: {
    cmyk: {
      overrideMap: [
        [
          { r: 6039, g: 6039, b: 6039 },
          { c: 0, m: 0, y: 0, k: 10000 - 6039 },
        ],

        (rgb) => ({c, m, y, k}),

        builtinCmykConversion()
      ],
    },
  },
});
```