### PR TITLE
fix(test): Run Vitest with the forks pool on all platforms to avoid native-module segfaults

### DIFF
--- a/.changeset/dirty-chicken-hear.md
+++ b/.changeset/dirty-chicken-hear.md
@@ -1,0 +1,5 @@
+---
+'@vivliostyle/cli': patch
+---
+
+Run tests with Vitest's default `forks` pool on all platforms to avoid native-module segfaults in CI.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,11 +16,5 @@ export default defineConfig({
       NO_COLOR: 'true',
     },
     clearMocks: true,
-    pool:
-      process.platform === 'linux'
-        ? // In Linux, we need to use forks mode to avoid segfaults
-          // https://vitest.dev/guide/common-errors.html#segfaults-and-native-code-errors
-          'forks'
-        : 'threads',
   },
 });


### PR DESCRIPTION
closes: #697

この設定の作成時のVitestのデフォルトは`threads`でしたが、現在デフォルトは`forks`なので、この記述を削除することでIssueの指摘を解消できます。

https://github.com/vitest-dev/vitest/blob/v4.1.6/packages/vitest/src/node/cli/cli-config.ts#L443-L445

失敗しているCIは #815 で解消されるはずです。
