### PR TITLE
docs: fix broken docs.vivliostyle.org URLs

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-Vivliostyle CLI is a command-line interface for typesetting HTML and Markdown documents. It includes the [Vivliostyle Viewer](https://docs.vivliostyle.org/#/vivliostyle-viewer) and generates high-quality PDFs suitable for publications.
+Vivliostyle CLI is a command-line interface for typesetting HTML and Markdown documents. It includes the [Vivliostyle Viewer](https://docs.vivliostyle.org/en/viewer/vivliostyle-viewer/) and generates high-quality PDFs suitable for publications.
 
 ## Creating a Vivliostyle Project
 

--- a/docs/ja/getting-started.md
+++ b/docs/ja/getting-started.md
@@ -1,6 +1,6 @@
 # はじめに
 
-Vivliostyle CLI は、HTML やマークダウン文書を組版するためのコマンドラインインターフェイスです。[Vivliostyle Viewer](https://docs.vivliostyle.org/#/ja/vivliostyle-viewer) を内蔵し、出版物に適した高品質な PDF を生成します。
+Vivliostyle CLI は、HTML やマークダウン文書を組版するためのコマンドラインインターフェイスです。[Vivliostyle Viewer](https://docs.vivliostyle.org/ja/viewer/vivliostyle-viewer/) を内蔵し、出版物に適した高品質な PDF を生成します。
 
 ## Vivliostyle プロジェクトを作成する
 

--- a/docs/ja/themes-and-css.md
+++ b/docs/ja/themes-and-css.md
@@ -94,4 +94,4 @@ vivliostyle build manuscript.md --theme ./my-theme -o paper.pdf
 
 ### Create Book の利用
 
-Create Book を使用すると、あらかじめテーマが設定された状態のプロジェクトを簡単に作成できます。[Create Book](https://docs.vivliostyle.org/#/ja/create-book) を参照してください。
+Create Book を使用すると、あらかじめテーマが設定された状態のプロジェクトを簡単に作成できます。[Create Book](https://docs.vivliostyle.org/ja/cli/getting-started/) を参照してください。

--- a/docs/themes-and-css.md
+++ b/docs/themes-and-css.md
@@ -94,4 +94,4 @@ vivliostyle build manuscript.md --theme ./my-theme -o paper.pdf
 
 ### Using Create Book
 
-By using Create Book, you can easily create a project with a theme already set. Refer to [Create Book](https://docs.vivliostyle.org/#/create-book).
+By using Create Book, you can easily create a project with a theme already set. Refer to [Create Book](https://docs.vivliostyle.org/en/cli/getting-started/).


### PR DESCRIPTION
The `https://docs.vivliostyle.org/#/...` URLs no longer work since the docs site moved to a path-based URL scheme. Replace them with the current URLs.

| Old | New |
|---|---|
| `https://docs.vivliostyle.org/#/vivliostyle-viewer` | `https://docs.vivliostyle.org/en/viewer/vivliostyle-viewer/` |
| `https://docs.vivliostyle.org/#/ja/vivliostyle-viewer` | `https://docs.vivliostyle.org/ja/viewer/vivliostyle-viewer/` |
| `https://docs.vivliostyle.org/#/create-book` | `https://docs.vivliostyle.org/en/cli/getting-started/` |
| `https://docs.vivliostyle.org/#/ja/create-book` | `https://docs.vivliostyle.org/ja/cli/getting-started/` |