### PR TITLE
feat: Update Vivliostyle.js to 2.43.0: typed attr() support and bug fixes

### DIFF
--- a/.changeset/sweet-seas-study.md
+++ b/.changeset/sweet-seas-study.md
@@ -1,0 +1,5 @@
+---
+'@vivliostyle/cli': minor
+---
+
+Update Vivliostyle.js to 2.43.0: typed attr() support and bug fixes

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@puppeteer/browsers": "2.10.5",
     "@vivliostyle/jsdom": "25.0.1-vivliostyle-cli.2",
     "@vivliostyle/vfm": "2.7.0",
-    "@vivliostyle/viewer": "2.42.1",
+    "@vivliostyle/viewer": "2.43.0",
     "ajv": "8.18.0",
     "ajv-formats": "3.0.1",
     "archiver": "7.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: 2.7.0
         version: 2.7.0(typescript@5.8.3)
       '@vivliostyle/viewer':
-        specifier: 2.42.1
-        version: 2.42.1
+        specifier: 2.43.0
+        version: 2.43.0
       ajv:
         specifier: 8.18.0
         version: 8.18.0
@@ -2293,8 +2293,8 @@ packages:
   '@vitest/utils@4.1.6':
     resolution: {integrity: sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==}
 
-  '@vivliostyle/core@2.42.1':
-    resolution: {integrity: sha512-4BEW/aJX8u3O/zugKg/VtST3umwDKlOHCJ5iaTkJowfeGa6i3Jev7p6wF91XppjGgYi/+wcsH8/O8wk0aZGwGA==}
+  '@vivliostyle/core@2.43.0':
+    resolution: {integrity: sha512-kDK8WxLWY3/Qj/bLNz3Hdn88m6qZkx7zpDep9AsnwqpX8HZAsLfW3+p94nWdLV6r/yz8RIbT1Lxc/xKojnOKEg==}
     engines: {node: '>=20'}
 
   '@vivliostyle/jsdom@25.0.1-vivliostyle-cli.2':
@@ -2311,8 +2311,8 @@ packages:
     engines: {node: '>= 20'}
     hasBin: true
 
-  '@vivliostyle/viewer@2.42.1':
-    resolution: {integrity: sha512-JyKIpyaR9LLsquV0101z8FVfd5Y4ifVjRJN+zQ1SWktoI2xEPk0tT15z5rMWiONZ4STIi+BcsPcWI2BSJo8p4A==}
+  '@vivliostyle/viewer@2.43.0':
+    resolution: {integrity: sha512-Tk+DbOJh61g1bV6ajV4fDo1uN+Iqz8U3A7UQcpkvR1pmKYJo8O8Ztj3e4qHF4aDze/lHZn+Y8eKjeVlxuboQzQ==}
     engines: {node: '>=20'}
 
   '@zachleat/heading-anchors@1.0.5':
@@ -8428,7 +8428,7 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  '@vivliostyle/core@2.42.1':
+  '@vivliostyle/core@2.43.0':
     dependencies:
       fast-diff: 1.3.0
 
@@ -8505,9 +8505,9 @@ snapshots:
       - supports-color
       - typescript
 
-  '@vivliostyle/viewer@2.42.1':
+  '@vivliostyle/viewer@2.43.0':
     dependencies:
-      '@vivliostyle/core': 2.42.1
+      '@vivliostyle/core': 2.43.0
       i18next-ko: 3.0.1
       knockout: 3.5.3
 


### PR DESCRIPTION
https://github.com/vivliostyle/vivliostyle.js/releases/tag/v2.43.0

### Features

- Support typed CSS `attr()` values

### Bug Fixes

- repeat table headers on nested rowspan continuations
- counter-style: count grapheme clusters for pad descriptor
- Prevent endless pagination on invalid page layouts
- Fix `@page` counter-set for page-based counters
- Fix attribute selector case sensitivity
- Fix all resetting browser-backed shorthand longhands
- Fix WPT CSS variable resolution edge cases
- Improve browser shorthand expansion and generated content text-box support
- Preserve named page styles during target-counter relayout