### PR TITLE
fix: Update Vivliostyle.js to 2.43.1: Bug Fixes

### DIFF
--- a/.changeset/kind-cameras-swim.md
+++ b/.changeset/kind-cameras-swim.md
@@ -1,0 +1,5 @@
+---
+'@vivliostyle/cli': patch
+---
+
+Update Vivliostyle.js to 2.43.1: Bug Fixes

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@puppeteer/browsers": "2.10.5",
     "@vivliostyle/jsdom": "25.0.1-vivliostyle-cli.2",
     "@vivliostyle/vfm": "2.7.0",
-    "@vivliostyle/viewer": "2.43.0",
+    "@vivliostyle/viewer": "2.43.1",
     "ajv": "8.18.0",
     "ajv-formats": "3.0.1",
     "archiver": "7.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: 2.7.0
         version: 2.7.0(typescript@5.8.3)
       '@vivliostyle/viewer':
-        specifier: 2.43.0
-        version: 2.43.0
+        specifier: 2.43.1
+        version: 2.43.1
       ajv:
         specifier: 8.18.0
         version: 8.18.0
@@ -2293,8 +2293,8 @@ packages:
   '@vitest/utils@4.1.6':
     resolution: {integrity: sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==}
 
-  '@vivliostyle/core@2.43.0':
-    resolution: {integrity: sha512-kDK8WxLWY3/Qj/bLNz3Hdn88m6qZkx7zpDep9AsnwqpX8HZAsLfW3+p94nWdLV6r/yz8RIbT1Lxc/xKojnOKEg==}
+  '@vivliostyle/core@2.43.1':
+    resolution: {integrity: sha512-5CKJJDquiGcyS2ZxfK9Ik9jonHK7Pjlod/ZDMoN0hvEjnQXeLgOuArAQYTaE3mNslXNKgc9pRLTFrV6Aq054hg==}
     engines: {node: '>=20'}
 
   '@vivliostyle/jsdom@25.0.1-vivliostyle-cli.2':
@@ -2311,8 +2311,8 @@ packages:
     engines: {node: '>= 20'}
     hasBin: true
 
-  '@vivliostyle/viewer@2.43.0':
-    resolution: {integrity: sha512-Tk+DbOJh61g1bV6ajV4fDo1uN+Iqz8U3A7UQcpkvR1pmKYJo8O8Ztj3e4qHF4aDze/lHZn+Y8eKjeVlxuboQzQ==}
+  '@vivliostyle/viewer@2.43.1':
+    resolution: {integrity: sha512-wSVRlmODjC+LCEYLwQEOP1bYp+BKVtkhB3tOYiAwU+r6K1RSAAarfBuLQy7UUcnb4m5AB/dSwyTOUssxbT6mUw==}
     engines: {node: '>=20'}
 
   '@zachleat/heading-anchors@1.0.5':
@@ -8427,7 +8427,7 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  '@vivliostyle/core@2.43.0':
+  '@vivliostyle/core@2.43.1':
     dependencies:
       fast-diff: 1.3.0
 
@@ -8504,9 +8504,9 @@ snapshots:
       - supports-color
       - typescript
 
-  '@vivliostyle/viewer@2.43.0':
+  '@vivliostyle/viewer@2.43.1':
     dependencies:
-      '@vivliostyle/core': 2.43.0
+      '@vivliostyle/core': 2.43.1
       i18next-ko: 3.0.1
       knockout: 3.5.3
 


### PR DESCRIPTION
https://github.com/vivliostyle/vivliostyle.js/releases/tag/v2.43.1

### Bug Fixes

- Keep clear page and column blocks visible after page floats
- Fix named page boundaries for inline content
- Fix `footnote-policy: line` page breaks
- Fix `outline-offset` handling in `@page` rules
- Resolve string-set with counter(page) and counter(pages)
- Fix `counter()` resolution in `@page` margin box content
- Fix nested named page starts and `:nth()` page-group matching
- Preserve named pages after deferred footnote text
- Fix `:nth(1 of Page)` after `target-counter()` rerender
- Fix text disappearing when `clear` follows a footnote