### PR TITLE
fix: Update Vivliostyle.js to 2.43.2: Bug Fixes

### DIFF
--- a/.changeset/tidy-paws-repair.md
+++ b/.changeset/tidy-paws-repair.md
@@ -1,0 +1,5 @@
+---
+'@vivliostyle/cli': patch
+---
+
+Update Vivliostyle.js to 2.43.2: Bug Fixes

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@puppeteer/browsers": "3.0.4",
     "@vivliostyle/jsdom": "25.0.1-vivliostyle-cli.2",
     "@vivliostyle/vfm": "2.7.0",
-    "@vivliostyle/viewer": "2.43.1",
+    "@vivliostyle/viewer": "2.43.2",
     "ajv": "8.18.0",
     "ajv-formats": "3.0.1",
     "archiver": "7.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: 2.7.0
         version: 2.7.0(typescript@5.8.3)
       '@vivliostyle/viewer':
-        specifier: 2.43.1
-        version: 2.43.1
+        specifier: 2.43.2
+        version: 2.43.2
       ajv:
         specifier: 8.18.0
         version: 8.18.0
@@ -2287,8 +2287,8 @@ packages:
   '@vitest/utils@4.1.6':
     resolution: {integrity: sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==}
 
-  '@vivliostyle/core@2.43.1':
-    resolution: {integrity: sha512-5CKJJDquiGcyS2ZxfK9Ik9jonHK7Pjlod/ZDMoN0hvEjnQXeLgOuArAQYTaE3mNslXNKgc9pRLTFrV6Aq054hg==}
+  '@vivliostyle/core@2.43.2':
+    resolution: {integrity: sha512-l4c6nv83C2GrYrVYJV9LhcVoq8gKihtdS1rXEdbHu6jvsXSOzMy2l3njFih40jRIcWy/4gx9L/rnSkPUMkCx/Q==}
     engines: {node: '>=20'}
 
   '@vivliostyle/jsdom@25.0.1-vivliostyle-cli.2':
@@ -2305,8 +2305,8 @@ packages:
     engines: {node: '>= 20'}
     hasBin: true
 
-  '@vivliostyle/viewer@2.43.1':
-    resolution: {integrity: sha512-wSVRlmODjC+LCEYLwQEOP1bYp+BKVtkhB3tOYiAwU+r6K1RSAAarfBuLQy7UUcnb4m5AB/dSwyTOUssxbT6mUw==}
+  '@vivliostyle/viewer@2.43.2':
+    resolution: {integrity: sha512-Vh0w1MtS466EvAaGEoXEwter7lDwHKA0ige3mEmX2liLLHzCLjvTaAsGR3eZzA93pclUfh5YLrQRnrYDNaP2Mg==}
     engines: {node: '>=20'}
 
   '@zachleat/heading-anchors@1.0.5':
@@ -8295,7 +8295,7 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  '@vivliostyle/core@2.43.1':
+  '@vivliostyle/core@2.43.2':
     dependencies:
       fast-diff: 1.3.0
 
@@ -8372,9 +8372,9 @@ snapshots:
       - supports-color
       - typescript
 
-  '@vivliostyle/viewer@2.43.1':
+  '@vivliostyle/viewer@2.43.2':
     dependencies:
-      '@vivliostyle/core': 2.43.1
+      '@vivliostyle/core': 2.43.2
       i18next-ko: 3.0.1
       knockout: 3.5.3
 


### PR DESCRIPTION
https://github.com/vivliostyle/vivliostyle.js/releases/tag/v2.43.2

### Bug Fixes

- Prevent first-child named pages from reviving on later pages
- Fix `target-counter()` crash after spread blank pages