### PR TITLE
fix: Handle custom style URLs for external viewers

### DIFF
--- a/.changeset/fix-issue-755.md
+++ b/.changeset/fix-issue-755.md
@@ -1,0 +1,5 @@
+---
+'@vivliostyle/cli': patch
+---
+
+Handle custom `--style` / `--user-style` for external viewers

--- a/src/server.ts
+++ b/src/server.ts
@@ -42,6 +42,7 @@ export type ViewerUrlOption = Pick<
   | 'viewerParam'
   | 'base'
   | 'outputs'
+  | 'rootUrl'
 >;
 
 export function generateCmykReserveMap({
@@ -76,6 +77,7 @@ export function getViewerParams(
     quick,
     viewerParam,
     base,
+    rootUrl,
   }: ViewerUrlOption,
   { cmykReserveMapUrl }: { cmykReserveMapUrl?: string } = {},
 ): string {
@@ -92,14 +94,14 @@ export function getViewerParams(
   if (customStyle) {
     const param = isValidUri(customStyle)
       ? customStyle
-      : upath.posix.join(base, customStyle);
+      : new URL(upath.posix.join(base, customStyle), rootUrl).href;
     viewerParams += `&style=${escapeParam(param)}`;
   }
 
   if (customUserStyle) {
     const param = isValidUri(customUserStyle)
       ? customUserStyle
-      : upath.posix.join(base, customUserStyle);
+      : new URL(upath.posix.join(base, customUserStyle), rootUrl).href;
     viewerParams += `&userStyle=${escapeParam(param)}`;
   }
 
@@ -211,7 +213,7 @@ export async function getViewerFullUrl({
     sourceUrl === EMPTY_DATA_URI
       ? undefined // open Viewer start page
       : sourceUrl,
-    { base, ...config },
+    { base, rootUrl, ...config },
     { cmykReserveMapUrl },
   );
   viewerUrl.hash = '';

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -312,6 +312,34 @@ describe('vite-plugin-browser', () => {
     });
   });
 
+  it('launches external viewer with custom style URLs', async () => {
+    const server = (await runCommand(
+      [
+        'preview',
+        '--viewer',
+        'https://example.com',
+        '--style',
+        'theme.css',
+        '--user-style',
+        'theme.css',
+      ],
+      {
+        cwd: resolveFixture('server'),
+        config: {
+          entry: 'main.md',
+          workspaceDir: '.vs-browser-external-viewer-style',
+        },
+      },
+    )) as ViteDevServer;
+    assert(server.resolvedUrls);
+    expect(launchPreviewSpy).toHaveBeenCalledOnce();
+    const { url } = launchPreviewSpy.mock.calls[0][0];
+    expect(parseUrlParams(url)).toMatchObject({
+      style: `${server.resolvedUrls.local[0]}vivliostyle/theme.css`,
+      userStyle: `${server.resolvedUrls.local[0]}vivliostyle/theme.css`,
+    });
+  });
+
   it('launches epub-opf input', async () => {
     const server = (await runCommand(
       ['preview', '../epubs/adaptive/OPS/content.opf'],


### PR DESCRIPTION
Fixes #755 by applying the approach mentioned in https://github.com/vivliostyle/vivliostyle.js/issues/1522#issuecomment-4028222320.

This updates custom style URLs for external viewers so that local `--style` / `--user-style` paths are resolved against the local CLI server, and adds a regression test.