### PR TITLE
fix(docker): Add `unzip` for @puppeteer/browsers v3+ Chrome extraction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,8 @@ RUN set -x \
     ghostscript poppler-utils \
     # for Puppeteer Firefox installation
     xz-utils \
+    # for @puppeteer/browsers v3+ Chrome zip extraction
+    unzip \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* `npm config get cache`/_npx
 
 # Install fonts


### PR DESCRIPTION
\`@puppeteer/browsers\` v3 以降、Chrome のダウンロード形式が変わり ZIP ファイルの展開に \`unzip\` が必要になりました。Dockerfile に \`unzip\` パッケージを追加することで、Docker 環境でのブラウザインストールを修正します。

- Add \`unzip\` to apt-get install list in Dockerfile (required for \`@puppeteer/browsers\` v3+ Chrome zip extraction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)