### PR TITLE
change: Deprecate `renderMode: docker` option

### DIFF
--- a/.changeset/deprecate-render-mode-docker.md
+++ b/.changeset/deprecate-render-mode-docker.md
@@ -1,0 +1,5 @@
+---
+'@vivliostyle/cli': patch
+---
+
+Deprecate the `renderMode: docker` option. Using it now prints a warning that links to https://github.com/vivliostyle/vivliostyle-cli/issues/823, where you can find the background and share your feedback.

--- a/docs/config.md
+++ b/docs/config.md
@@ -381,6 +381,7 @@ type ArticleEntryConfig = {
 
   - `renderMode`: "local" | "docker"  
     If set to `docker`, Vivliostyle will render the PDF using a Docker container. (default: `local`)
+    `renderMode: docker` is deprecated and may be removed in a future major release. See https://github.com/vivliostyle/vivliostyle-cli/issues/823
 
   - ~~`preflight`~~ _Deprecated_  
     Use `pdfPostprocess.preflight` instead

--- a/docs/ja/special-output-settings.md
+++ b/docs/ja/special-output-settings.md
@@ -55,6 +55,9 @@ vivliostyle build manuscript.md --preflight press-ready --preflight-option enfor
 
 - [Example: render-on-docker](https://github.com/vivliostyle/vivliostyle-cli/tree/main/examples/render-on-docker)
 
+> [!WARNING]
+> `renderMode: docker` オプション（`--render-mode docker`）は非推奨となり、将来のメジャーリリースで削除される可能性があります。背景やフィードバックについては [#823](https://github.com/vivliostyle/vivliostyle-cli/issues/823) を参照してください。
+
 `vivliostyle build` コマンドで `--render-mode docker` オプションを指定すると、PDF 出力時の環境として Docker を指定できます（上記のオプションでは後処理のみ Docker 上で実行しますが、このオプションは全ての処理を Docker 上で実行します）Docker を用いることで出力時の環境を固定できるため、異なる環境・OSでも同じ出力結果となることを保証できます。
 
 Docker render mode を使用する際は、以下の点に注意してください。

--- a/docs/special-output-settings.md
+++ b/docs/special-output-settings.md
@@ -55,6 +55,9 @@ You can also specify the `--preflight press-ready-local` option to execute the o
 
 - [Example: render-on-docker](https://github.com/vivliostyle/vivliostyle-cli/tree/main/examples/render-on-docker)
 
+> [!WARNING]
+> The `renderMode: docker` option (`--render-mode docker`) is deprecated and may be removed in a future major release. See [#823](https://github.com/vivliostyle/vivliostyle-cli/issues/823) for the background and to share your feedback.
+
 To specify Docker as the environment for PDF output, use the `--render-mode docker` option in the `vivliostyle build` command (the above option only executes post-processing on Docker, but this option executes all processing on Docker). This option ensures that all processing is executed on Docker, fixing the environment at the time of output and ensuring consistent results across different environments and OS.
 
 When using Docker render mode, please note the following points:

--- a/src/commands/build.parser.ts
+++ b/src/commands/build.parser.ts
@@ -110,7 +110,7 @@ This option is equivalent with "--preflight press-ready"`,
     .addOption(
       new Option(
         '--render-mode <mode>',
-        'if docker is set, Vivliostyle try to render PDF on Docker container [local] (note: `docker` is deprecated, see https://github.com/vivliostyle/vivliostyle-cli/issues/823)',
+        'if docker is set, Vivliostyle tries to render PDF on Docker container [local] (note: `docker` is deprecated, see https://github.com/vivliostyle/vivliostyle-cli/issues/823)',
       ).choices(['local', 'docker']),
     )
     .addOption(

--- a/src/commands/build.parser.ts
+++ b/src/commands/build.parser.ts
@@ -110,7 +110,7 @@ This option is equivalent with "--preflight press-ready"`,
     .addOption(
       new Option(
         '--render-mode <mode>',
-        'if docker is set, Vivliostyle try to render PDF on Docker container [local]',
+        'if docker is set, Vivliostyle try to render PDF on Docker container [local] (note: `docker` is deprecated, see https://github.com/vivliostyle/vivliostyle-cli/issues/823)',
       ).choices(['local', 'docker']),
     )
     .addOption(

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -2,8 +2,10 @@ import fs from 'node:fs';
 import { createRequire } from 'node:module';
 import { pathToFileURL } from 'node:url';
 
+import terminalLink from 'terminal-link';
 import upath from 'upath';
 import * as v from 'valibot';
+import { cyan, underline } from 'yoctocolors';
 
 import { Logger } from '../logger.js';
 import {
@@ -135,6 +137,27 @@ export function warnDeprecatedConfig(config: ParsedVivliostyleConfigSchema) {
   ) {
     Logger.logWarn(
       "'preflightOption' property of output config was deprecated and will be removed in a future release. Please use 'pdfPostprocess.preflightOption' property instead.",
+    );
+  }
+
+  if (
+    config.inlineOptions.renderMode === 'docker' ||
+    config.tasks.some(
+      (task) =>
+        task.output &&
+        [task.output].flat().some((o) => o.renderMode === 'docker'),
+    )
+  ) {
+    const issueUrl =
+      'https://github.com/vivliostyle/vivliostyle-cli/issues/823';
+    const issueLinkText = underline(issueUrl);
+    const issueLink = terminalLink(issueLinkText, issueUrl, {
+      fallback: () => issueLinkText,
+    });
+    Logger.logWarn(
+      `'renderMode: docker' option was deprecated and may be removed in a future major release.\n${cyan(
+        `     See ${issueLink} for details and to share your feedback.`,
+      )}`,
     );
   }
 }

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -396,8 +396,10 @@ export const OutputConfig = v.pipe(
         ),
         renderMode: v.pipe(
           RenderMode,
+          v.metadata({ deprecated: true }),
           v.description($`
             If set to \`docker\`, Vivliostyle will render the PDF using a Docker container. (default: \`local\`)
+            \`renderMode: docker\` is deprecated and may be removed in a future major release. See https://github.com/vivliostyle/vivliostyle-cli/issues/823
           `),
         ),
         /** @deprecated */
@@ -1143,6 +1145,7 @@ export const VivliostyleInlineConfigWithoutChecks = v.partial(
       RenderMode,
       v.description($`
           If docker is set, Vivliostyle try to render PDF on Docker container. [local]
+          \`renderMode: docker\` is deprecated and may be removed in a future major release. See https://github.com/vivliostyle/vivliostyle-cli/issues/823
         `),
     ),
     preflight: v.pipe(

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,8 +1,11 @@
 import { VFM, readMetadata } from '@vivliostyle/vfm';
+import * as v from 'valibot';
 import { expect, it, onTestFinished, vi } from 'vitest';
 
+import { warnDeprecatedConfig } from '../src/config/load.js';
 import { UseTemporaryServerRoot } from '../src/config/resolve.js';
-import type { VivliostyleConfigSchema } from '../src/config/schema.js';
+import { VivliostyleConfigSchema } from '../src/config/schema.js';
+import { Logger } from '../src/logger.js';
 import { getTaskConfig, maskConfig, resolveFixture } from './command-util.js';
 
 const validConfigData = {
@@ -697,4 +700,28 @@ it('output-level pdfPostprocess.preflight overrides output.preflight', async () 
     format: 'pdf',
     preflight: 'press-ready-local',
   });
+});
+
+it('warns when output config uses deprecated renderMode: docker', () => {
+  const warn = vi.spyOn(Logger, 'logWarn').mockImplementation(() => {});
+  onTestFinished(() => warn.mockRestore());
+  const config = v.parse(VivliostyleConfigSchema, {
+    entry: 'manuscript.md',
+    output: [{ path: 'output.pdf', renderMode: 'docker' }],
+  });
+  warnDeprecatedConfig(config);
+  expect(warn).toHaveBeenCalledWith(
+    expect.stringContaining('vivliostyle-cli/issues/823'),
+  );
+});
+
+it('warns when --render-mode docker is passed as an inline option', () => {
+  const warn = vi.spyOn(Logger, 'logWarn').mockImplementation(() => {});
+  onTestFinished(() => warn.mockRestore());
+  const config = v.parse(VivliostyleConfigSchema, { entry: 'manuscript.md' });
+  config.inlineOptions.renderMode = 'docker';
+  warnDeprecatedConfig(config);
+  expect(warn).toHaveBeenCalledWith(
+    expect.stringContaining('vivliostyle-cli/issues/823'),
+  );
 });


### PR DESCRIPTION
Emit a warning when `renderMode: docker` is used via config or the `--render-mode docker` flag, linking to #823 for background and feedback. Mark the option as deprecated in the schema and document the deprecation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)