### PR TITLE
docs: fix typo (frotnend → frontend) and grammar nit

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Development Guide
 
-Please ensure pnpm:>=10 is installed in your machine.
+Please ensure pnpm:>=10 is installed on your machine.
 
 ```bash
 git clone https://github.com/vivliostyle/vivliostyle-cli.git && cd vivliostyle-cli

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@
 - [Creating Table of Contents Page](./toc-page.md)
 - [Creating Cover Page](./cover-page.md)
 - [Special Output Settings](./special-output-settings.md)
-- [Frontend Framework Support](./frotnend-framework-support.md)
+- [Frontend Framework Support](./frontend-framework-support.md)
 
 </li>
 <li>


### PR DESCRIPTION
- docs/index.md: link target had `frotnend-framework-support`, the actual filename is `frontend-framework-support.md` (404 link otherwise).
- CONTRIBUTING.md: small grammar nit, "installed in your machine" → "installed on your machine" (idiomatic English).