### PR TITLE
refactor: Use VFM-exported Valibot schemas for VfmConfig

### DIFF
--- a/.changeset/quiet-rivers-mend.md
+++ b/.changeset/quiet-rivers-mend.md
@@ -1,0 +1,5 @@
+---
+'@vivliostyle/cli': patch
+---
+
+Reuse the Valibot schemas exported from `@vivliostyle/vfm` for `vfm:` config validation, surfacing newly added options (`editPlugins`, `captionlessImagePolicy`, expanded `footnote` variants) in the documented config schema.

--- a/docs/config.md
+++ b/docs/config.md
@@ -659,71 +659,95 @@ type CoverConfig = {
 
 - `VfmConfig`
 
-  - `style`: (string)[] | string  
-    Path(s) or URL(s) to custom stylesheets.
-
-  - `partial`: boolean  
-    Output markdown fragments instead of a full document.
+  - `style`: string | (string)[]  
+    Custom stylesheet path/URL.
 
   - `title`: string  
-    Title of the document (ignored in partial mode).
+    Document title (ignored in partial mode).
 
   - `language`: string  
-    Language of the document (ignored in partial mode).
+    Document language (ignored in partial mode).
 
-  - `replace`: ({test: RegExp; match: (result: RegExpMatchArray, h: any) => Object | string})[]  
-    Handlers for replacing matched HTML strings.
+  - `editPlugins`: (plugins: BuiltinPlugins) => EditedPlugins  
+    Edit the plugin lists assembled by VFM before they are used.
 
   - `hardLineBreaks`: boolean  
-    Insert `<br>` tags at hard line breaks without requiring spaces.
-
-  - `disableFormatHtml`: boolean  
-    Disable automatic HTML formatting.
+    Add `<br>` at the position of hard line breaks, without needing spaces.
 
   - `math`: boolean  
-    Enable support for math syntax.
+    Enable math syntax.
+
+  - `partial`: boolean  
+    Output markdown fragments.
+
+  - `disableFormatHtml`: boolean  
+    Disable automatic HTML format.
 
   - `imgFigcaptionOrder`: "img-figcaption" | "figcaption-img"  
     Order of img and figcaption elements in figure.
 
   - `assignIdToFigcaption`: boolean  
-    Assign ID to figcaption instead of img/code.
+    Assign ID to figcaption instead of the `<code>` element.
 
-  - `footnote`: "pandoc" | "dpub" | "gcpm" | {mode: "pandoc" | "dpub" | "gcpm"}  
-    Footnote output mode. Default is `'pandoc'` (endnote section).
+  - `captionlessImagePolicy`: "paragraph" | "figure" | "figure-with-figcaption"  
+    How to render an image-only paragraph whose `alt` is empty.
+
+  - `footnote`: "pandoc" | "dpub" | "gcpm" | {mode: "pandoc"} | {mode: "dpub"; call?: import("hast").Properties | DpubCallFactory; body?: import("hast").Properties | DpubBodyFactory} | {mode: "gcpm"; body?: import("hast").Properties | GcpmBodyFactory; duplicatedCall?: import("hast").Properties | GcpmDuplicatedCallFactory}
+
+  - `replace`: ({test: RegExp; match: (result: RegExpMatchArray, h: typeof import("hastscript").h) => import("unist").Node | string})[]
 
 #### Type definition
 
 ```ts
 type VfmConfig = {
-  style?: string[] | string;
-  partial?: boolean;
+  style?: string | string[];
   title?: string;
   language?: string;
-  replace?: {
-    test: RegExp;
-    match: (
-      result: RegExpMatchArray,
-      h: any,
-    ) => Object | string;
-  }[];
+  editPlugins?: (
+    plugins: BuiltinPlugins,
+  ) => EditedPlugins;
   hardLineBreaks?: boolean;
-  disableFormatHtml?: boolean;
   math?: boolean;
+  partial?: boolean;
+  disableFormatHtml?: boolean;
   imgFigcaptionOrder?:
     | "img-figcaption"
     | "figcaption-img";
   assignIdToFigcaption?: boolean;
+  captionlessImagePolicy?:
+    | "paragraph"
+    | "figure"
+    | "figure-with-figcaption";
   footnote?:
     | "pandoc"
     | "dpub"
     | "gcpm"
+    | { mode: "pandoc" }
     | {
-        mode:
-          | "pandoc"
-          | "dpub"
-          | "gcpm";
+        mode: "dpub";
+        call?:
+          | import("hast").Properties
+          | DpubCallFactory;
+        body?:
+          | import("hast").Properties
+          | DpubBodyFactory;
+      }
+    | {
+        mode: "gcpm";
+        body?:
+          | import("hast").Properties
+          | GcpmBodyFactory;
+        duplicatedCall?:
+          | import("hast").Properties
+          | GcpmDuplicatedCallFactory;
       };
+  replace?: {
+    test: RegExp;
+    match: (
+      result: RegExpMatchArray,
+      h: typeof import("hastscript").h,
+    ) => import("unist").Node | string;
+  }[];
 };
 ```
 

--- a/scripts/update-docs.ts
+++ b/scripts/update-docs.ts
@@ -36,6 +36,7 @@ async function buildConfigDocs(): Promise<string> {
     | v.ObjectSchema<v.ObjectEntries, any>
     | v.LooseObjectSchema<v.ObjectEntries, any>
     | v.UnionSchema<v.UnionOptions, any>
+    | v.VariantSchema<string, v.VariantOptions<string>, any>
     | v.IntersectSchema<v.IntersectOptions, any>
     | v.OptionalSchema<any, any>
     | v.NonOptionalSchemaAsync<any, any>
@@ -113,7 +114,11 @@ async function buildConfigDocs(): Promise<string> {
         )
         .join('; ')}}`;
       properties = { ...schema.entries };
-    } else if (v.isOfType('union', schema) || v.isOfType('intersect', schema)) {
+    } else if (
+      v.isOfType('union', schema) ||
+      v.isOfType('variant', schema) ||
+      v.isOfType('intersect', schema)
+    ) {
       const out = await [...schema.options].reduce(
         (acc, option) =>
           acc.then(async (acc) => [...acc, await traverse(option)]),
@@ -126,24 +131,44 @@ async function buildConfigDocs(): Promise<string> {
           /^{.+}$/g.test(getSchema(option)[definition] ?? ''),
         )
       ) {
-        // Merge plain object intersections
-        schema[definition] = `{${schema.options
-          .map((option) =>
-            (getSchema(option)[definition] ?? '').replace(/^{(.+)}$/, '$1'),
-          )
-          .join(';')}}`;
-        properties = [...schema.options].reduce(
-          (acc, option) => ({
-            ...acc,
-            ...(option as v.ObjectSchema<v.ObjectEntries, any>).entries,
-          }),
+        // Merge plain object intersections, recursing through nested
+        // intersects so all leaf entries contribute to `properties`
+        // (later occurrences of the same key override earlier ones, just
+        // as TypeScript's intersection semantics would).
+        const collectEntries = (
+          s: v.BaseSchema<any, any, any>,
+        ): v.ObjectEntries => {
+          const inner = getSchema(s);
+          if (
+            v.isOfType('object', inner) ||
+            v.isOfType('loose_object', inner)
+          ) {
+            return { ...inner.entries };
+          }
+          if (v.isOfType('intersect', inner)) {
+            return [...inner.options].reduce(
+              (acc, option) => ({ ...acc, ...collectEntries(option) }),
+              {} as v.ObjectEntries,
+            );
+          }
+          return {};
+        };
+        const merged = [...schema.options].reduce(
+          (acc, option) => ({ ...acc, ...collectEntries(option) }),
           {} as v.ObjectEntries,
         );
+        properties = merged;
+        schema[definition] = `{${Object.entries<any>(merged)
+          .map(
+            ([k, value]) =>
+              `${v.isOfType('optional', value) ? `${k}?` : k}: ${getSchema(value)[definition] || 'unknown'}`,
+          )
+          .join('; ')}}`;
       } else {
         schema[definition] = schema.options
           .map((option) => getSchema(option)[definition])
           .filter(Boolean)
-          .join(schema.type === 'union' ? ' | ' : ' & ');
+          .join(schema.type === 'intersect' ? ' & ' : ' | ');
       }
     } else if (
       v.isOfType('optional', schema) ||

--- a/scripts/update-docs.ts
+++ b/scripts/update-docs.ts
@@ -132,9 +132,7 @@ async function buildConfigDocs(): Promise<string> {
         )
       ) {
         // Merge plain object intersections, recursing through nested
-        // intersects so all leaf entries contribute to `properties`
-        // (later occurrences of the same key override earlier ones, just
-        // as TypeScript's intersection semantics would).
+        // intersects so all leaf entries contribute to `properties`.
         const collectEntries = (
           s: v.BaseSchema<any, any, any>,
         ): v.ObjectEntries => {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1,4 +1,8 @@
-import type { Metadata, StringifyMarkdownOptions } from '@vivliostyle/vfm';
+import {
+  type Metadata,
+  type StringifyMarkdownOptions,
+  StringifyMarkdownOptionsSchema,
+} from '@vivliostyle/vfm';
 import { satisfies as semverSatisfies } from 'semver';
 import type { Processor } from 'unified';
 import upath from 'upath';
@@ -419,35 +423,6 @@ export const OutputConfig = v.pipe(
 );
 export type OutputConfig = v.InferInput<typeof OutputConfig>;
 
-// Use v.looseObject to allow unknown keys in future VFM versions
-export const VfmReplaceRule = v.looseObject({
-  test: v.instance(RegExp),
-  match: v.pipe(
-    v.function() as v.GenericSchema<
-      (result: RegExpMatchArray, h: any) => Object | string
-    >,
-    // https://github.com/fabian-hiller/valibot/issues/243
-    v.metadata({
-      typeString: '(result: RegExpMatchArray, h: any) => Object | string',
-    }),
-  ),
-});
-export type VfmReplaceRule = v.InferInput<typeof VfmReplaceRule>;
-
-export const VfmFootnoteMode = v.union([
-  v.literal('pandoc'),
-  v.literal('dpub'),
-  v.literal('gcpm'),
-]);
-export type VfmFootnoteMode = v.InferInput<typeof VfmFootnoteMode>;
-
-export const VfmFootnoteOptions = v.union([
-  VfmFootnoteMode,
-  // Use v.looseObject to allow unknown keys in future VFM versions
-  v.looseObject({ mode: VfmFootnoteMode }),
-]);
-export type VfmFootnoteOptions = v.InferInput<typeof VfmFootnoteOptions>;
-
 export const BrowserType = v.union([
   v.literal('chrome'),
   v.literal('chromium'),
@@ -626,83 +601,8 @@ export const CoverConfig = v.pipe(
 );
 export type CoverConfig = v.InferInput<typeof CoverConfig>;
 
-const VfmConfig = v.pipe(
-  v.partial(
-    // Use v.looseObject to allow unknown keys in future VFM versions
-    v.looseObject({
-      style: v.pipe(
-        v.union([v.array(ValidString), ValidString]),
-
-        v.transform((input) => [input].flat()),
-        v.description($`
-          Path(s) or URL(s) to custom stylesheets.
-        `),
-      ),
-      partial: v.pipe(
-        v.boolean(),
-        v.description($`
-          Output markdown fragments instead of a full document.
-        `),
-      ),
-      title: v.pipe(
-        ValidString,
-        v.description($`
-          Title of the document (ignored in partial mode).
-        `),
-      ),
-      language: v.pipe(
-        ValidString,
-        v.description($`
-          Language of the document (ignored in partial mode).
-        `),
-      ),
-      replace: v.pipe(
-        v.array(VfmReplaceRule),
-        v.description($`
-          Handlers for replacing matched HTML strings.
-        `),
-      ),
-      hardLineBreaks: v.pipe(
-        v.boolean(),
-        v.description($`
-          Insert \`<br>\` tags at hard line breaks without requiring spaces.
-        `),
-      ),
-      disableFormatHtml: v.pipe(
-        v.boolean(),
-        v.description($`
-          Disable automatic HTML formatting.
-        `),
-      ),
-      math: v.pipe(
-        v.boolean(),
-        v.description($`
-          Enable support for math syntax.
-        `),
-      ),
-      imgFigcaptionOrder: v.pipe(
-        v.union([v.literal('img-figcaption'), v.literal('figcaption-img')]),
-        v.description($`
-          Order of img and figcaption elements in figure.
-        `),
-      ),
-      assignIdToFigcaption: v.pipe(
-        v.boolean(),
-        v.description($`
-          Assign ID to figcaption instead of img/code.
-        `),
-      ),
-      footnote: v.pipe(
-        VfmFootnoteOptions,
-        v.description($`
-          Footnote output mode. Default is \`'pandoc'\` (endnote section).
-        `),
-      ),
-    }),
-  ),
-  v.title('VfmConfig'),
-);
-export type VfmConfig = v.InferInput<typeof VfmConfig>;
+const VfmConfig = v.pipe(StringifyMarkdownOptionsSchema, v.title('VfmConfig'));
+export type VfmConfig = StringifyMarkdownOptions;
 
 export const ServerConfig = v.pipe(
   v.partial(


### PR DESCRIPTION
refs: https://github.com/vivliostyle/vfm/pull/243

VFM 2.7.0では、VFMのオプションをプラグインのオプションのインターセクションとして整理し、Vivliostyle CLIでの追従を楽にするためにValibotスキーマをexportしていますので、ぜひ使っていただきたいです。