### PR TITLE
Improve cleanup on interrupted CLI commands

### DIFF
--- a/.changeset/clean-cli-termination.md
+++ b/.changeset/clean-cli-termination.md
@@ -1,0 +1,5 @@
+---
+'@vivliostyle/cli': patch
+---
+
+Ensure CLI termination waits for active work to abort and cleanup to complete.

--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     "shx": "0.4.0",
     "supertest": "7.2.2",
     "tsup": "8.5.1",
+    "tsx": "4.19.3",
     "typedoc": "^0.28.3",
     "typedoc-plugin-markdown": "4.6.3",
     "typescript": "5.8.3",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "vite": "8.0.12",
     "w3c-xmlserializer": "5.0.0",
     "whatwg-mimetype": "4.0.0",
-    "yocto-spinner": "0.2.2",
+    "yocto-spinner": "1.2.0",
     "yoctocolors": "2.1.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -288,6 +288,9 @@ importers:
       tsup:
         specifier: 8.5.1
         version: 8.5.1(postcss@8.5.14)(tsx@4.19.3)(typescript@5.8.3)(yaml@2.9.0)
+      tsx:
+        specifier: 4.19.3
+        version: 4.19.3
       typedoc:
         specifier: ^0.28.3
         version: 0.28.15(typescript@5.8.3)
@@ -9613,7 +9616,6 @@ snapshots:
       '@esbuild/win32-arm64': 0.25.12
       '@esbuild/win32-ia32': 0.25.12
       '@esbuild/win32-x64': 0.25.12
-    optional: true
 
   esbuild@0.25.3:
     optionalDependencies:
@@ -9978,7 +9980,6 @@ snapshots:
   get-tsconfig@4.14.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
-    optional: true
 
   github-slugger@2.0.0: {}
 
@@ -12383,8 +12384,7 @@ snapshots:
 
   resolve-from@5.0.0: {}
 
-  resolve-pkg-maps@1.0.0:
-    optional: true
+  resolve-pkg-maps@1.0.0: {}
 
   resolve-pkg@2.0.0:
     dependencies:
@@ -13115,7 +13115,6 @@ snapshots:
       get-tsconfig: 4.14.0
     optionalDependencies:
       fsevents: 2.3.3
-    optional: true
 
   tuf-js@4.0.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -177,8 +177,8 @@ importers:
         specifier: 4.0.0
         version: 4.0.0
       yocto-spinner:
-        specifier: 0.2.2
-        version: 0.2.2
+        specifier: 1.2.0
+        version: 1.2.0
       yoctocolors:
         specifier: 2.1.1
         version: 2.1.1
@@ -6699,12 +6699,12 @@ packages:
     resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
     engines: {node: '>=12.20'}
 
-  yocto-spinner@0.2.2:
-    resolution: {integrity: sha512-21rPcM3e4vCpOXThiFRByX8amU5By1R0wNS8Oex+DP3YgC8xdU0vEJ/K8cbPLiIJVosSSysgcFof6s6MSD5/Vw==}
-    engines: {node: '>=18.19'}
-
   yocto-spinner@0.2.3:
     resolution: {integrity: sha512-sqBChb33loEnkoXte1bLg45bEBsOP9N1kzQh5JZNKj/0rik4zAPTNSAVPj3uQAdc6slYJ0Ksc403G2XgxsJQFQ==}
+    engines: {node: '>=18.19'}
+
+  yocto-spinner@1.2.0:
+    resolution: {integrity: sha512-Yw0hUB6UA3o4YUgKy3oSe9a4cxoaZ9sBfYDw+JSxo6Id0KoJGoxzPA24qqUXYKBWABs/zDSGTz9kww7t3F0XGw==}
     engines: {node: '>=18.19'}
 
   yoctocolors@2.1.1:
@@ -13663,11 +13663,11 @@ snapshots:
 
   yocto-queue@1.2.2: {}
 
-  yocto-spinner@0.2.2:
+  yocto-spinner@0.2.3:
     dependencies:
       yoctocolors: 2.1.1
 
-  yocto-spinner@0.2.3:
+  yocto-spinner@1.2.0:
     dependencies:
       yoctocolors: 2.1.1
 

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -33,6 +33,72 @@ const browserEnumMap = {
   [key in BrowserType]: SupportedBrowser;
 };
 
+function getAbortReason(signal: AbortSignal): unknown {
+  try {
+    signal.throwIfAborted();
+  } catch (err) {
+    return err;
+  }
+  return signal.reason;
+}
+
+export async function runBrowserOperationWithAbort<T>({
+  signal,
+  closeBrowser,
+  operation,
+}: {
+  signal?: AbortSignal;
+  closeBrowser: () => Promise<void>;
+  operation: () => Promise<T>;
+}): Promise<T> {
+  if (!signal) {
+    return await operation();
+  }
+
+  signal.throwIfAborted();
+
+  let abortClosePromise: Promise<void> | undefined;
+  let removeAbortListener: (() => void) | undefined;
+  const abortPromise = new Promise<never>((_, reject) => {
+    const handleAbort = () => {
+      abortClosePromise = closeBrowser();
+      void abortClosePromise.then(
+        () => reject(getAbortReason(signal)),
+        () => reject(getAbortReason(signal)),
+      );
+    };
+    signal.addEventListener('abort', handleAbort, { once: true });
+    removeAbortListener = () => {
+      signal.removeEventListener('abort', handleAbort);
+    };
+  });
+
+  const operationPromise = operation().catch((err) => {
+    if (signal.aborted) {
+      throw getAbortReason(signal);
+    }
+    throw err;
+  });
+
+  try {
+    const result = await Promise.race([operationPromise, abortPromise]);
+    signal.throwIfAborted();
+    return result;
+  } catch (err) {
+    if (signal.aborted) {
+      try {
+        await (abortClosePromise ?? closeBrowser());
+      } catch (closeError) {
+        Logger.debug('Failed to close browser after abort', closeError);
+      }
+      throw getAbortReason(signal);
+    }
+    throw err;
+  } finally {
+    removeAbortListener?.();
+  }
+}
+
 async function launchBrowser({
   browserType,
   proxy,
@@ -61,6 +127,7 @@ async function launchBrowser({
 }): Promise<{
   browser: Browser;
   browserContext: BrowserContext;
+  closeBrowser: () => Promise<void>;
 }> {
   const puppeteer = await importNodeModule('puppeteer-core');
 
@@ -145,18 +212,20 @@ async function launchBrowser({
     protocolTimeout,
   } satisfies LaunchOptions;
   Logger.debug('launchOptions %O', launchOptions);
-  const browser = await puppeteer.launch({
+  const browserLaunch = puppeteer.launch({
     ...launchOptions,
     env: { ...process.env, LANG: 'en.UTF-8' },
     handleSIGINT: false,
     handleSIGTERM: false,
     handleSIGHUP: false,
   });
-  registerCleanupHandler('Closing browser', async () => {
-    await browser.close();
-  });
+  let closeBrowserPromise: Promise<void> | undefined;
+  const closeBrowser = () =>
+    (closeBrowserPromise ??= browserLaunch.then((browser) => browser.close()));
+  registerCleanupHandler('Closing browser', closeBrowser);
+  const browser = await browserLaunch;
   const [browserContext] = browser.browserContexts();
-  return { browser, browserContext };
+  return { browser, browserContext, closeBrowser };
 }
 
 function getPuppeteerCacheDir() {
@@ -332,7 +401,7 @@ export async function launchPreview({
   }
 
   signal?.throwIfAborted();
-  const { browser, browserContext } = await launchBrowser({
+  const { browser, browserContext, closeBrowser } = await launchBrowser({
     browserType: browserConfig.type,
     proxy,
     executablePath: executableBrowser,
@@ -345,27 +414,34 @@ export async function launchPreview({
   await onBrowserOpen?.(browser);
   signal?.throwIfAborted();
 
-  const page =
-    (await browserContext.pages())[0] ?? (await browserContext.newPage());
-  await page.setViewport(
-    mode === 'build'
-      ? // This viewport size is important to detect headless environment in Vivliostyle viewer
-        // https://github.com/vivliostyle/vivliostyle.js/blob/73bcf323adcad80126b0175630609451ccd09d8a/packages/core/src/vivliostyle/vgen.ts#L2489-L2500
-        { width: 800, height: 600 }
-      : null,
-  );
-  await onPageOpen?.(page);
+  const page = await runBrowserOperationWithAbort({
+    signal,
+    closeBrowser,
+    operation: async () => {
+      const previewPage =
+        (await browserContext.pages())[0] ?? (await browserContext.newPage());
+      await previewPage.setViewport(
+        mode === 'build'
+          ? // This viewport size is important to detect headless environment in Vivliostyle viewer
+            // https://github.com/vivliostyle/vivliostyle.js/blob/73bcf323adcad80126b0175630609451ccd09d8a/packages/core/src/vivliostyle/vgen.ts#L2489-L2500
+            { width: 800, height: 600 }
+          : null,
+      );
+      await onPageOpen?.(previewPage);
 
-  // Prevent confirm dialog from being auto-dismissed
-  page.on('dialog', () => {});
+      // Prevent confirm dialog from being auto-dismissed
+      previewPage.on('dialog', () => {});
 
-  if (proxy?.username && proxy?.password) {
-    await page.authenticate({
-      username: proxy.username,
-      password: proxy.password,
-    });
-  }
-  await page.goto(url, { signal });
+      if (proxy?.username && proxy?.password) {
+        await previewPage.authenticate({
+          username: proxy.username,
+          password: proxy.password,
+        });
+      }
+      await previewPage.goto(url, { signal });
+      return previewPage;
+    },
+  });
 
-  return { browser, page };
+  return { browser, page, closeBrowser };
 }

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -148,6 +148,9 @@ async function launchBrowser({
   const browser = await puppeteer.launch({
     ...launchOptions,
     env: { ...process.env, LANG: 'en.UTF-8' },
+    handleSIGINT: false,
+    handleSIGTERM: false,
+    handleSIGHUP: false,
   });
   registerExitHandler('Closing browser', async () => {
     await browser.close();

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -22,7 +22,7 @@ import {
   getDefaultBrowserTag,
   isInContainer,
   isRunningOnWSL,
-  registerExitHandler,
+  registerCleanupHandler,
 } from './util.js';
 
 const browserEnumMap = {
@@ -152,7 +152,7 @@ async function launchBrowser({
     handleSIGTERM: false,
     handleSIGHUP: false,
   });
-  registerExitHandler('Closing browser', async () => {
+  registerCleanupHandler('Closing browser', async () => {
     await browser.close();
   });
   const [browserContext] = browser.browserContexts();
@@ -283,6 +283,7 @@ async function downloadBrowser({
 export async function launchPreview({
   mode,
   url,
+  signal,
   onBrowserOpen,
   onPageOpen,
   config: {
@@ -295,6 +296,7 @@ export async function launchPreview({
 }: {
   mode: 'preview' | 'build';
   url: string;
+  signal?: AbortSignal;
   onBrowserOpen?: (browser: Browser) => void | Promise<void>;
   onPageOpen?: (page: Page) => void | Promise<void>;
   config: Pick<
@@ -329,6 +331,7 @@ export async function launchPreview({
     }
   }
 
+  signal?.throwIfAborted();
   const { browser, browserContext } = await launchBrowser({
     browserType: browserConfig.type,
     proxy,
@@ -340,6 +343,7 @@ export async function launchPreview({
     protocolTimeout: timeout,
   });
   await onBrowserOpen?.(browser);
+  signal?.throwIfAborted();
 
   const page =
     (await browserContext.pages())[0] ?? (await browserContext.newPage());
@@ -361,7 +365,7 @@ export async function launchPreview({
       password: proxy.password,
     });
   }
-  await page.goto(url);
+  await page.goto(url, { signal });
 
   return { browser, page };
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,23 +1,96 @@
 #!/usr/bin/env node
 
-import { Command } from 'commander';
+import process from 'node:process';
 
+import { Command, CommanderError } from 'commander';
+
+import { runBuildCli } from './commands/build.runner.js';
+import { runCreateCli } from './commands/create.runner.js';
+import { runInitCli } from './commands/init.runner.js';
+import { runPreviewCli } from './commands/preview.runner.js';
+import { isDirectExecution } from './entry-util.js';
 import { versionForDisplay } from './util.js';
 
-const program = new Command();
-program
-  .name('vivliostyle')
-  .version(versionForDisplay, '-v, --version')
-  .command('create', 'Scaffold a new Vivliostyle project', {
-    executableFile: 'commands/create',
-  })
-  .command('init', 'Create a Vivliostyle configuration file', {
-    executableFile: 'commands/init',
-  })
-  .command('build', 'Create PDF, EPUB, and other publication files', {
-    executableFile: 'commands/build',
-  })
-  .command('preview', 'Open the preview page and interactively save PDFs', {
-    executableFile: 'commands/preview',
-  })
-  .parse(process.argv);
+const commandRunners = {
+  build: runBuildCli,
+  create: runCreateCli,
+  init: runInitCli,
+  preview: runPreviewCli,
+} as const;
+
+type CommandName = keyof typeof commandRunners;
+
+function setupProgram(argv: string[]) {
+  const program = new Command()
+    .name('vivliostyle')
+    .version(versionForDisplay, '-v, --version')
+    .helpCommand(false)
+    .exitOverride();
+
+  const addProxyCommand = (command: CommandName, description: string) => {
+    program
+      .command(command)
+      .description(description)
+      .helpOption(false)
+      .allowUnknownOption()
+      .allowExcessArguments()
+      .action(async () => {
+        const commandIndex = argv.indexOf(command);
+        // Preserve `--` so the existing parser does not reinterpret following
+        // option-like operands during its second parse.
+        const commandArgs = argv.slice(commandIndex + 1);
+        await commandRunners[command](['vivliostyle', command, ...commandArgs]);
+      });
+  };
+
+  addProxyCommand('create', 'Scaffold a new Vivliostyle project');
+  addProxyCommand('init', 'Create a Vivliostyle configuration file');
+  addProxyCommand('build', 'Create PDF, EPUB, and other publication files');
+  addProxyCommand(
+    'preview',
+    'Open the preview page and interactively save PDFs',
+  );
+
+  program
+    .command('help [command]')
+    .description('display help for command')
+    .helpOption(false)
+    .allowUnknownOption()
+    .allowExcessArguments()
+    .action(async (command?: string) => {
+      if (!command) {
+        program.help();
+        return;
+      }
+      if (isCommandName(command)) {
+        await commandRunners[command](['vivliostyle', command, '--help']);
+        return;
+      }
+      program.help({ error: true });
+    });
+
+  return program;
+}
+
+function isCommandName(command: string): command is CommandName {
+  return Object.hasOwn(commandRunners, command);
+}
+
+export async function dispatchCli(argv: string[]) {
+  const commandArgs = argv.slice(2);
+  const rootProgram = setupProgram(commandArgs);
+
+  try {
+    await rootProgram.parseAsync(commandArgs, { from: 'user' });
+  } catch (error) {
+    if (error instanceof CommanderError) {
+      process.exitCode = error.exitCode;
+      return;
+    }
+    throw error;
+  }
+}
+
+if (isDirectExecution(import.meta.url)) {
+  await dispatchCli(process.argv);
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,21 +4,24 @@ import process from 'node:process';
 
 import { Command, CommanderError } from 'commander';
 
-import { runBuildCli } from './commands/build.runner.js';
-import { runCreateCli } from './commands/create.runner.js';
-import { runInitCli } from './commands/init.runner.js';
-import { runPreviewCli } from './commands/preview.runner.js';
 import { isDirectExecution } from './entry-util.js';
 import { versionForDisplay } from './util.js';
 
-const commandRunners = {
-  build: runBuildCli,
-  create: runCreateCli,
-  init: runInitCli,
-  preview: runPreviewCli,
+const commandLoaders = {
+  build: async () => (await import('./commands/build.runner.js')).runBuildCli,
+  create: async () =>
+    (await import('./commands/create.runner.js')).runCreateCli,
+  init: async () => (await import('./commands/init.runner.js')).runInitCli,
+  preview: async () =>
+    (await import('./commands/preview.runner.js')).runPreviewCli,
 } as const;
 
-type CommandName = keyof typeof commandRunners;
+type CommandName = keyof typeof commandLoaders;
+
+async function runCommand(command: CommandName, argv: string[]) {
+  const runner = await commandLoaders[command]();
+  await runner(argv);
+}
 
 function setupProgram(argv: string[]) {
   const program = new Command()
@@ -39,7 +42,7 @@ function setupProgram(argv: string[]) {
         // Preserve `--` so the existing parser does not reinterpret following
         // option-like operands during its second parse.
         const commandArgs = argv.slice(commandIndex + 1);
-        await commandRunners[command](['vivliostyle', command, ...commandArgs]);
+        await runCommand(command, ['vivliostyle', command, ...commandArgs]);
       });
   };
 
@@ -63,7 +66,7 @@ function setupProgram(argv: string[]) {
         return;
       }
       if (isCommandName(command)) {
-        await commandRunners[command](['vivliostyle', command, '--help']);
+        await runCommand(command, ['vivliostyle', command, '--help']);
         return;
       }
       program.help({ error: true });
@@ -73,7 +76,7 @@ function setupProgram(argv: string[]) {
 }
 
 function isCommandName(command: string): command is CommandName {
-  return Object.hasOwn(commandRunners, command);
+  return Object.hasOwn(commandLoaders, command);
 }
 
 export async function dispatchCli(argv: string[]) {

--- a/src/commands/build.runner.ts
+++ b/src/commands/build.runner.ts
@@ -1,0 +1,25 @@
+import process from 'node:process';
+
+import { build } from '../core/build.js';
+import { Logger } from '../logger.js';
+import { gracefulError, isInContainer, setupExitHandlers } from '../util.js';
+import { parseBuildCommand } from './build.parser.js';
+
+export async function runBuildCli(argv: string[]) {
+  setupExitHandlers();
+
+  try {
+    let inlineConfig = parseBuildCommand(argv);
+    let containerForkMode = false;
+    if (isInContainer() && process.env.VS_CLI_BUILD_PDF_OPTIONS) {
+      inlineConfig = JSON.parse(process.env.VS_CLI_BUILD_PDF_OPTIONS);
+      containerForkMode = true;
+      Logger.debug('bypassedPdfBuilderOption %O', inlineConfig);
+    }
+    await build(inlineConfig, { containerForkMode });
+  } catch (err) {
+    if (err instanceof Error) {
+      await gracefulError(err);
+    }
+  }
+}

--- a/src/commands/build.runner.ts
+++ b/src/commands/build.runner.ts
@@ -1,14 +1,13 @@
 import process from 'node:process';
 
 import { build } from '../core/build.js';
+import { runCliCommand } from '../entry-util.js';
 import { Logger } from '../logger.js';
-import { gracefulError, isInContainer, setupExitHandlers } from '../util.js';
+import { isInContainer } from '../util.js';
 import { parseBuildCommand } from './build.parser.js';
 
 export async function runBuildCli(argv: string[]) {
-  setupExitHandlers();
-
-  try {
+  await runCliCommand(async (cliSignal) => {
     let inlineConfig = parseBuildCommand(argv);
     let containerForkMode = false;
     if (isInContainer() && process.env.VS_CLI_BUILD_PDF_OPTIONS) {
@@ -16,10 +15,6 @@ export async function runBuildCli(argv: string[]) {
       containerForkMode = true;
       Logger.debug('bypassedPdfBuilderOption %O', inlineConfig);
     }
-    await build(inlineConfig, { containerForkMode });
-  } catch (err) {
-    if (err instanceof Error) {
-      await gracefulError(err);
-    }
-  }
+    await build({ ...inlineConfig, signal: cliSignal }, { containerForkMode });
+  });
 }

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -1,21 +1,7 @@
 import process from 'node:process';
 
-import { build } from '../core/build.js';
-import { Logger } from '../logger.js';
-import { gracefulError, isInContainer } from '../util.js';
-import { parseBuildCommand } from './build.parser.js';
+import { runBuildCli } from './build.runner.js';
 
-try {
-  let inlineConfig = parseBuildCommand(process.argv);
-  let containerForkMode = false;
-  if (isInContainer() && process.env.VS_CLI_BUILD_PDF_OPTIONS) {
-    inlineConfig = JSON.parse(process.env.VS_CLI_BUILD_PDF_OPTIONS);
-    containerForkMode = true;
-    Logger.debug('bypassedPdfBuilderOption %O', inlineConfig);
-  }
-  await build(inlineConfig, { containerForkMode });
-} catch (err) {
-  if (err instanceof Error) {
-    gracefulError(err);
-  }
-}
+export { runBuildCli } from './build.runner.js';
+
+await runBuildCli(process.argv);

--- a/src/commands/create.runner.ts
+++ b/src/commands/create.runner.ts
@@ -1,16 +1,10 @@
 import { create } from '../core/create.js';
-import { gracefulError, setupExitHandlers } from '../util.js';
+import { runCliCommand } from '../entry-util.js';
 import { parseCreateCommand } from './create.parser.js';
 
 export async function runCreateCli(argv: string[]) {
-  setupExitHandlers();
-
-  try {
+  await runCliCommand(async (cliSignal) => {
     const inlineConfig = parseCreateCommand(argv);
-    await create(inlineConfig);
-  } catch (err) {
-    if (err instanceof Error) {
-      await gracefulError(err);
-    }
-  }
+    await create({ ...inlineConfig, signal: cliSignal });
+  });
 }

--- a/src/commands/create.runner.ts
+++ b/src/commands/create.runner.ts
@@ -1,0 +1,16 @@
+import { create } from '../core/create.js';
+import { gracefulError, setupExitHandlers } from '../util.js';
+import { parseCreateCommand } from './create.parser.js';
+
+export async function runCreateCli(argv: string[]) {
+  setupExitHandlers();
+
+  try {
+    const inlineConfig = parseCreateCommand(argv);
+    await create(inlineConfig);
+  } catch (err) {
+    if (err instanceof Error) {
+      await gracefulError(err);
+    }
+  }
+}

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -1,12 +1,7 @@
-import { create } from '../core/create.js';
-import { gracefulError } from '../util.js';
-import { parseCreateCommand } from './create.parser.js';
+import process from 'node:process';
 
-try {
-  const inlineConfig = parseCreateCommand(process.argv);
-  await create(inlineConfig);
-} catch (err) {
-  if (err instanceof Error) {
-    gracefulError(err);
-  }
-}
+import { runCreateCli } from './create.runner.js';
+
+export { runCreateCli } from './create.runner.js';
+
+await runCreateCli(process.argv);

--- a/src/commands/init.runner.ts
+++ b/src/commands/init.runner.ts
@@ -1,16 +1,10 @@
 import { create } from '../core/create.js';
-import { gracefulError, setupExitHandlers } from '../util.js';
+import { runCliCommand } from '../entry-util.js';
 import { parseInitCommand } from './init.parser.js';
 
 export async function runInitCli(argv: string[]) {
-  setupExitHandlers();
-
-  try {
+  await runCliCommand(async (cliSignal) => {
     const inlineConfig = parseInitCommand(argv);
-    await create(inlineConfig);
-  } catch (err) {
-    if (err instanceof Error) {
-      await gracefulError(err);
-    }
-  }
+    await create({ ...inlineConfig, signal: cliSignal });
+  });
 }

--- a/src/commands/init.runner.ts
+++ b/src/commands/init.runner.ts
@@ -1,0 +1,16 @@
+import { create } from '../core/create.js';
+import { gracefulError, setupExitHandlers } from '../util.js';
+import { parseInitCommand } from './init.parser.js';
+
+export async function runInitCli(argv: string[]) {
+  setupExitHandlers();
+
+  try {
+    const inlineConfig = parseInitCommand(argv);
+    await create(inlineConfig);
+  } catch (err) {
+    if (err instanceof Error) {
+      await gracefulError(err);
+    }
+  }
+}

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,12 +1,7 @@
-import { create } from '../core/create.js';
-import { gracefulError } from '../util.js';
-import { parseInitCommand } from './init.parser.js';
+import process from 'node:process';
 
-try {
-  const inlineConfig = parseInitCommand(process.argv);
-  await create(inlineConfig);
-} catch (err) {
-  if (err instanceof Error) {
-    gracefulError(err);
-  }
-}
+import { runInitCli } from './init.runner.js';
+
+export { runInitCli } from './init.runner.js';
+
+await runInitCli(process.argv);

--- a/src/commands/preview.runner.ts
+++ b/src/commands/preview.runner.ts
@@ -1,0 +1,16 @@
+import { preview } from '../core/preview.js';
+import { gracefulError, setupExitHandlers } from '../util.js';
+import { parsePreviewCommand } from './preview.parser.js';
+
+export async function runPreviewCli(argv: string[]) {
+  setupExitHandlers();
+
+  try {
+    const inlineConfig = parsePreviewCommand(argv);
+    await preview(inlineConfig);
+  } catch (err) {
+    if (err instanceof Error) {
+      await gracefulError(err);
+    }
+  }
+}

--- a/src/commands/preview.runner.ts
+++ b/src/commands/preview.runner.ts
@@ -1,16 +1,10 @@
 import { preview } from '../core/preview.js';
-import { gracefulError, setupExitHandlers } from '../util.js';
+import { runCliCommand } from '../entry-util.js';
 import { parsePreviewCommand } from './preview.parser.js';
 
 export async function runPreviewCli(argv: string[]) {
-  setupExitHandlers();
-
-  try {
+  await runCliCommand(async (cliSignal) => {
     const inlineConfig = parsePreviewCommand(argv);
-    await preview(inlineConfig);
-  } catch (err) {
-    if (err instanceof Error) {
-      await gracefulError(err);
-    }
-  }
+    await preview({ ...inlineConfig, signal: cliSignal });
+  });
 }

--- a/src/commands/preview.runner.ts
+++ b/src/commands/preview.runner.ts
@@ -1,10 +1,30 @@
+import type { ViteDevServer } from 'vite';
+
 import { preview } from '../core/preview.js';
 import { runCliCommand } from '../entry-util.js';
+import { runCleanupHandlers } from '../util.js';
 import { parsePreviewCommand } from './preview.parser.js';
+
+async function waitForPreviewServerClose(
+  server: ViteDevServer | undefined,
+  signal: AbortSignal,
+) {
+  const { httpServer } = server ?? {};
+  if (!httpServer?.listening) {
+    signal.throwIfAborted();
+    return;
+  }
+  await new Promise<void>((resolve) => {
+    httpServer.once('close', resolve);
+  });
+  signal.throwIfAborted();
+}
 
 export async function runPreviewCli(argv: string[]) {
   await runCliCommand(async (cliSignal) => {
     const inlineConfig = parsePreviewCommand(argv);
-    await preview({ ...inlineConfig, signal: cliSignal });
+    const server = await preview({ ...inlineConfig, signal: cliSignal });
+    await waitForPreviewServerClose(server, cliSignal);
+    await runCleanupHandlers();
   });
 }

--- a/src/commands/preview.ts
+++ b/src/commands/preview.ts
@@ -1,12 +1,7 @@
-import { preview } from '../core/preview.js';
-import { gracefulError } from '../util.js';
-import { parsePreviewCommand } from './preview.parser.js';
+import process from 'node:process';
 
-try {
-  const inlineConfig = parsePreviewCommand(process.argv);
-  await preview(inlineConfig);
-} catch (err) {
-  if (err instanceof Error) {
-    gracefulError(err);
-  }
-}
+import { runPreviewCli } from './preview.runner.js';
+
+export { runPreviewCli } from './preview.runner.js';
+
+await runPreviewCli(process.argv);

--- a/src/container.ts
+++ b/src/container.ts
@@ -10,7 +10,12 @@ import { CONTAINER_LOCAL_HOSTNAME, CONTAINER_ROOT_DIR } from './constants.js';
 import { Logger } from './logger.js';
 import { importNodeModule } from './node-modules.js';
 import { getSourceUrl } from './server.js';
-import { exec, isValidUri, pathEquals } from './util.js';
+import {
+  exec,
+  isValidUri,
+  pathEquals,
+  registerCleanupHandler,
+} from './util.js';
 
 export function toContainerPath(urlOrAbsPath: string): string {
   if (isValidUri(urlOrAbsPath)) {
@@ -58,6 +63,7 @@ export async function runContainer({
   entrypoint,
   env,
   workdir,
+  signal,
 }: {
   image: string;
   userVolumeArgs: string[];
@@ -65,16 +71,29 @@ export async function runContainer({
   entrypoint?: string;
   env?: [string, string][];
   workdir?: string;
+  signal?: AbortSignal;
 }) {
+  signal?.throwIfAborted();
   const { default: commandExists } = await importNodeModule('command-exists');
-  if (!(await commandExists('docker'))) {
+  const dockerExists = await commandExists('docker');
+  signal?.throwIfAborted();
+  if (!dockerExists) {
     throw new Error(
       `Docker isn't be installed. To use this feature, you'll need to install Docker.`,
     );
   }
-  const version = (
-    await exec('docker', ['version', '--format', '{{.Server.Version}}'])
-  ).stdout;
+  let version: string;
+  try {
+    version = (
+      await exec('docker', ['version', '--format', '{{.Server.Version}}'], {
+        signal,
+      })
+    ).stdout;
+  } catch (error) {
+    signal?.throwIfAborted();
+    throw error;
+  }
+  signal?.throwIfAborted();
   const [major, minor] = version.split('.').map(Number);
   if (major < 20 || (major === 20 && minor < 10)) {
     throw new Error(
@@ -101,18 +120,39 @@ export async function runContainer({
     Logger.debug(`docker ${args.join(' ')}`);
     const proc = x('docker', args, {
       throwOnError: true,
+      signal,
       nodeOptions: {
         stdio: Logger.isInteractive ? 'inherit' : undefined,
       },
     });
-    if (Logger.isInteractive) {
-      await proc;
-    } else {
-      for await (const line of proc) {
-        Logger.log(line);
+    const containerRun = (async () => {
+      if (Logger.isInteractive) {
+        await proc;
+      } else {
+        for await (const line of proc) {
+          Logger.log(line);
+        }
       }
+    })();
+    const unregisterCleanupHandler = registerCleanupHandler(
+      'Waiting for Docker process to stop',
+      async () => {
+        try {
+          await containerRun;
+        } catch {
+          // The active caller reports or normalizes the Docker error.
+        }
+      },
+      { prepend: true },
+    );
+    try {
+      await containerRun;
+    } finally {
+      unregisterCleanupHandler();
     }
+    signal?.throwIfAborted();
   } catch (error) {
+    signal?.throwIfAborted();
     throw new Error(
       'An error occurred on the running container. Please see logs above.',
       { cause: error },
@@ -158,6 +198,7 @@ export async function buildPDFWithContainer({
     ]),
     env: [['VS_CLI_BUILD_PDF_OPTIONS', JSON.stringify(bypassedOption)]],
     commandArgs: ['build'],
+    signal: inlineConfig.signal,
     workdir:
       typeof config.serverRootDir === 'string'
         ? toContainerPath(config.serverRootDir)

--- a/src/core/build.ts
+++ b/src/core/build.ts
@@ -22,7 +22,7 @@ import {
   prepareThemeDirectory,
 } from '../processor/compile.js';
 import { createViteServer, generateCmykReserveMap } from '../server.js';
-import { cwd, runExitHandlers } from '../util.js';
+import { cwd, runCleanupHandlers } from '../util.js';
 
 export async function build(
   inlineConfig: ParsedVivliostyleInlineConfig,
@@ -118,7 +118,11 @@ export async function build(
             inlineConfig,
           });
         } else {
-          output = await buildPDF({ target, config });
+          output = await buildPDF({
+            target,
+            config,
+            signal: inlineConfig.signal,
+          });
         }
       } else if (format === 'webpub' || format === 'epub') {
         output = await buildWebPublication({ target, config });
@@ -142,7 +146,7 @@ export async function build(
     await server?.close();
   }
 
-  await runExitHandlers();
+  await runCleanupHandlers();
   if (!containerForkMode) {
     const num = vivliostyleConfig.tasks.flatMap((t) => t.output ?? []).length;
     const symbol = isUnicodeSupported

--- a/src/core/build.ts
+++ b/src/core/build.ts
@@ -97,7 +97,7 @@ export async function build(
       // build artifacts
       if (isWebPubConfig(config)) {
         await cleanupWorkspace(config);
-        await prepareThemeDirectory(config);
+        await prepareThemeDirectory(config, inlineConfig.signal);
         await compile(config);
         await copyAssets(config);
       }

--- a/src/core/build.ts
+++ b/src/core/build.ts
@@ -142,7 +142,7 @@ export async function build(
     await server?.close();
   }
 
-  runExitHandlers();
+  await runExitHandlers();
   if (!containerForkMode) {
     const num = vivliostyleConfig.tasks.flatMap((t) => t.output ?? []).length;
     const symbol = isUnicodeSupported

--- a/src/core/create.ts
+++ b/src/core/create.ts
@@ -202,6 +202,7 @@ export async function create(inlineConfig: ParsedVivliostyleInlineConfig) {
       projectPath,
       cwd,
       template: template!,
+      signal: inlineConfig.signal,
       templateVariables: {
         ...inlineConfig,
         ...explicitTemplateVariables,
@@ -211,7 +212,12 @@ export async function create(inlineConfig: ParsedVivliostyleInlineConfig) {
     if (installDependencies) {
       const pm = whichPm();
       using _ = Logger.suspendLogging(`Installing dependencies with ${pm}`);
-      await performInstallDependencies({ projectPath, cwd, pm });
+      await performInstallDependencies({
+        projectPath,
+        cwd,
+        pm,
+        signal: inlineConfig.signal,
+      });
     }
   }
 
@@ -598,12 +604,15 @@ async function setupTemplate({
   template,
   templateVariables,
   useLocalTemplate,
+  signal,
 }: Required<
   Pick<ParsedVivliostyleInlineConfig, 'cwd' | 'projectPath' | 'template'>
 > & {
   templateVariables: Record<string, unknown>;
   useLocalTemplate?: boolean;
+  signal?: AbortSignal;
 }) {
+  signal?.throwIfAborted();
   if (useLocalTemplate) {
     const matcher = new GlobMatcher([
       {
@@ -614,11 +623,14 @@ async function setupTemplate({
       },
     ]);
     const files = await matcher.glob({ followSymbolicLinks: true });
+    signal?.throwIfAborted();
     Logger.debug('setupTemplate > files from local template %O', files);
     for (const file of files) {
+      signal?.throwIfAborted();
       const targetPath = upath.join(cwd, projectPath, file);
       fs.mkdirSync(upath.dirname(targetPath), { recursive: true });
       await copy(upath.join(template, file), targetPath);
+      signal?.throwIfAborted();
     }
   } else {
     // `downloadTemplate` deletes the destination directory for rollback purposes
@@ -632,21 +644,32 @@ async function setupTemplate({
       `.vs-template-${Date.now()}`,
     );
     Logger.debug('setupTemplate > tmpDownloadDir %s', tmpDownloadDir);
-    const takeCleanupHandler = registerCleanupHandler(
+    const templateDownload = downloadTemplate(template, {
+      dir: tmpDownloadDir,
+    });
+    const unregisterCleanupHandler = registerCleanupHandler(
       `Removing the temporary directory: ${tmpDownloadDir}`,
-      () => {
+      async () => {
+        try {
+          await templateDownload;
+        } catch {
+          // Remove any partial output after a failed or interrupted download.
+        }
         fs.rmSync(tmpDownloadDir, { recursive: true, force: true });
       },
     );
 
-    await downloadTemplate(template, { dir: tmpDownloadDir });
+    await templateDownload;
+    signal?.throwIfAborted();
     for (const entry of fs.readdirSync(tmpDownloadDir)) {
       fs.renameSync(
         upath.join(tmpDownloadDir, entry),
         upath.join(cwd, projectPath, entry),
       );
+      signal?.throwIfAborted();
     }
-    takeCleanupHandler()?.();
+    fs.rmSync(tmpDownloadDir, { recursive: true, force: true });
+    unregisterCleanupHandler();
   }
 
   const packageJsonPath = upath.join(cwd, projectPath, 'package.json');
@@ -699,23 +722,46 @@ async function performInstallDependencies({
   pm,
   cwd,
   projectPath,
+  signal,
 }: Required<Pick<ParsedVivliostyleInlineConfig, 'cwd' | 'projectPath'>> & {
   pm: PackageManager;
+  signal?: AbortSignal;
 }) {
+  signal?.throwIfAborted();
   const proc = x(pm, ['install'], {
     throwOnError: true,
+    signal,
     nodeOptions: {
       cwd: upath.join(cwd, projectPath),
       stdio: Logger.isInteractive ? 'inherit' : undefined,
     },
   });
-  if (Logger.isInteractive) {
-    await proc;
-  } else {
-    for await (const line of proc) {
-      Logger.log(line);
+  const installation = (async () => {
+    if (Logger.isInteractive) {
+      await proc;
+    } else {
+      for await (const line of proc) {
+        Logger.log(line);
+      }
     }
+  })();
+  const unregisterCleanupHandler = registerCleanupHandler(
+    'Waiting for dependency installation to stop',
+    async () => {
+      try {
+        await installation;
+      } catch {
+        // The active caller reports or normalizes the installation error.
+      }
+    },
+    { prepend: true },
+  );
+  try {
+    await installation;
+  } finally {
+    unregisterCleanupHandler();
   }
+  signal?.throwIfAborted();
 }
 
 function caveat(

--- a/src/core/create.ts
+++ b/src/core/create.ts
@@ -42,7 +42,7 @@ import {
   getDefaultBrowserTag,
   getOsLocale,
   type PackageManager,
-  registerExitHandler,
+  registerCleanupHandler,
   toTitleCase,
   whichPm,
 } from '../util.js';
@@ -632,7 +632,7 @@ async function setupTemplate({
       `.vs-template-${Date.now()}`,
     );
     Logger.debug('setupTemplate > tmpDownloadDir %s', tmpDownloadDir);
-    const cleanupExitHandler = registerExitHandler(
+    const takeCleanupHandler = registerCleanupHandler(
       `Removing the temporary directory: ${tmpDownloadDir}`,
       () => {
         fs.rmSync(tmpDownloadDir, { recursive: true, force: true });
@@ -646,7 +646,7 @@ async function setupTemplate({
         upath.join(cwd, projectPath, entry),
       );
     }
-    cleanupExitHandler()?.();
+    takeCleanupHandler()?.();
   }
 
   const packageJsonPath = upath.join(cwd, projectPath, 'package.json');

--- a/src/core/create.ts
+++ b/src/core/create.ts
@@ -659,17 +659,24 @@ async function setupTemplate({
       },
     );
 
-    await templateDownload;
-    signal?.throwIfAborted();
-    for (const entry of fs.readdirSync(tmpDownloadDir)) {
-      fs.renameSync(
-        upath.join(tmpDownloadDir, entry),
-        upath.join(cwd, projectPath, entry),
-      );
+    try {
+      await templateDownload;
       signal?.throwIfAborted();
+      for (const entry of fs.readdirSync(tmpDownloadDir)) {
+        fs.renameSync(
+          upath.join(tmpDownloadDir, entry),
+          upath.join(cwd, projectPath, entry),
+        );
+        signal?.throwIfAborted();
+      }
+    } catch (error) {
+      signal?.throwIfAborted();
+      throw error;
+    } finally {
+      // Always release our cleanup handler and remove any leftover temp download.
+      fs.rmSync(tmpDownloadDir, { recursive: true, force: true });
+      unregisterCleanupHandler();
     }
-    fs.rmSync(tmpDownloadDir, { recursive: true, force: true });
-    unregisterCleanupHandler();
   }
 
   const packageJsonPath = upath.join(cwd, projectPath, 'package.json');
@@ -758,6 +765,9 @@ async function performInstallDependencies({
   );
   try {
     await installation;
+  } catch (error) {
+    signal?.throwIfAborted();
+    throw error;
   } finally {
     unregisterCleanupHandler();
   }

--- a/src/entry-util.ts
+++ b/src/entry-util.ts
@@ -1,8 +1,56 @@
 import { pathToFileURL } from 'node:url';
 
+import {
+  gracefulError,
+  registerTerminationHook,
+  setupProcessTermination,
+} from './util.js';
+
 export function isDirectExecution(importMetaUrl: string) {
   return (
     Boolean(process.argv[1]) &&
     importMetaUrl === pathToFileURL(process.argv[1]).href
   );
+}
+
+export class CliInterruptError extends Error {
+  readonly exitCode: number;
+
+  constructor(exitCode: number) {
+    super(
+      exitCode === 130
+        ? 'Interrupted by SIGINT'
+        : `Terminated by signal: ${exitCode}`,
+    );
+    this.name = 'CliInterruptError';
+    this.exitCode = exitCode;
+  }
+}
+
+export async function runCliCommand(
+  command: (signal: AbortSignal) => Promise<void>,
+) {
+  setupProcessTermination();
+
+  const controller = new AbortController();
+  const unregisterTerminationHook = registerTerminationHook((exitCode) => {
+    if (!controller.signal.aborted) {
+      controller.abort(new CliInterruptError(exitCode));
+    }
+  });
+
+  try {
+    await command(controller.signal);
+  } catch (err) {
+    if (err === controller.signal.reason) {
+      return;
+    }
+    if (err instanceof Error) {
+      await gracefulError(err);
+      return;
+    }
+    throw err;
+  } finally {
+    unregisterTerminationHook();
+  }
 }

--- a/src/entry-util.ts
+++ b/src/entry-util.ts
@@ -1,0 +1,8 @@
+import { pathToFileURL } from 'node:url';
+
+export function isDirectExecution(importMetaUrl: string) {
+  return (
+    Boolean(process.argv[1]) &&
+    importMetaUrl === pathToFileURL(process.argv[1]).href
+  );
+}

--- a/src/entry-util.ts
+++ b/src/entry-util.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
+import { PromptCancelError } from './prompt-cancel.js';
 import {
   gracefulError,
   registerTerminationHook,
@@ -52,6 +53,9 @@ export async function runCliCommand(
     await command(controller.signal);
   } catch (err) {
     if (err === controller.signal.reason) {
+      return;
+    }
+    if (err instanceof PromptCancelError) {
       return;
     }
     if (err instanceof Error) {

--- a/src/entry-util.ts
+++ b/src/entry-util.ts
@@ -1,4 +1,5 @@
-import { pathToFileURL } from 'node:url';
+import fs from 'node:fs';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import {
   gracefulError,
@@ -7,10 +8,18 @@ import {
 } from './util.js';
 
 export function isDirectExecution(importMetaUrl: string) {
-  return (
-    Boolean(process.argv[1]) &&
-    importMetaUrl === pathToFileURL(process.argv[1]).href
-  );
+  const entryPath = process.argv[1];
+  if (!entryPath) {
+    return false;
+  }
+  try {
+    return (
+      fs.realpathSync(fileURLToPath(importMetaUrl)) ===
+      fs.realpathSync(entryPath)
+    );
+  } catch {
+    return importMetaUrl === pathToFileURL(entryPath).href;
+  }
 }
 
 export class CliInterruptError extends Error {

--- a/src/interactive.ts
+++ b/src/interactive.ts
@@ -34,6 +34,7 @@ import {
 import type { PromptOption, SelectPromptOption } from './config/schema.js';
 import { ValidString } from './config/schema.js';
 import { isUnicodeSupported, Logger } from './logger.js';
+import { PromptCancelError } from './prompt-cancel.js';
 
 type DistributiveOmit<T, K extends keyof any> = T extends any
   ? Omit<T, K>
@@ -129,7 +130,8 @@ export async function askQuestion<
         result = question satisfies never;
       }
       if (isCancel(result)) {
-        process.exit(0);
+        // Let the CLI entry point handle cleanup while preserving prompt cancellation as non-error.
+        throw new PromptCancelError();
       }
       response[name] = result;
       interactiveLogger.messageHistory.push({

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -6,7 +6,7 @@ import debug from 'debug';
 import yoctoSpinner, { type Spinner } from 'yocto-spinner';
 import { blueBright, greenBright, redBright, yellowBright } from 'yoctocolors';
 
-import { isInContainer, registerExitHandler } from './util.js';
+import { isInContainer, registerCleanupHandler } from './util.js';
 
 export const isUnicodeSupported =
   process.platform !== 'win32' || Boolean(process.env.WT_SESSION);
@@ -278,7 +278,7 @@ export class Logger {
   }
 
   #_spinner: Spinner;
-  #_disposeSpinnerExitHandler: (() => void) | undefined;
+  #_disposeSpinnerCleanupHandler: (() => void) | undefined;
 
   constructor(stream: Writable) {
     this.#_spinner = yoctoSpinner({
@@ -295,7 +295,7 @@ export class Logger {
 
   #start(text: string) {
     this.#_spinner.start(text);
-    this.#_disposeSpinnerExitHandler = registerExitHandler(
+    this.#_disposeSpinnerCleanupHandler = registerCleanupHandler(
       'Stopping spinner',
       () => {
         this.#_spinner.stop();
@@ -304,7 +304,7 @@ export class Logger {
   }
 
   [Symbol.dispose]() {
-    this.#_disposeSpinnerExitHandler?.();
+    this.#_disposeSpinnerCleanupHandler?.();
     this.#_spinner.stop(
       Logger.#nonBlockingLogPrinted
         ? undefined

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -282,6 +282,7 @@ export class Logger {
 
   constructor(stream: Writable) {
     this.#_spinner = yoctoSpinner({
+      handleSignals: false,
       spinner: {
         frames: spinnerFrames,
         interval: spinnerInterval,

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -39,11 +39,12 @@ export function createFetch(options: {
   proxyBypass?: string;
   proxyUser?: string;
   proxyPass?: string;
+  signal?: AbortSignal;
 }): typeof _fetch {
-  const url = options.proxyServer ?? process.env.HTTP_PROXY;
-  const proxy = url
+  const proxyUrl = options.proxyServer ?? process.env.HTTP_PROXY;
+  const proxy = proxyUrl
     ? createProxy({
-        url,
+        url: proxyUrl,
         noProxy: options.proxyBypass ?? process.env.NO_PROXY ?? undefined,
       })
     : undefined;
@@ -67,15 +68,26 @@ export function createFetch(options: {
       )[proxyHeadersKey]['proxy-authorization'] = token;
     }
   }
-  return (url, fetchOptions) =>
-    _fetch(url, { ...proxy, ...fetchOptions }).then((response) => {
-      if (!response.ok) {
-        throw new Error(
-          `Failed to fetch ${url}: ${response.status} ${response.statusText}`,
-        );
-      }
-      return response;
-    });
+  return (url, fetchOptions) => {
+    const signal = fetchOptions?.signal ?? options.signal;
+    return _fetch(url, {
+      ...proxy,
+      ...fetchOptions,
+      signal,
+    })
+      .catch((error) => {
+        signal?.throwIfAborted();
+        throw error;
+      })
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error(
+            `Failed to fetch ${url}: ${response.status} ${response.statusText}`,
+          );
+        }
+        return response;
+      });
+  };
 }
 
 export async function listVivliostyleThemes({

--- a/src/output/pdf-postprocess.ts
+++ b/src/output/pdf-postprocess.ts
@@ -15,7 +15,7 @@ import {
 import type { CmykMap, Meta, TOCItem } from '../global-viewer.js';
 import { Logger } from '../logger.js';
 import { importNodeModule } from '../node-modules.js';
-import { coreVersion, isInContainer } from '../util.js';
+import { coreVersion, isInContainer, registerCleanupHandler } from '../util.js';
 import { convertCmykColors } from './cmyk.js';
 import { replaceImages } from './image.js';
 
@@ -23,7 +23,10 @@ export type SaveOption = Pick<
   PdfOutput,
   'preflight' | 'preflightOption' | 'cmyk' | 'replaceImage'
 > &
-  Pick<ResolvedTaskConfig, 'image'> & { cmykMap: CmykMap };
+  Pick<ResolvedTaskConfig, 'image'> & {
+    cmykMap: CmykMap;
+    signal?: AbortSignal;
+  };
 
 const prefixes = {
   dcterms: 'http://purl.org/dc/terms/',
@@ -60,11 +63,13 @@ export async function pressReadyWithContainer({
   output,
   preflightOption,
   image,
+  signal,
 }: {
   input: string;
   output: string;
   preflightOption: string[];
   image: string;
+  signal?: AbortSignal;
 }) {
   await runContainer({
     image,
@@ -83,6 +88,7 @@ export async function pressReadyWithContainer({
         .map((opt) => `--${decamelize(opt, { separator: '-' })}`)
         .filter((str) => /^[\w-]+/.test(str)),
     ],
+    signal,
   });
 }
 
@@ -108,9 +114,11 @@ export class PostProcess {
       cmyk,
       cmykMap,
       replaceImage,
+      signal,
     }: SaveOption,
   ) {
     let pdf = await this.document.save();
+    signal?.throwIfAborted();
 
     if (cmyk) {
       const mergedMap: CmykMap = { ...cmykMap };
@@ -125,6 +133,7 @@ export class PostProcess {
         colorMap: mergedMap,
         warnUnmapped: cmyk.warnUnmapped,
       });
+      signal?.throwIfAborted();
 
       if (cmyk.mapOutput) {
         const mapOutputDir = upath.dirname(cmyk.mapOutput);
@@ -143,44 +152,72 @@ export class PostProcess {
         pdf,
         replaceImageConfig: replaceImage,
       });
+      signal?.throwIfAborted();
     }
 
     if (preflight) {
       const input = upath.join(os.tmpdir(), `vivliostyle-cli-${uuid()}.pdf`);
-      await fs.promises.writeFile(input, pdf);
+      let inputReady: Promise<void> | undefined;
+      let preflightOperation: Promise<void> | undefined;
+      const unregisterPreflightInputCleanup = registerCleanupHandler(
+        `Removing temporary preflight input: ${input}`,
+        async () => {
+          try {
+            await inputReady;
+            await preflightOperation;
+          } catch {
+            // Remove the temporary input after failed or interrupted preflight.
+          }
+          await fs.promises.rm(input, { force: true });
+        },
+      );
 
-      if (
-        preflight === 'press-ready-local' ||
-        (preflight === 'press-ready' && isInContainer())
-      ) {
-        using _ = Logger.suspendLogging('Running press-ready');
-        const { build } = await importNodeModule('press-ready');
-        await build({
-          ...preflightOption.reduce((acc, opt) => {
-            const optName = decamelize(opt, { separator: '-' });
-            return optName.startsWith('no-')
-              ? {
-                  ...acc,
-                  [optName.slice(3)]: false,
-                }
-              : {
-                  ...acc,
-                  [optName]: true,
-                };
-          }, {}),
-          input,
-          output,
-        });
-      } else if (preflight === 'press-ready') {
-        using _ = Logger.suspendLogging('Running press-ready');
-        await pressReadyWithContainer({
-          input,
-          output,
-          preflightOption,
-          image,
-        });
+      try {
+        inputReady = fs.promises.writeFile(input, pdf);
+        await inputReady;
+        signal?.throwIfAborted();
+
+        preflightOperation = (async () => {
+          if (
+            preflight === 'press-ready-local' ||
+            (preflight === 'press-ready' && isInContainer())
+          ) {
+            using _ = Logger.suspendLogging('Running press-ready');
+            const { build } = await importNodeModule('press-ready');
+            await build({
+              ...preflightOption.reduce((acc, opt) => {
+                const optName = decamelize(opt, { separator: '-' });
+                return optName.startsWith('no-')
+                  ? {
+                      ...acc,
+                      [optName.slice(3)]: false,
+                    }
+                  : {
+                      ...acc,
+                      [optName]: true,
+                    };
+              }, {}),
+              input,
+              output,
+            });
+          } else if (preflight === 'press-ready') {
+            using _ = Logger.suspendLogging('Running press-ready');
+            await pressReadyWithContainer({
+              input,
+              output,
+              preflightOption,
+              image,
+              signal,
+            });
+          }
+        })();
+        await preflightOperation;
+      } finally {
+        unregisterPreflightInputCleanup();
+        await fs.promises.rm(input, { force: true });
       }
     } else {
+      signal?.throwIfAborted();
       await fs.promises.writeFile(output, pdf);
     }
   }

--- a/src/output/pdf.ts
+++ b/src/output/pdf.ts
@@ -6,7 +6,7 @@ import terminalLink from 'terminal-link';
 import upath from 'upath';
 import { cyan, gray, green, red } from 'yoctocolors';
 
-import { launchPreview } from '../browser.js';
+import { launchPreview, runBrowserOperationWithAbort } from '../browser.js';
 import type {
   ManuscriptEntry,
   PdfOutput,
@@ -76,7 +76,7 @@ export async function buildPDF({
     }
   }
 
-  const { browser, page } = await launchPreview({
+  const { browser, page, closeBrowser } = await launchPreview({
     mode: 'build',
     url: viewerFullUrl,
     signal,
@@ -134,108 +134,124 @@ export async function buildPDF({
     },
   });
 
-  const browserVersion = await browser.version();
-  Logger.debug(green('success'), `browserVersion=${browserVersion}`);
+  const browserResult = await runBrowserOperationWithAbort({
+    signal,
+    closeBrowser,
+    operation: async () => {
+      const browserVersion = await browser.version();
+      Logger.debug(green('success'), `browserVersion=${browserVersion}`);
 
-  let remainTime = config.timeout;
-  const startTime = Date.now();
+      let remainTime = config.timeout;
+      const startTime = Date.now();
 
-  signal?.throwIfAborted();
-  await page.waitForNetworkIdle({ signal });
-  await page.waitForFunction(() => !!window.coreViewer, { signal });
+      await page.waitForNetworkIdle({ signal });
+      await page.waitForFunction(() => !!window.coreViewer, { signal });
 
-  const { protocol } = browser as Browser & {
-    protocol: 'cdp' | 'webDriverBiDi';
-  };
-  // Only CDP supports emulateMediaType
-  if (protocol === 'cdp') {
-    await page.emulateMediaType('print');
-  }
-  await page.waitForFunction(
-    /* v8 ignore next */
-    () => window.coreViewer.readyState === 'complete',
-    { polling: 1000, signal },
-  );
-  signal?.throwIfAborted();
+      const { protocol } = browser as Browser & {
+        protocol: 'cdp' | 'webDriverBiDi';
+      };
+      // Only CDP supports emulateMediaType
+      if (protocol === 'cdp') {
+        await page.emulateMediaType('print');
+      }
+      await page.waitForFunction(
+        /* v8 ignore next */
+        () => window.coreViewer.readyState === 'complete',
+        { polling: 1000, signal },
+      );
 
-  if (lastEntry) {
-    Logger.logSuccess(stringifyEntry(lastEntry));
-  }
+      if (lastEntry) {
+        Logger.logSuccess(stringifyEntry(lastEntry));
+      }
 
-  const pageProgression = await page.evaluate(() =>
-    /* v8 ignore next 5 */
-    document
-      .querySelector('#vivliostyle-viewer-viewport')
-      ?.getAttribute('data-vivliostyle-page-progression') === 'rtl'
-      ? 'rtl'
-      : 'ltr',
-  );
-  const viewerCoreVersion = await page.evaluate(() =>
-    /* v8 ignore next 3 */
-    document
-      .querySelector('#vivliostyle-menu_settings .version')
-      ?.textContent?.replace(/^.*?: (\d[-+.\w]+).*$/, '$1'),
-  );
-  const metadata = await loadMetadata(page);
-  const toc = await loadTOC(page);
-  const pageSizeData = await loadPageSizeData(page);
-  const cmykMap = target.cmyk ? await loadCmykMap(page) : {};
+      const pageProgression = await page.evaluate((): 'ltr' | 'rtl' =>
+        /* v8 ignore next 5 */
+        document
+          .querySelector('#vivliostyle-viewer-viewport')
+          ?.getAttribute('data-vivliostyle-page-progression') === 'rtl'
+          ? 'rtl'
+          : 'ltr',
+      );
+      const viewerCoreVersion = await page.evaluate(() =>
+        /* v8 ignore next 3 */
+        document
+          .querySelector('#vivliostyle-menu_settings .version')
+          ?.textContent?.replace(/^.*?: (\d[-+.\w]+).*$/, '$1'),
+      );
+      const metadata = await loadMetadata(page);
+      const toc = await loadTOC(page);
+      const pageSizeData = await loadPageSizeData(page);
+      const cmykMap = target.cmyk ? await loadCmykMap(page) : {};
 
-  remainTime -= Date.now() - startTime;
-  if (remainTime <= 0) {
-    throw new Error('Typesetting process timed out');
-  }
-  Logger.debug('Remaining timeout:', remainTime);
+      remainTime -= Date.now() - startTime;
+      if (remainTime <= 0) {
+        throw new Error('Typesetting process timed out');
+      }
+      Logger.debug('Remaining timeout:', remainTime);
 
-  Logger.logUpdate('Building PDF');
+      Logger.logUpdate('Building PDF');
 
-  // For Firefox WebDriver BiDi, explicitly set width and height
-  // because page.pdf() doesn't support for the preferCSSPageSize option.
-  // Use a sufficiently large value to accommodate user-defined page sizes.
-  const dimensionSizeForWebDriverBiDi =
-    parseInt(process.env.VS_CLI_PDF_BUILD_PDF_PAGE_SIZE || '', 10) || 3780; // 1000mm
-  const pdf = await page.pdf({
-    margin: {
-      top: 0,
-      bottom: 0,
-      right: 0,
-      left: 0,
+      // For Firefox WebDriver BiDi, explicitly set width and height
+      // because page.pdf() doesn't support for the preferCSSPageSize option.
+      // Use a sufficiently large value to accommodate user-defined page sizes.
+      const dimensionSizeForWebDriverBiDi =
+        parseInt(process.env.VS_CLI_PDF_BUILD_PDF_PAGE_SIZE || '', 10) || 3780; // 1000mm
+      const pdf = await page.pdf({
+        margin: {
+          top: 0,
+          bottom: 0,
+          right: 0,
+          left: 0,
+        },
+        printBackground: true,
+        tagged: true,
+        // timeout: remainTime,
+        ...(protocol === 'webDriverBiDi'
+          ? {
+              width: dimensionSizeForWebDriverBiDi,
+              height: dimensionSizeForWebDriverBiDi,
+            }
+          : {
+              preferCSSPageSize: true,
+            }),
+      });
+
+      return {
+        browserVersion,
+        pageProgression,
+        viewerCoreVersion,
+        metadata,
+        toc,
+        pageSizeData,
+        cmykMap,
+        pdf,
+      };
     },
-    printBackground: true,
-    tagged: true,
-    // timeout: remainTime,
-    ...(protocol === 'webDriverBiDi'
-      ? {
-          width: dimensionSizeForWebDriverBiDi,
-          height: dimensionSizeForWebDriverBiDi,
-        }
-      : {
-          preferCSSPageSize: true,
-        }),
   });
 
-  await browser.close();
+  await closeBrowser();
+  signal?.throwIfAborted();
 
   Logger.logUpdate('Processing PDF');
   fs.mkdirSync(upath.dirname(target.path), { recursive: true });
 
-  const post = await PostProcess.load(pdf);
-  await post.metadata(metadata, {
-    pageProgression,
-    browserVersion,
-    viewerCoreVersion,
+  const post = await PostProcess.load(browserResult.pdf);
+  await post.metadata(browserResult.metadata, {
+    pageProgression: browserResult.pageProgression,
+    browserVersion: browserResult.browserVersion,
+    viewerCoreVersion: browserResult.viewerCoreVersion,
     // If custom viewer is set and its version info is not available,
     // there is no guarantee that the default creator option is correct.
-    disableCreatorOption: !!config.viewer && !viewerCoreVersion,
+    disableCreatorOption: !!config.viewer && !browserResult.viewerCoreVersion,
   });
-  await post.toc(toc);
-  await post.setPageBoxes(pageSizeData);
+  await post.toc(browserResult.toc);
+  await post.setPageBoxes(browserResult.pageSizeData);
   await post.save(target.path, {
     preflight: target.preflight,
     preflightOption: target.preflightOption,
     image: config.image,
     cmyk: target.cmyk,
-    cmykMap,
+    cmykMap: browserResult.cmykMap,
     replaceImage: target.replaceImage,
   });
 

--- a/src/output/pdf.ts
+++ b/src/output/pdf.ts
@@ -253,6 +253,7 @@ export async function buildPDF({
     cmyk: target.cmyk,
     cmykMap: browserResult.cmykMap,
     replaceImage: target.replaceImage,
+    signal,
   });
 
   return target.path;

--- a/src/output/pdf.ts
+++ b/src/output/pdf.ts
@@ -21,9 +21,11 @@ import { type PageSizeData, PostProcess } from './pdf-postprocess.js';
 export async function buildPDF({
   target,
   config,
+  signal,
 }: {
   target: PdfOutput;
   config: ResolvedTaskConfig;
+  signal?: AbortSignal;
 }): Promise<string | null> {
   Logger.logUpdate(`Launching PDF build environment`);
 
@@ -77,6 +79,7 @@ export async function buildPDF({
   const { browser, page } = await launchPreview({
     mode: 'build',
     url: viewerFullUrl,
+    signal,
     config,
     onBrowserOpen: () => {
       Logger.logUpdate('Building pages');
@@ -137,8 +140,9 @@ export async function buildPDF({
   let remainTime = config.timeout;
   const startTime = Date.now();
 
-  await page.waitForNetworkIdle();
-  await page.waitForFunction(() => !!window.coreViewer);
+  signal?.throwIfAborted();
+  await page.waitForNetworkIdle({ signal });
+  await page.waitForFunction(() => !!window.coreViewer, { signal });
 
   const { protocol } = browser as Browser & {
     protocol: 'cdp' | 'webDriverBiDi';
@@ -150,8 +154,9 @@ export async function buildPDF({
   await page.waitForFunction(
     /* v8 ignore next */
     () => window.coreViewer.readyState === 'complete',
-    { polling: 1000 },
+    { polling: 1000, signal },
   );
+  signal?.throwIfAborted();
 
   if (lastEntry) {
     Logger.logSuccess(stringifyEntry(lastEntry));

--- a/src/processor/compile.ts
+++ b/src/processor/compile.ts
@@ -133,8 +133,11 @@ export async function cleanupWorkspace({
       }
     },
   );
-  await workspaceCleanup;
-  unregisterCleanupHandler();
+  try {
+    await workspaceCleanup;
+  } finally {
+    unregisterCleanupHandler();
+  }
 }
 
 export async function prepareThemeDirectory(

--- a/src/processor/compile.ts
+++ b/src/processor/compile.ts
@@ -128,10 +128,10 @@ export async function cleanupWorkspace({
   }
 }
 
-export async function prepareThemeDirectory({
-  themesDir,
-  themeIndexes,
-}: ResolvedTaskConfig): Promise<string[]> {
+export async function prepareThemeDirectory(
+  { themesDir, themeIndexes }: ResolvedTaskConfig,
+  signal?: AbortSignal,
+): Promise<string[]> {
   // Backward compatibility: v8 to v9
   if (
     fs.existsSync(upath.join(themesDir, 'packages')) &&
@@ -146,7 +146,7 @@ export async function prepareThemeDirectory({
   // install theme packages
   if (await checkThemeInstallationNecessity({ themesDir, themeIndexes })) {
     Logger.startLogging('Installing theme files');
-    await installThemeDependencies({ themesDir, themeIndexes });
+    await installThemeDependencies({ themesDir, themeIndexes, signal });
   }
 
   // copy theme files

--- a/src/processor/compile.ts
+++ b/src/processor/compile.ts
@@ -102,30 +102,39 @@ export async function cleanupWorkspace({
   // workspaceDir is placed on different directory; delete everything excepting theme files
   Logger.debug('cleanup workspace files', workspaceDir);
   let movedWorkspacePath: string | undefined;
-  if (pathContains(workspaceDir, themesDir) && fs.existsSync(themesDir)) {
-    movedWorkspacePath = upath.join(
-      upath.dirname(workspaceDir),
-      `.vs-${Date.now()}`,
-    );
-    const movedThemePath = upath.join(
-      movedWorkspacePath,
-      upath.relative(workspaceDir, themesDir),
-    );
-    fs.mkdirSync(upath.dirname(movedThemePath), { recursive: true });
-    registerCleanupHandler(
-      `Removing the moved workspace directory: ${movedWorkspacePath}`,
-      () => {
-        if (movedWorkspacePath && fs.existsSync(movedWorkspacePath)) {
-          fs.rmSync(movedWorkspacePath, { recursive: true, force: true });
-        }
-      },
-    );
-    await move(themesDir, movedThemePath);
-  }
-  await fs.promises.rm(workspaceDir, { recursive: true, force: true });
-  if (movedWorkspacePath) {
-    await move(movedWorkspacePath, workspaceDir);
-  }
+  const workspaceCleanup = (async () => {
+    if (pathContains(workspaceDir, themesDir) && fs.existsSync(themesDir)) {
+      movedWorkspacePath = upath.join(
+        upath.dirname(workspaceDir),
+        `.vs-${Date.now()}`,
+      );
+      const movedThemePath = upath.join(
+        movedWorkspacePath,
+        upath.relative(workspaceDir, themesDir),
+      );
+      fs.mkdirSync(upath.dirname(movedThemePath), { recursive: true });
+      await move(themesDir, movedThemePath);
+    }
+    await fs.promises.rm(workspaceDir, { recursive: true, force: true });
+    if (movedWorkspacePath) {
+      await move(movedWorkspacePath, workspaceDir);
+    }
+  })();
+  const unregisterCleanupHandler = registerCleanupHandler(
+    'Waiting for workspace cleanup',
+    async () => {
+      try {
+        await workspaceCleanup;
+      } catch {
+        // Remove any temporary moved workspace after cleanup fails.
+      }
+      if (movedWorkspacePath && fs.existsSync(movedWorkspacePath)) {
+        fs.rmSync(movedWorkspacePath, { recursive: true, force: true });
+      }
+    },
+  );
+  await workspaceCleanup;
+  unregisterCleanupHandler();
 }
 
 export async function prepareThemeDirectory(

--- a/src/processor/compile.ts
+++ b/src/processor/compile.ts
@@ -24,7 +24,7 @@ import {
   DetailError,
   pathContains,
   pathEquals,
-  registerExitHandler,
+  registerCleanupHandler,
   writeFileIfChanged,
 } from '../util.js';
 import {
@@ -112,7 +112,7 @@ export async function cleanupWorkspace({
       upath.relative(workspaceDir, themesDir),
     );
     fs.mkdirSync(upath.dirname(movedThemePath), { recursive: true });
-    registerExitHandler(
+    registerCleanupHandler(
       `Removing the moved workspace directory: ${movedWorkspacePath}`,
       () => {
         if (movedWorkspacePath && fs.existsSync(movedWorkspacePath)) {

--- a/src/processor/theme.ts
+++ b/src/processor/theme.ts
@@ -4,7 +4,7 @@ import Arborist from '@npmcli/arborist';
 import upath from 'upath';
 
 import type { ResolvedTaskConfig } from '../config/resolve.js';
-import { DetailError } from '../util.js';
+import { DetailError, registerCleanupHandler } from '../util.js';
 
 function* iterateSymlinksInThemesNodeModules(
   themesDir: string,
@@ -72,7 +72,11 @@ export function getLocalThemePaths({
 export async function installThemeDependencies({
   themesDir,
   themeIndexes,
-}: Pick<ResolvedTaskConfig, 'themesDir' | 'themeIndexes'>): Promise<void> {
+  signal,
+}: Pick<ResolvedTaskConfig, 'themesDir' | 'themeIndexes'> & {
+  signal?: AbortSignal;
+}): Promise<void> {
+  signal?.throwIfAborted();
   fs.mkdirSync(themesDir, { recursive: true });
   removeThemesDirIfBrokenSymlinks(themesDir);
 
@@ -83,6 +87,7 @@ export async function installThemeDependencies({
       installLinks: true,
     };
     const tree = await new Arborist(commonOpt).buildIdealTree();
+    signal?.throwIfAborted();
     const existing = Array.from(tree.children.keys());
     const add = [
       ...new Set(
@@ -96,7 +101,26 @@ export async function installThemeDependencies({
     // Install dependencies
     const opt = { ...commonOpt, rm, add };
     const arb = new Arborist(opt);
-    const actualTree = await arb.reify(opt);
+    const reify = arb.reify(opt);
+    const unregisterReifyCleanup = registerCleanupHandler(
+      'Waiting for theme installation rollback',
+      async () => {
+        try {
+          await reify;
+        } catch {
+          // The active caller reports or normalizes the reify error.
+        }
+      },
+      // Arborist handles the process signal and must finish rollback before
+      // other cleanup removes directories that reify may still be using.
+      { prepend: true },
+    );
+    let actualTree;
+    try {
+      actualTree = await reify;
+    } finally {
+      unregisterReifyCleanup();
+    }
 
     // Replace all local package directories with symlinks for hot reload support
     for (const child of actualTree.children.values()) {
@@ -109,7 +133,9 @@ export async function installThemeDependencies({
         fs.symlinkSync(relPath, child.path, 'junction');
       }
     }
+    signal?.throwIfAborted();
   } catch (error) {
+    signal?.throwIfAborted();
     const thrownError = error as Error;
     throw new DetailError(
       'An error occurred during the installation of the theme',

--- a/src/prompt-cancel.ts
+++ b/src/prompt-cancel.ts
@@ -1,0 +1,6 @@
+export class PromptCancelError extends Error {
+  constructor() {
+    super('Prompt canceled');
+    this.name = 'PromptCancelError';
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -283,7 +283,9 @@ export async function createViteServer({
       closeLaunchedServer ??= server.close.bind(server);
       return closeLaunchedServer();
     }));
-  registerCleanupHandler('Closing Vite server', closeServer);
+  registerCleanupHandler('Closing Vite server', closeServer, {
+    prepend: true,
+  });
 
   const server = await serverLaunch;
   closeLaunchedServer = server.close.bind(server);

--- a/src/server.ts
+++ b/src/server.ts
@@ -23,7 +23,7 @@ import {
   getDefaultEpubOpfPath,
   isValidUri,
   openEpub,
-  registerExitHandler,
+  registerCleanupHandler,
 } from './util.js';
 import { vsBrowserPlugin } from './vite/vite-plugin-browser.js';
 import { vsDevServerPlugin } from './vite/vite-plugin-dev-server.js';
@@ -265,7 +265,7 @@ export async function createViteServer({
 
   if (config.serverRootDir === config.workspaceDir) {
     const { cacheDir } = viteInlineConfig;
-    registerExitHandler('Removing the Vite cacheDir', () => {
+    registerCleanupHandler('Removing the Vite cacheDir', () => {
       if (fs.existsSync(cacheDir)) {
         fs.rmSync(cacheDir, { recursive: true });
       }

--- a/src/server.ts
+++ b/src/server.ts
@@ -272,9 +272,21 @@ export async function createViteServer({
     });
   }
 
-  if (mode === 'preview') {
-    return await createServer(viteInlineConfig);
-  } else {
-    return await preview(viteInlineConfig);
-  }
+  const serverLaunch =
+    mode === 'preview'
+      ? createServer(viteInlineConfig)
+      : preview(viteInlineConfig);
+  let closeServerPromise: Promise<void> | undefined;
+  let closeLaunchedServer: (() => Promise<void>) | undefined;
+  const closeServer = () =>
+    (closeServerPromise ??= serverLaunch.then((server) => {
+      closeLaunchedServer ??= server.close.bind(server);
+      return closeLaunchedServer();
+    }));
+  registerCleanupHandler('Closing Vite server', closeServer);
+
+  const server = await serverLaunch;
+  closeLaunchedServer = server.close.bind(server);
+  server.close = closeServer;
+  return server;
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -49,11 +49,14 @@ export async function exec(
   return subprocess;
 }
 
-const beforeExitHandlers: (() => void | Promise<void>)[] = [];
-let exitHandlersRun = false;
-let exitHandlersInstalled = false;
+const cleanupHandlers: (() => void | Promise<void>)[] = [];
+const terminationHooks = new Set<(exitCode: number) => void>();
+let cleanupStarted = false;
+let processTerminationInstalled = false;
+let handlingProcessTermination = false;
 
-export const registerExitHandler = (
+// Cleanup handlers release resources on normal completion, errors, and process termination.
+export const registerCleanupHandler = (
   debugMessage: string,
   handler: () => void | Promise<void>,
 ) => {
@@ -61,57 +64,67 @@ export const registerExitHandler = (
     Logger.debug(debugMessage);
     return handler();
   };
-  beforeExitHandlers.push(callback);
+  cleanupHandlers.push(callback);
   return () => {
-    const index = beforeExitHandlers.indexOf(callback);
+    const index = cleanupHandlers.indexOf(callback);
     if (index !== -1) {
-      return beforeExitHandlers.splice(index, 1)[0];
+      return cleanupHandlers.splice(index, 1)[0];
     }
   };
 };
 
-export async function runExitHandlers() {
-  if (exitHandlersRun) {
+// Termination hooks notify active work before cleanup starts closing resources.
+export function registerTerminationHook(hook: (exitCode: number) => void) {
+  terminationHooks.add(hook);
+  return () => {
+    terminationHooks.delete(hook);
+  };
+}
+
+export async function runCleanupHandlers() {
+  if (cleanupStarted) {
     return;
   }
-  exitHandlersRun = true;
-  while (beforeExitHandlers.length) {
+  cleanupStarted = true;
+  while (cleanupHandlers.length) {
     try {
-      await beforeExitHandlers.shift()?.();
+      await cleanupHandlers.shift()?.();
     } catch (e) {
       // NOOP
     }
   }
 }
 
-let terminating = false;
-
-async function terminate(exitCode: number) {
-  if (terminating) {
+async function handleProcessTermination(exitCode: number) {
+  if (handlingProcessTermination) {
     return;
   }
-  terminating = true;
-  try {
-    if (exitCode === 130 || exitCode === 143) {
-      await runExitHandlers();
-    } else {
-      runExitHandlers();
+  handlingProcessTermination = true;
+  for (const hook of terminationHooks) {
+    try {
+      hook(exitCode);
+    } catch (e) {
+      // NOOP
     }
+  }
+  try {
+    await runCleanupHandlers();
   } finally {
     process.exit(exitCode);
   }
 }
 
-export function setupExitHandlers() {
-  if (exitHandlersInstalled) {
+export function setupProcessTermination() {
+  if (processTerminationInstalled) {
     return;
   }
-  exitHandlersInstalled = true;
+  processTerminationInstalled = true;
 
-  process.once('SIGINT', () => void terminate(130));
-  process.once('SIGTERM', () => void terminate(143));
+  process.once('SIGINT', () => void handleProcessTermination(130));
+  process.once('SIGTERM', () => void handleProcessTermination(143));
+  process.once('SIGHUP', () => void handleProcessTermination(129));
   process.once('exit', () => {
-    void runExitHandlers();
+    void runCleanupHandlers();
   });
 }
 
@@ -135,7 +148,7 @@ export async function gracefulError(err: Error) {
 
 ${gray('If you think this is a bug, please report at https://github.com/vivliostyle/vivliostyle-cli/issues')}`);
   process.exitCode = 1;
-  await runExitHandlers();
+  await runCleanupHandlers();
 }
 
 export function readJSON(path: string) {
@@ -199,7 +212,7 @@ export function useTmpDirectory(): Promise<[string, () => void]> {
         // clear();
         fs.rmSync(path, { force: true, recursive: true });
       };
-      registerExitHandler(
+      registerCleanupHandler(
         `Removing the temporary directory: ${path}`,
         callback,
       );
@@ -216,7 +229,7 @@ export function touchTmpFile(path: string): () => void {
   const callback = () => {
     fs.rmSync(path, { force: true, recursive: true });
   };
-  registerExitHandler(`Removing the temporary file: ${path}`, callback);
+  registerCleanupHandler(`Removing the temporary file: ${path}`, callback);
   return callback;
 }
 
@@ -256,7 +269,7 @@ export async function openEpub(epubPath: string, tmpDir: string) {
   const deleteEpub = () => {
     fs.rmSync(tmpDir, { force: true, recursive: true });
   };
-  registerExitHandler(
+  registerCleanupHandler(
     `Removing the temporary EPUB directory: ${tmpDir}`,
     deleteEpub,
   );

--- a/src/util.ts
+++ b/src/util.ts
@@ -59,12 +59,17 @@ let handlingProcessTermination = false;
 export const registerCleanupHandler = (
   debugMessage: string,
   handler: () => void | Promise<void>,
+  { prepend = false }: { prepend?: boolean } = {},
 ) => {
   const callback = () => {
     Logger.debug(debugMessage);
     return handler();
   };
-  cleanupHandlers.push(callback);
+  if (prepend) {
+    cleanupHandlers.unshift(callback);
+  } else {
+    cleanupHandlers.push(callback);
+  }
   return () => {
     const index = cleanupHandlers.indexOf(callback);
     if (index !== -1) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -91,19 +91,25 @@ export function runCleanupHandlers() {
     return cleanupPromise;
   }
   let resolveCleanup: (() => void) | undefined;
-  cleanupPromise = new Promise<void>((resolve) => {
+  const currentCleanupPromise = new Promise<void>((resolve) => {
     resolveCleanup = resolve;
   });
+  cleanupPromise = currentCleanupPromise;
   void (async () => {
-    while (cleanupHandlers.length) {
-      try {
-        await cleanupHandlers.shift()?.();
-      } catch (e) {
-        // NOOP
+    try {
+      while (cleanupHandlers.length) {
+        try {
+          await cleanupHandlers.shift()?.();
+        } catch (e) {
+          // NOOP
+        }
       }
+    } finally {
+      cleanupPromise = undefined;
+      resolveCleanup?.();
     }
-  })().then(() => resolveCleanup?.());
-  return cleanupPromise;
+  })();
+  return currentCleanupPromise;
 }
 
 async function handleProcessTermination(exitCode: number) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -51,6 +51,7 @@ export async function exec(
 
 const beforeExitHandlers: (() => void | Promise<void>)[] = [];
 let exitHandlersRun = false;
+let exitHandlersInstalled = false;
 
 export const registerExitHandler = (
   debugMessage: string,
@@ -101,11 +102,18 @@ async function terminate(exitCode: number) {
   }
 }
 
-process.once('SIGINT', () => void terminate(130));
-process.once('SIGTERM', () => void terminate(143));
-process.once('exit', () => {
-  void runExitHandlers();
-});
+export function setupExitHandlers() {
+  if (exitHandlersInstalled) {
+    return;
+  }
+  exitHandlersInstalled = true;
+
+  process.once('SIGINT', () => void terminate(130));
+  process.once('SIGTERM', () => void terminate(143));
+  process.once('exit', () => {
+    void runExitHandlers();
+  });
+}
 
 export class DetailError extends Error {
   detail: string | undefined;
@@ -122,12 +130,12 @@ export function getFormattedError(err: Error) {
     : err.stack || `${err.message}`;
 }
 
-export function gracefulError(err: Error) {
+export async function gracefulError(err: Error) {
   console.log(`${redBright('ERROR')} ${getFormattedError(err)}
 
 ${gray('If you think this is a bug, please report at https://github.com/vivliostyle/vivliostyle-cli/issues')}`);
-
-  process.exit(1);
+  process.exitCode = 1;
+  await runExitHandlers();
 }
 
 export function readJSON(path: string) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -264,15 +264,21 @@ export const isRunningOnWSL = cachedFn(function isRunningOnWSL() {
 });
 
 export async function openEpub(epubPath: string, tmpDir: string) {
-  await inflateZip(epubPath, tmpDir);
-  Logger.debug(`Created the temporary EPUB directory: ${tmpDir}`);
-  const deleteEpub = () => {
+  const inflation = inflateZip(epubPath, tmpDir);
+  const deleteEpub = async () => {
+    try {
+      await inflation;
+    } catch {
+      // Remove any partial output after a failed or interrupted extraction.
+    }
     fs.rmSync(tmpDir, { force: true, recursive: true });
   };
   registerCleanupHandler(
     `Removing the temporary EPUB directory: ${tmpDir}`,
     deleteEpub,
   );
+  await inflation;
+  Logger.debug(`Created the temporary EPUB directory: ${tmpDir}`);
   return deleteEpub;
 }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -51,7 +51,7 @@ export async function exec(
 
 const cleanupHandlers: (() => void | Promise<void>)[] = [];
 const terminationHooks = new Set<(exitCode: number) => void>();
-let cleanupStarted = false;
+let cleanupPromise: Promise<void> | undefined;
 let processTerminationInstalled = false;
 let handlingProcessTermination = false;
 
@@ -86,18 +86,24 @@ export function registerTerminationHook(hook: (exitCode: number) => void) {
   };
 }
 
-export async function runCleanupHandlers() {
-  if (cleanupStarted) {
-    return;
+export function runCleanupHandlers() {
+  if (cleanupPromise) {
+    return cleanupPromise;
   }
-  cleanupStarted = true;
-  while (cleanupHandlers.length) {
-    try {
-      await cleanupHandlers.shift()?.();
-    } catch (e) {
-      // NOOP
+  let resolveCleanup: (() => void) | undefined;
+  cleanupPromise = new Promise<void>((resolve) => {
+    resolveCleanup = resolve;
+  });
+  void (async () => {
+    while (cleanupHandlers.length) {
+      try {
+        await cleanupHandlers.shift()?.();
+      } catch (e) {
+        // NOOP
+      }
     }
-  }
+  })().then(() => resolveCleanup?.());
+  return cleanupPromise;
 }
 
 async function handleProcessTermination(exitCode: number) {
@@ -125,9 +131,9 @@ export function setupProcessTermination() {
   }
   processTerminationInstalled = true;
 
-  process.once('SIGINT', () => void handleProcessTermination(130));
-  process.once('SIGTERM', () => void handleProcessTermination(143));
-  process.once('SIGHUP', () => void handleProcessTermination(129));
+  process.on('SIGINT', () => void handleProcessTermination(130));
+  process.on('SIGTERM', () => void handleProcessTermination(143));
+  process.on('SIGHUP', () => void handleProcessTermination(129));
   process.once('exit', () => {
     void runCleanupHandlers();
   });
@@ -203,26 +209,36 @@ export async function inflateZip(filePath: string, dest: string) {
 }
 
 export function useTmpDirectory(): Promise<[string, () => void]> {
-  return new Promise<[string, () => void]>((res, rej) => {
+  const directory = new Promise<string>((res, rej) => {
     tmp.dir({ unsafeCleanup: true }, (err, path) => {
       if (err) {
         return rej(err);
       }
       Logger.debug(`Created the temporary directory: ${path}`);
-      if (import.meta.env?.VITEST) {
-        return res([path, () => {}]);
-      }
-      const callback = () => {
-        // clear function doesn't work well?
-        // clear();
-        fs.rmSync(path, { force: true, recursive: true });
-      };
-      registerCleanupHandler(
-        `Removing the temporary directory: ${path}`,
-        callback,
-      );
-      res([path, callback]);
+      res(path);
     });
+  });
+  if (import.meta.env?.VITEST) {
+    return directory.then((path) => [path, () => {}]);
+  }
+
+  let path: string | undefined;
+  const callback = () => {
+    if (path) {
+      fs.rmSync(path, { force: true, recursive: true });
+    }
+  };
+  registerCleanupHandler('Removing the temporary directory', async () => {
+    try {
+      path = await directory;
+    } catch {
+      return;
+    }
+    callback();
+  });
+  return directory.then((createdPath) => {
+    path = createdPath;
+    return [createdPath, callback];
   });
 }
 

--- a/src/vite/vite-plugin-browser.ts
+++ b/src/vite/vite-plugin-browser.ts
@@ -4,7 +4,7 @@ import { launchPreview } from '../browser.js';
 import type { ResolvedTaskConfig } from '../config/resolve.js';
 import type { ParsedVivliostyleInlineConfig } from '../config/schema.js';
 import { getViewerFullUrl } from '../server.js';
-import { getOsLocale, runExitHandlers } from '../util.js';
+import { getOsLocale, runCleanupHandlers } from '../util.js';
 import { reloadConfig } from './plugin-util.js';
 
 export function vsBrowserPlugin({
@@ -20,7 +20,7 @@ export function vsBrowserPlugin({
 
   async function handlePageClose() {
     await server?.close();
-    await runExitHandlers();
+    await runCleanupHandlers();
   }
 
   async function openPreviewPage() {

--- a/src/vite/vite-plugin-browser.ts
+++ b/src/vite/vite-plugin-browser.ts
@@ -1,6 +1,6 @@
 import type * as vite from 'vite';
 
-import { launchPreview } from '../browser.js';
+import { launchPreview, runBrowserOperationWithAbort } from '../browser.js';
 import type { ResolvedTaskConfig } from '../config/resolve.js';
 import type { ParsedVivliostyleInlineConfig } from '../config/schema.js';
 import { getViewerFullUrl } from '../server.js';
@@ -16,7 +16,7 @@ export function vsBrowserPlugin({
 }): vite.Plugin {
   let config = _config;
   let server: vite.ViteDevServer | undefined;
-  let closeBrowser: (() => void) | undefined;
+  let closeBrowser: (() => Promise<void>) | undefined;
 
   async function handlePageClose() {
     await server?.close();
@@ -26,9 +26,10 @@ export function vsBrowserPlugin({
   async function openPreviewPage() {
     const locale = await getOsLocale();
     const url = await getViewerFullUrl(config);
-    const { page, browser } = await launchPreview({
+    const { page, closeBrowser: closeLaunchedBrowser } = await launchPreview({
       mode: 'preview',
       url,
+      signal: inlineConfig.signal,
       config,
       /* v8 ignore next 4 */
       onPageOpen: async (page) => {
@@ -37,29 +38,35 @@ export function vsBrowserPlugin({
       },
     });
 
-    // Vivliostyle Viewer uses `i18nextLng` in localStorage for UI language
-    if (!import.meta.env?.VITEST) {
-      /* v8 ignore next 4 */
-      await page.evaluate((locale) => {
-        window.localStorage.setItem('i18nextLng', locale);
-      }, locale);
-    }
-    // Move focus from the address bar to the page
-    await page.bringToFront();
-    // Focus to the URL input box if available
-    if (!import.meta.env?.VITEST) {
-      /* v8 ignore next 6 */
-      await page.evaluate(() => {
-        document
-          .querySelector<HTMLInputElement>('#vivliostyle-input-url')
-          ?.focus();
-      });
-    }
-
     closeBrowser = () => {
       page.off('close', handlePageClose);
-      browser.close();
+      return closeLaunchedBrowser();
     };
+
+    await runBrowserOperationWithAbort({
+      signal: inlineConfig.signal,
+      closeBrowser,
+      operation: async () => {
+        // Vivliostyle Viewer uses `i18nextLng` in localStorage for UI language
+        if (!import.meta.env?.VITEST) {
+          /* v8 ignore next 4 */
+          await page.evaluate((locale) => {
+            window.localStorage.setItem('i18nextLng', locale);
+          }, locale);
+        }
+        // Move focus from the address bar to the page
+        await page.bringToFront();
+        // Focus to the URL input box if available
+        if (!import.meta.env?.VITEST) {
+          /* v8 ignore next 6 */
+          await page.evaluate(() => {
+            document
+              .querySelector<HTMLInputElement>('#vivliostyle-input-url')
+              ?.focus();
+          });
+        }
+      },
+    });
   }
 
   return {
@@ -76,8 +83,8 @@ export function vsBrowserPlugin({
         return server;
       };
     },
-    closeBundle() {
-      closeBrowser?.();
+    async closeBundle() {
+      await closeBrowser?.();
     },
   };
 }

--- a/src/vite/vite-plugin-browser.ts
+++ b/src/vite/vite-plugin-browser.ts
@@ -20,7 +20,7 @@ export function vsBrowserPlugin({
 
   async function handlePageClose() {
     await server?.close();
-    runExitHandlers();
+    await runExitHandlers();
   }
 
   async function openPreviewPage() {

--- a/src/vite/vite-plugin-dev-server.ts
+++ b/src/vite/vite-plugin-dev-server.ts
@@ -173,7 +173,10 @@ export function vsDevServerPlugin({
     // Write CMYK reserve map if configured
     generateCmykReserveMap(config);
 
-    const localThemePaths = await prepareThemeDirectory(config);
+    const localThemePaths = await prepareThemeDirectory(
+      config,
+      inlineConfig.signal,
+    );
 
     const entriesLookup = createEntriesRouteLookup(
       config.entries,

--- a/tests/browser.test.ts
+++ b/tests/browser.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockedLaunch = vi.hoisted(() => vi.fn());
 const mockedRegisterCleanupHandler = vi.hoisted(() => vi.fn());
@@ -20,6 +20,16 @@ vi.mock('../src/util.js', async (importOriginal) => {
 import { launchPreview } from '../src/browser.js';
 
 describe('launchPreview', () => {
+  let registeredCleanupHandler: (() => void | Promise<void>) | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    registeredCleanupHandler = undefined;
+    mockedRegisterCleanupHandler.mockImplementation((_message, handler) => {
+      registeredCleanupHandler = handler;
+    });
+  });
+
   it('disables Puppeteer signal handlers', async () => {
     mockedLaunch.mockResolvedValue({
       browserContexts: () => [
@@ -59,5 +69,103 @@ describe('launchPreview', () => {
       handleSIGTERM: false,
       handleSIGHUP: false,
     });
+  });
+
+  it('shares browser closure between callers and cleanup', async () => {
+    let resolveClose: (() => void) | undefined;
+    const browserClose = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveClose = resolve;
+        }),
+    );
+    mockedLaunch.mockResolvedValue({
+      browserContexts: () => [
+        {
+          pages: async () => [],
+          newPage: async () => ({
+            setViewport: vi.fn(),
+            on: vi.fn(),
+            authenticate: vi.fn(),
+            goto: vi.fn(),
+          }),
+        },
+      ],
+      close: browserClose,
+    });
+
+    const { closeBrowser } = await launchPreview({
+      mode: 'build',
+      url: 'https://example.com',
+      config: {
+        browser: {
+          type: 'chrome',
+          tag: 'stable',
+          executablePath: process.execPath,
+        },
+        proxy: undefined,
+        sandbox: false,
+        ignoreHttpsErrors: false,
+        timeout: 1000,
+      },
+    });
+
+    const directClose = closeBrowser();
+    const cleanupClose = registeredCleanupHandler?.();
+
+    expect(cleanupClose).toBe(directClose);
+    await vi.waitFor(() => {
+      expect(browserClose).toHaveBeenCalledOnce();
+    });
+
+    resolveClose?.();
+    await Promise.all([directClose, cleanupClose]);
+  });
+
+  it('registers cleanup before browser launch completes', async () => {
+    let resolveLaunch:
+      | ((browser: {
+          browserContexts: () => never[];
+          close: () => Promise<void>;
+        }) => void)
+      | undefined;
+    const browserClose = vi.fn(async () => {});
+    mockedLaunch.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveLaunch = resolve;
+        }),
+    );
+
+    const launching = launchPreview({
+      mode: 'build',
+      url: 'https://example.com',
+      config: {
+        browser: {
+          type: 'chrome',
+          tag: 'stable',
+          executablePath: process.execPath,
+        },
+        proxy: undefined,
+        sandbox: false,
+        ignoreHttpsErrors: false,
+        timeout: 1000,
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(registeredCleanupHandler).toBeDefined();
+    });
+    const cleanup = registeredCleanupHandler?.();
+    expect(browserClose).not.toHaveBeenCalled();
+
+    resolveLaunch?.({
+      browserContexts: () => [],
+      close: browserClose,
+    });
+
+    await cleanup;
+    expect(browserClose).toHaveBeenCalledOnce();
+    await expect(launching).rejects.toThrow();
   });
 });

--- a/tests/browser.test.ts
+++ b/tests/browser.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const mockedLaunch = vi.hoisted(() => vi.fn());
+const mockedRegisterExitHandler = vi.hoisted(() => vi.fn());
+
+vi.mock('../src/node-modules.js', () => ({
+  importNodeModule: vi.fn(async () => ({
+    launch: mockedLaunch,
+  })),
+}));
+
+vi.mock('../src/util.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/util.js')>();
+  return {
+    ...actual,
+    registerExitHandler: mockedRegisterExitHandler,
+  };
+});
+
+import { launchPreview } from '../src/browser.js';
+
+describe('launchPreview', () => {
+  it('disables Puppeteer signal handlers', async () => {
+    mockedLaunch.mockResolvedValue({
+      browserContexts: () => [
+        {
+          pages: async () => [],
+          newPage: async () => ({
+            setViewport: vi.fn(),
+            on: vi.fn(),
+            authenticate: vi.fn(),
+            goto: vi.fn(),
+          }),
+        },
+      ],
+      close: vi.fn(),
+    });
+
+    await launchPreview({
+      mode: 'build',
+      url: 'https://example.com',
+      config: {
+        browser: {
+          type: 'chrome',
+          tag: 'stable',
+          executablePath: process.execPath,
+        },
+        proxy: undefined,
+        sandbox: false,
+        ignoreHttpsErrors: false,
+        timeout: 1000,
+      },
+    });
+
+    expect(mockedLaunch).toHaveBeenCalledOnce();
+    expect(mockedLaunch.mock.calls[0][0]).toMatchObject({
+      env: expect.any(Object),
+      handleSIGINT: false,
+      handleSIGTERM: false,
+      handleSIGHUP: false,
+    });
+    expect(mockedRegisterExitHandler).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/browser.test.ts
+++ b/tests/browser.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 const mockedLaunch = vi.hoisted(() => vi.fn());
-const mockedRegisterExitHandler = vi.hoisted(() => vi.fn());
+const mockedRegisterCleanupHandler = vi.hoisted(() => vi.fn());
 
 vi.mock('../src/node-modules.js', () => ({
   importNodeModule: vi.fn(async () => ({
@@ -13,7 +13,7 @@ vi.mock('../src/util.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../src/util.js')>();
   return {
     ...actual,
-    registerExitHandler: mockedRegisterExitHandler,
+    registerCleanupHandler: mockedRegisterCleanupHandler,
   };
 });
 
@@ -59,6 +59,5 @@ describe('launchPreview', () => {
       handleSIGTERM: false,
       handleSIGHUP: false,
     });
-    expect(mockedRegisterExitHandler).toHaveBeenCalledOnce();
   });
 });

--- a/tests/build-parser.test.ts
+++ b/tests/build-parser.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseBuildCommand } from '../src/commands/build.parser.js';
+
+describe('build command parser', () => {
+  it('accepts a positional input starting with a hyphen after --', () => {
+    const options = parseBuildCommand([
+      'vivliostyle',
+      'build',
+      '--',
+      '-input.md',
+    ]);
+
+    expect(options.input).toEqual({
+      format: 'markdown',
+      entry: '-input.md',
+    });
+  });
+});

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,0 +1,170 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockedCommands = vi.hoisted(() => ({
+  runBuildCli: vi.fn(),
+  runCreateCli: vi.fn(),
+  runInitCli: vi.fn(),
+  runPreviewCli: vi.fn(),
+}));
+
+vi.mock('../src/commands/build.runner.js', () => ({
+  runBuildCli: mockedCommands.runBuildCli,
+}));
+
+vi.mock('../src/commands/create.runner.js', () => ({
+  runCreateCli: mockedCommands.runCreateCli,
+}));
+
+vi.mock('../src/commands/init.runner.js', () => ({
+  runInitCli: mockedCommands.runInitCli,
+}));
+
+vi.mock('../src/commands/preview.runner.js', () => ({
+  runPreviewCli: mockedCommands.runPreviewCli,
+}));
+
+import { dispatchCli } from '../src/cli.js';
+
+function expectRootHelp(calls: unknown[][]) {
+  const output = calls.flat().map(String).join('');
+
+  expect(output).toContain('Usage: vivliostyle [options] [command]');
+  for (const command of ['create', 'init', 'build', 'preview']) {
+    expect(output).toMatch(new RegExp(`^  ${command}\\b`, 'm'));
+  }
+}
+
+describe('dispatchCli', () => {
+  const originalExitCode = process.exitCode;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.exitCode = originalExitCode;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.exitCode = originalExitCode;
+  });
+
+  it.each([
+    ['build', mockedCommands.runBuildCli],
+    ['create', mockedCommands.runCreateCli],
+    ['init', mockedCommands.runInitCli],
+    ['preview', mockedCommands.runPreviewCli],
+  ])('routes the %s subcommand in-process', async (command, runner) => {
+    await dispatchCli(['node', 'cli.js', command, '--help']);
+
+    expect(runner).toHaveBeenCalledOnce();
+    expect(runner).toHaveBeenCalledWith(['vivliostyle', command, '--help']);
+  });
+
+  it('shows the root command tree', async () => {
+    const write = vi
+      .spyOn(process.stdout, 'write')
+      .mockImplementation(() => true);
+
+    await dispatchCli(['node', 'cli.js', '--help']);
+
+    expectRootHelp(write.mock.calls);
+    expect(process.exitCode).toBe(0);
+  });
+
+  it('shows root help with a failure status when no command is specified', async () => {
+    const write = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => true);
+
+    await dispatchCli(['node', 'cli.js']);
+
+    expectRootHelp(write.mock.calls);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('preserves raw subcommand arguments for the subcommand parser', async () => {
+    await dispatchCli(['node', 'cli.js', 'build', '--', '-input.md']);
+
+    expect(mockedCommands.runBuildCli).toHaveBeenCalledOnce();
+    expect(mockedCommands.runBuildCli).toHaveBeenCalledWith([
+      'vivliostyle',
+      'build',
+      '--',
+      '-input.md',
+    ]);
+  });
+
+  it('propagates unexpected subcommand failures', async () => {
+    const error = new Error('unexpected failure');
+    mockedCommands.runBuildCli.mockRejectedValueOnce(error);
+
+    await expect(
+      dispatchCli(['node', 'cli.js', 'build', 'input.md']),
+    ).rejects.toBe(error);
+  });
+
+  it('routes help for subcommands in-process', async () => {
+    await dispatchCli(['node', 'cli.js', 'help', 'preview']);
+
+    expect(mockedCommands.runPreviewCli).toHaveBeenCalledOnce();
+    expect(mockedCommands.runPreviewCli).toHaveBeenCalledWith([
+      'vivliostyle',
+      'preview',
+      '--help',
+    ]);
+  });
+
+  it('shows root help successfully for the help command', async () => {
+    const write = vi
+      .spyOn(process.stdout, 'write')
+      .mockImplementation(() => true);
+
+    await dispatchCli(['node', 'cli.js', 'help']);
+
+    expectRootHelp(write.mock.calls);
+    expect(process.exitCode).toBe(0);
+  });
+
+  it('reports unknown options through Commander', async () => {
+    const write = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => true);
+
+    await dispatchCli(['node', 'cli.js', '--unknown']);
+
+    expect(write).toHaveBeenCalledWith("error: unknown option '--unknown'\n");
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('reports unknown commands with spelling suggestions', async () => {
+    const write = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => true);
+
+    await dispatchCli(['node', 'cli.js', 'buid']);
+
+    expect(write).toHaveBeenCalledWith(
+      "error: unknown command 'buid'\n(Did you mean build?)\n",
+    );
+    expect(process.exitCode).toBe(1);
+  });
+
+  it.each(['constructor', '__proto__'])(
+    'does not treat the inherited property %s as a command',
+    async (command) => {
+      const write = vi
+        .spyOn(process.stderr, 'write')
+        .mockImplementation(() => true);
+
+      await dispatchCli(['node', 'cli.js', command]);
+
+      expect(write).toHaveBeenCalledWith(
+        `error: unknown command '${command}'\n`,
+      );
+      expect(process.exitCode).toBe(1);
+      expect(mockedCommands.runBuildCli).not.toHaveBeenCalled();
+      expect(mockedCommands.runCreateCli).not.toHaveBeenCalled();
+      expect(mockedCommands.runInitCli).not.toHaveBeenCalled();
+      expect(mockedCommands.runPreviewCli).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/tests/command-entrypoints.test.ts
+++ b/tests/command-entrypoints.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const mockedCommands = vi.hoisted(() => ({
+  runBuildCli: vi.fn(),
+  runCreateCli: vi.fn(),
+  runInitCli: vi.fn(),
+  runPreviewCli: vi.fn(),
+}));
+
+vi.mock('../src/commands/build.runner.js', () => ({
+  runBuildCli: mockedCommands.runBuildCli,
+}));
+
+vi.mock('../src/commands/create.runner.js', () => ({
+  runCreateCli: mockedCommands.runCreateCli,
+}));
+
+vi.mock('../src/commands/init.runner.js', () => ({
+  runInitCli: mockedCommands.runInitCli,
+}));
+
+vi.mock('../src/commands/preview.runner.js', () => ({
+  runPreviewCli: mockedCommands.runPreviewCli,
+}));
+
+describe('standalone command entry points', () => {
+  it.each([
+    [
+      'build',
+      mockedCommands.runBuildCli,
+      () => import('../src/commands/build.js'),
+    ],
+    [
+      'create',
+      mockedCommands.runCreateCli,
+      () => import('../src/commands/create.js'),
+    ],
+    [
+      'init',
+      mockedCommands.runInitCli,
+      () => import('../src/commands/init.js'),
+    ],
+    [
+      'preview',
+      mockedCommands.runPreviewCli,
+      () => import('../src/commands/preview.js'),
+    ],
+  ])('runs the %s command when imported', async (_command, runner, load) => {
+    await load();
+
+    expect(runner).toHaveBeenCalledOnce();
+    expect(runner).toHaveBeenCalledWith(process.argv);
+  });
+});

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -1,4 +1,8 @@
+import { EventEmitter } from 'node:events';
+
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type * as UtilModule from '../src/util.js';
 
 const mocked = vi.hoisted(() => ({
   build: vi.fn(),
@@ -9,6 +13,7 @@ const mocked = vi.hoisted(() => ({
   parseInitCommand: vi.fn(),
   parsePreviewCommand: vi.fn(),
   cliSignal: new AbortController().signal,
+  runCleanupHandlers: vi.fn<() => Promise<void>>(async () => {}),
 }));
 
 vi.mock('../src/entry-util.js', () => ({
@@ -16,6 +21,11 @@ vi.mock('../src/entry-util.js', () => ({
   runCliCommand: vi.fn(async (command) => {
     await command(mocked.cliSignal);
   }),
+}));
+
+vi.mock('../src/util.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof UtilModule>()),
+  runCleanupHandlers: mocked.runCleanupHandlers,
 }));
 
 vi.mock('../src/core/build.js', () => ({
@@ -76,4 +86,32 @@ describe('CLI command signals', () => {
       );
     },
   );
+
+  it('keeps the preview command active until the server closes', async () => {
+    const httpServer = new EventEmitter() as EventEmitter & {
+      listening: boolean;
+    };
+    httpServer.listening = true;
+    mocked.parsePreviewCommand.mockReturnValue({});
+    mocked.preview.mockResolvedValue({ httpServer });
+
+    let settled = false;
+    const running = runPreviewCli(['vivliostyle', 'preview']).then(() => {
+      settled = true;
+    });
+
+    await vi.waitFor(() => {
+      expect(mocked.preview).toHaveBeenCalledOnce();
+    });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+    expect(mocked.runCleanupHandlers).not.toHaveBeenCalled();
+
+    httpServer.listening = false;
+    httpServer.emit('close');
+
+    await running;
+    expect(settled).toBe(true);
+    expect(mocked.runCleanupHandlers).toHaveBeenCalledOnce();
+  });
 });

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocked = vi.hoisted(() => ({
+  build: vi.fn(),
+  create: vi.fn(),
+  preview: vi.fn(),
+  parseBuildCommand: vi.fn(),
+  parseCreateCommand: vi.fn(),
+  parseInitCommand: vi.fn(),
+  parsePreviewCommand: vi.fn(),
+  cliSignal: new AbortController().signal,
+}));
+
+vi.mock('../src/entry-util.js', () => ({
+  isDirectExecution: vi.fn(() => false),
+  runCliCommand: vi.fn(async (command) => {
+    await command(mocked.cliSignal);
+  }),
+}));
+
+vi.mock('../src/core/build.js', () => ({
+  build: mocked.build,
+}));
+
+vi.mock('../src/core/create.js', () => ({
+  create: mocked.create,
+}));
+
+vi.mock('../src/core/preview.js', () => ({
+  preview: mocked.preview,
+}));
+
+vi.mock('../src/commands/build.parser.js', () => ({
+  parseBuildCommand: mocked.parseBuildCommand,
+}));
+
+vi.mock('../src/commands/create.parser.js', () => ({
+  parseCreateCommand: mocked.parseCreateCommand,
+}));
+
+vi.mock('../src/commands/init.parser.js', () => ({
+  parseInitCommand: mocked.parseInitCommand,
+}));
+
+vi.mock('../src/commands/preview.parser.js', () => ({
+  parsePreviewCommand: mocked.parsePreviewCommand,
+}));
+
+import { runBuildCli } from '../src/commands/build.runner.js';
+import { runCreateCli } from '../src/commands/create.runner.js';
+import { runInitCli } from '../src/commands/init.runner.js';
+import { runPreviewCli } from '../src/commands/preview.runner.js';
+
+describe('CLI command signals', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    ['build', mocked.parseBuildCommand, mocked.build, runBuildCli],
+    ['create', mocked.parseCreateCommand, mocked.create, runCreateCli],
+    ['init', mocked.parseInitCommand, mocked.create, runInitCli],
+    ['preview', mocked.parsePreviewCommand, mocked.preview, runPreviewCli],
+  ])(
+    'passes the CLI signal to the %s operation',
+    async (command, parser, operation, runCommand) => {
+      const parsedSignal = new AbortController().signal;
+      parser.mockReturnValue({ signal: parsedSignal });
+
+      await runCommand(['vivliostyle', command]);
+
+      expect(operation.mock.calls[0]?.[0]).toEqual(
+        expect.objectContaining({
+          signal: mocked.cliSignal,
+        }),
+      );
+    },
+  );
+});

--- a/tests/container-interrupt.test.ts
+++ b/tests/container-interrupt.test.ts
@@ -1,0 +1,101 @@
+import type { ExecFileOptions } from 'node:child_process';
+
+import { beforeEach, expect, it, vi } from 'vitest';
+
+import type * as UtilModule from '../src/util.js';
+
+const mockedX = vi.hoisted(() =>
+  vi.fn<
+    (
+      command: string,
+      args: string[],
+      options: { signal?: AbortSignal },
+    ) => AsyncIterable<string>
+  >(),
+);
+const mockedExec = vi.hoisted(() =>
+  vi.fn<
+    (
+      command: string,
+      args?: string[],
+      options?: ExecFileOptions,
+    ) => Promise<{ stdout: string; stderr: string }>
+  >(async () => ({ stdout: '24.0.0', stderr: '' })),
+);
+
+vi.mock('tinyexec', () => ({
+  x: mockedX,
+}));
+
+vi.mock('../src/node-modules.js', () => ({
+  importNodeModule: vi.fn<() => Promise<{ default: () => Promise<boolean> }>>(
+    async () => ({
+      default: vi.fn<() => Promise<boolean>>(async () => true),
+    }),
+  ),
+}));
+
+vi.mock('../src/util.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof UtilModule>()),
+  exec: mockedExec,
+}));
+
+import { runContainer } from '../src/container.js';
+import { runCleanupHandlers } from '../src/util.js';
+
+beforeEach(() => {
+  mockedExec.mockClear();
+  mockedX.mockReset();
+});
+
+it('aborts Docker and waits for its process to stop', async () => {
+  let finishContainer: (() => void) | undefined;
+  const containerFinished = new Promise<void>((resolve) => {
+    finishContainer = resolve;
+  });
+  mockedX.mockReturnValue({
+    [Symbol.asyncIterator]() {
+      return {
+        async next() {
+          await containerFinished;
+          return { done: true, value: undefined };
+        },
+      };
+    },
+  });
+
+  const controller = new AbortController();
+  const abortReason = new Error('interrupted');
+  const running = runContainer({
+    image: 'example/image',
+    userVolumeArgs: [],
+    commandArgs: ['build'],
+    signal: controller.signal,
+  });
+
+  await vi.waitFor(() => {
+    expect(mockedX).toHaveBeenCalledOnce();
+  });
+  expect(mockedExec).toHaveBeenCalledWith(
+    'docker',
+    ['version', '--format', '{{.Server.Version}}'],
+    { signal: controller.signal },
+  );
+  expect(mockedX.mock.calls[0]?.[2]).toEqual(
+    expect.objectContaining({ signal: controller.signal }),
+  );
+
+  controller.abort(abortReason);
+  let cleanupFinished = false;
+  const cleanup = runCleanupHandlers().then(() => {
+    cleanupFinished = true;
+  });
+  await Promise.resolve();
+
+  expect(cleanupFinished).toBe(false);
+
+  finishContainer?.();
+
+  await expect(running).rejects.toBe(abortReason);
+  await cleanup;
+});

--- a/tests/create-dependency-interrupt.test.ts
+++ b/tests/create-dependency-interrupt.test.ts
@@ -61,7 +61,7 @@ it('aborts dependency installation and waits for the child process to stop', asy
     author: 'Author',
     language: 'en',
     theme: false,
-    template: templateDirectory,
+    template: 'template',
     installDependencies: true,
     logLevel: 'silent',
     signal: controller.signal,
@@ -87,4 +87,52 @@ it('aborts dependency installation and waits for the child process to stop', asy
 
   await expect(creating).rejects.toBe(abortReason);
   await cleanup;
+});
+
+it('normalizes dependency installation errors after cancellation', async () => {
+  temporaryDirectory = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'vivliostyle-cli-create-install-'),
+  );
+  const templateDirectory = path.join(temporaryDirectory, 'template');
+  fs.mkdirSync(templateDirectory);
+  fs.writeFileSync(path.join(templateDirectory, 'package.json'), '{}');
+
+  let rejectInstall: ((error: Error) => void) | undefined;
+  mockedX.mockReturnValue({
+    [Symbol.asyncIterator]() {
+      return {
+        async next() {
+          await new Promise<void>((_, reject) => {
+            rejectInstall = reject;
+          });
+          return { done: true, value: undefined };
+        },
+      };
+    },
+  });
+
+  const controller = new AbortController();
+  const abortReason = new Error('interrupted');
+  const installError = new Error('install failed');
+  const creating = create({
+    cwd: temporaryDirectory,
+    projectPath: 'book',
+    title: 'Book',
+    author: 'Author',
+    language: 'en',
+    theme: false,
+    template: 'template',
+    installDependencies: true,
+    logLevel: 'silent',
+    signal: controller.signal,
+  });
+
+  await vi.waitFor(() => {
+    expect(mockedX).toHaveBeenCalledOnce();
+  });
+
+  controller.abort(abortReason);
+  rejectInstall?.(installError);
+
+  await expect(creating).rejects.toBe(abortReason);
 });

--- a/tests/create-dependency-interrupt.test.ts
+++ b/tests/create-dependency-interrupt.test.ts
@@ -1,0 +1,90 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, expect, it, vi } from 'vitest';
+
+const mockedX = vi.hoisted(() =>
+  vi.fn<
+    (
+      command: string,
+      args: string[],
+      options: { signal?: AbortSignal },
+    ) => AsyncIterable<string>
+  >(),
+);
+
+vi.mock('tinyexec', () => ({
+  x: mockedX,
+}));
+
+import { create } from '../src/core/create.js';
+import { runCleanupHandlers } from '../src/util.js';
+
+let temporaryDirectory: string | undefined;
+
+afterEach(() => {
+  if (temporaryDirectory) {
+    fs.rmSync(temporaryDirectory, { recursive: true, force: true });
+  }
+});
+
+it('aborts dependency installation and waits for the child process to stop', async () => {
+  temporaryDirectory = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'vivliostyle-cli-create-install-'),
+  );
+  const templateDirectory = path.join(temporaryDirectory, 'template');
+  fs.mkdirSync(templateDirectory);
+  fs.writeFileSync(path.join(templateDirectory, 'package.json'), '{}');
+
+  let finishInstall: (() => void) | undefined;
+  const installFinished = new Promise<void>((resolve) => {
+    finishInstall = resolve;
+  });
+  mockedX.mockReturnValue({
+    [Symbol.asyncIterator]() {
+      return {
+        async next() {
+          await installFinished;
+          return { done: true, value: undefined };
+        },
+      };
+    },
+  });
+
+  const controller = new AbortController();
+  const abortReason = new Error('interrupted');
+  const creating = create({
+    cwd: temporaryDirectory,
+    projectPath: 'book',
+    title: 'Book',
+    author: 'Author',
+    language: 'en',
+    theme: false,
+    template: templateDirectory,
+    installDependencies: true,
+    logLevel: 'silent',
+    signal: controller.signal,
+  });
+
+  await vi.waitFor(() => {
+    expect(mockedX).toHaveBeenCalledOnce();
+  });
+  expect(mockedX.mock.calls[0]?.[2]).toEqual(
+    expect.objectContaining({ signal: controller.signal }),
+  );
+
+  controller.abort(abortReason);
+  let cleanupFinished = false;
+  const cleanup = runCleanupHandlers().then(() => {
+    cleanupFinished = true;
+  });
+  await Promise.resolve();
+
+  expect(cleanupFinished).toBe(false);
+
+  finishInstall?.();
+
+  await expect(creating).rejects.toBe(abortReason);
+  await cleanup;
+});

--- a/tests/create-interrupt.test.ts
+++ b/tests/create-interrupt.test.ts
@@ -1,0 +1,85 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+
+const mockedDownloadTemplate = vi.hoisted(() =>
+  vi.fn<
+    (
+      template: string,
+      options: { dir: string },
+    ) => Promise<Record<string, never>>
+  >(),
+);
+
+vi.mock('@bluwy/giget-core', () => ({
+  downloadTemplate: mockedDownloadTemplate,
+}));
+
+import { create } from '../src/core/create.js';
+import { runCleanupHandlers } from '../src/util.js';
+
+let temporaryDirectory: string | undefined;
+
+beforeEach(() => {
+  mockedDownloadTemplate.mockReset();
+});
+
+afterEach(() => {
+  if (temporaryDirectory) {
+    fs.rmSync(temporaryDirectory, { recursive: true, force: true });
+  }
+});
+
+it('waits for an interrupted template download before removing partial output', async () => {
+  temporaryDirectory = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'vivliostyle-cli-create-'),
+  );
+  const controller = new AbortController();
+  const abortReason = new Error('interrupted');
+  let finishDownload: (() => void) | undefined;
+  let downloadDirectory: string | undefined;
+  mockedDownloadTemplate.mockImplementation(
+    (_template: string, { dir }: { dir: string }) =>
+      new Promise((resolve) => {
+        downloadDirectory = dir;
+        fs.mkdirSync(dir, { recursive: true });
+        fs.writeFileSync(path.join(dir, 'partial'), '');
+        finishDownload = () => resolve({});
+      }),
+  );
+
+  const creating = create({
+    cwd: temporaryDirectory,
+    projectPath: 'book',
+    title: 'Book',
+    author: 'Author',
+    language: 'en',
+    theme: false,
+    template: 'https://example.com/template.tar.gz',
+    installDependencies: false,
+    logLevel: 'silent',
+    signal: controller.signal,
+  });
+
+  await vi.waitFor(() => {
+    expect(downloadDirectory).toBeDefined();
+  });
+  controller.abort(abortReason);
+
+  let cleanupFinished = false;
+  const cleanup = runCleanupHandlers().then(() => {
+    cleanupFinished = true;
+  });
+  await Promise.resolve();
+
+  expect(cleanupFinished).toBe(false);
+  expect(fs.existsSync(downloadDirectory!)).toBe(true);
+
+  finishDownload?.();
+
+  await expect(creating).rejects.toBe(abortReason);
+  await cleanup;
+  expect(fs.existsSync(downloadDirectory!)).toBe(false);
+});

--- a/tests/create-interrupt.test.ts
+++ b/tests/create-interrupt.test.ts
@@ -83,3 +83,79 @@ it('waits for an interrupted template download before removing partial output', 
   await cleanup;
   expect(fs.existsSync(downloadDirectory!)).toBe(false);
 });
+
+it('removes temporary template download after download failure', async () => {
+  temporaryDirectory = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'vivliostyle-cli-create-'),
+  );
+  const downloadError = new Error('download failed');
+  let downloadDirectory: string | undefined;
+  mockedDownloadTemplate.mockImplementation(
+    async (_template: string, { dir }: { dir: string }) => {
+      downloadDirectory = dir;
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(path.join(dir, 'partial'), '');
+      throw downloadError;
+    },
+  );
+
+  await expect(
+    create({
+      cwd: temporaryDirectory,
+      projectPath: 'book',
+      title: 'Book',
+      author: 'Author',
+      language: 'en',
+      theme: false,
+      template: 'https://example.com/template.tar.gz',
+      installDependencies: false,
+      logLevel: 'silent',
+    }),
+  ).rejects.toBe(downloadError);
+
+  expect(downloadDirectory).toBeDefined();
+  expect(fs.existsSync(downloadDirectory!)).toBe(false);
+});
+
+it('normalizes template download errors after cancellation', async () => {
+  temporaryDirectory = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'vivliostyle-cli-create-'),
+  );
+  const controller = new AbortController();
+  const abortReason = new Error('interrupted');
+  const downloadError = new Error('download failed');
+  let rejectDownload: ((error: Error) => void) | undefined;
+  let downloadDirectory: string | undefined;
+  mockedDownloadTemplate.mockImplementation(
+    (_template: string, { dir }: { dir: string }) =>
+      new Promise((_, reject) => {
+        downloadDirectory = dir;
+        fs.mkdirSync(dir, { recursive: true });
+        fs.writeFileSync(path.join(dir, 'partial'), '');
+        rejectDownload = reject;
+      }),
+  );
+
+  const creating = create({
+    cwd: temporaryDirectory,
+    projectPath: 'book',
+    title: 'Book',
+    author: 'Author',
+    language: 'en',
+    theme: false,
+    template: 'https://example.com/template.tar.gz',
+    installDependencies: false,
+    logLevel: 'silent',
+    signal: controller.signal,
+  });
+
+  await vi.waitFor(() => {
+    expect(downloadDirectory).toBeDefined();
+  });
+
+  controller.abort(abortReason);
+  rejectDownload?.(downloadError);
+
+  await expect(creating).rejects.toBe(abortReason);
+  expect(fs.existsSync(downloadDirectory!)).toBe(false);
+});

--- a/tests/entry-util.test.ts
+++ b/tests/entry-util.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let terminationHook: ((exitCode: number) => void) | undefined;
+
+const mockedUtil = vi.hoisted(() => ({
+  gracefulError: vi.fn(),
+  setupProcessTermination: vi.fn(),
+  unregisterTerminationHook: vi.fn(),
+}));
+
+vi.mock('../src/util.js', () => ({
+  gracefulError: mockedUtil.gracefulError,
+  setupProcessTermination: mockedUtil.setupProcessTermination,
+  registerTerminationHook: vi.fn((hook) => {
+    terminationHook = hook;
+    return mockedUtil.unregisterTerminationHook;
+  }),
+}));
+
+import { runCliCommand } from '../src/entry-util.js';
+import { gracefulError, setupProcessTermination } from '../src/util.js';
+
+describe('runCliCommand', () => {
+  beforeEach(() => {
+    terminationHook = undefined;
+    vi.clearAllMocks();
+  });
+
+  it('suppresses the CLI interrupt reason after a termination signal', async () => {
+    await runCliCommand(async (signal) => {
+      terminationHook?.(130);
+      signal.throwIfAborted();
+    });
+
+    expect(setupProcessTermination).toHaveBeenCalledOnce();
+    expect(gracefulError).not.toHaveBeenCalled();
+    expect(mockedUtil.unregisterTerminationHook).toHaveBeenCalledOnce();
+  });
+
+  it('reports regular command errors', async () => {
+    const err = new Error('boom');
+
+    await runCliCommand(async () => {
+      throw err;
+    });
+
+    expect(gracefulError).toHaveBeenCalledWith(err);
+    expect(mockedUtil.unregisterTerminationHook).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/entry-util.test.ts
+++ b/tests/entry-util.test.ts
@@ -5,6 +5,8 @@ import { pathToFileURL } from 'node:url';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { PromptCancelError } from '../src/prompt-cancel.js';
+
 let terminationHook: ((exitCode: number) => void) | undefined;
 
 const mockedUtil = vi.hoisted(() => ({
@@ -50,6 +52,16 @@ describe('runCliCommand', () => {
     });
 
     expect(gracefulError).toHaveBeenCalledWith(err);
+    expect(mockedUtil.unregisterTerminationHook).toHaveBeenCalledOnce();
+  });
+
+  it('treats prompt cancellation as a non-error command exit', async () => {
+    await runCliCommand(async () => {
+      throw new PromptCancelError();
+    });
+
+    expect(setupProcessTermination).toHaveBeenCalledOnce();
+    expect(gracefulError).not.toHaveBeenCalled();
     expect(mockedUtil.unregisterTerminationHook).toHaveBeenCalledOnce();
   });
 });

--- a/tests/entry-util.test.ts
+++ b/tests/entry-util.test.ts
@@ -1,4 +1,9 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 let terminationHook: ((exitCode: number) => void) | undefined;
 
@@ -17,7 +22,7 @@ vi.mock('../src/util.js', () => ({
   }),
 }));
 
-import { runCliCommand } from '../src/entry-util.js';
+import { isDirectExecution, runCliCommand } from '../src/entry-util.js';
 import { gracefulError, setupProcessTermination } from '../src/util.js';
 
 describe('runCliCommand', () => {
@@ -46,5 +51,41 @@ describe('runCliCommand', () => {
 
     expect(gracefulError).toHaveBeenCalledWith(err);
     expect(mockedUtil.unregisterTerminationHook).toHaveBeenCalledOnce();
+  });
+});
+
+describe('isDirectExecution', () => {
+  const originalEntryPath = process.argv[1];
+  let temporaryDirectory: string | undefined;
+
+  beforeEach(() => {
+    process.argv[1] = originalEntryPath;
+  });
+
+  afterEach(() => {
+    process.argv[1] = originalEntryPath;
+    if (temporaryDirectory) {
+      fs.rmSync(temporaryDirectory, { recursive: true, force: true });
+    }
+  });
+
+  it('recognizes an entry point reached through a symbolic link', () => {
+    temporaryDirectory = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'vivliostyle-cli-entry-'),
+    );
+    const realDirectory = path.join(temporaryDirectory, 'real');
+    const linkedDirectory = path.join(temporaryDirectory, 'linked');
+    const realEntryPath = path.join(realDirectory, 'cli.js');
+    const linkedEntryPath = path.join(linkedDirectory, 'cli.js');
+    fs.mkdirSync(realDirectory);
+    fs.writeFileSync(realEntryPath, '');
+    fs.symlinkSync(
+      realDirectory,
+      linkedDirectory,
+      process.platform === 'win32' ? 'junction' : 'dir',
+    );
+    process.argv[1] = linkedEntryPath;
+
+    expect(isDirectExecution(pathToFileURL(realEntryPath).href)).toBe(true);
   });
 });

--- a/tests/fixtures/process-termination.ts
+++ b/tests/fixtures/process-termination.ts
@@ -1,0 +1,51 @@
+import { writeFile } from 'node:fs/promises';
+import { Writable } from 'node:stream';
+import { CliInterruptError, runCliCommand } from '../../src/entry-util.js';
+import { Logger } from '../../src/logger.js';
+import { registerCleanupHandler } from '../../src/util.js';
+
+const markerPath = process.argv[2];
+if (!markerPath) {
+  throw new Error('Cleanup marker path is required');
+}
+
+delete process.env.CI;
+process.env.TERM = 'xterm';
+
+const ttyStream = new Writable({
+  write(_chunk, _encoding, callback) {
+    callback();
+  },
+}) as Writable & { isTTY: boolean };
+ttyStream.isTTY = true;
+Logger.setLogOptions({ stderr: ttyStream });
+
+await runCliCommand(async (signal) => {
+  Logger.startLogging('Waiting for termination signal');
+  registerCleanupHandler('Writing cleanup marker', async () => {
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    await writeFile(
+      markerPath,
+      JSON.stringify({
+        aborted: signal.aborted,
+        exitCode:
+          signal.reason instanceof CliInterruptError
+            ? signal.reason.exitCode
+            : null,
+      }),
+    );
+  });
+
+  process.stdout.write('READY\n');
+  await new Promise<void>((_resolve, reject) => {
+    const keepAlive = setInterval(() => {}, 1_000);
+    signal.addEventListener(
+      'abort',
+      () => {
+        clearInterval(keepAlive);
+        reject(signal.reason);
+      },
+      { once: true },
+    );
+  });
+});

--- a/tests/interactive-cancel.test.ts
+++ b/tests/interactive-cancel.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, expect, it, vi } from 'vitest';
+
+const mockedPrompt = vi.hoisted(() => ({
+  cancelSymbol: Symbol('cancel'),
+  prompt: vi.fn<() => Promise<symbol>>(),
+}));
+
+vi.mock('@clack/core', () => {
+  class PromptClass {
+    prompt = mockedPrompt.prompt;
+  }
+
+  return {
+    AutocompletePrompt: PromptClass,
+    getColumns: vi.fn<() => number>(() => 80),
+    isCancel: vi.fn<(value: unknown) => boolean>(
+      (value) => value === mockedPrompt.cancelSymbol,
+    ),
+    MultiSelectPrompt: PromptClass,
+    SelectPrompt: PromptClass,
+    TextPrompt: PromptClass,
+  };
+});
+
+vi.mock('@clack/prompts', () => ({
+  limitOptions: vi.fn<
+    ({
+      options,
+    }: {
+      options: { label?: string; value?: unknown }[];
+    }) => string[]
+  >(({ options }) =>
+    options.map(({ label, value }) => label ?? String(value ?? '')),
+  ),
+}));
+
+import { askQuestion, InteractiveLogger } from '../src/interactive.js';
+import { PromptCancelError } from '../src/prompt-cancel.js';
+
+beforeEach(() => {
+  mockedPrompt.prompt.mockReset();
+});
+
+it('throws a prompt cancellation error instead of exiting the process', async () => {
+  mockedPrompt.prompt.mockResolvedValue(mockedPrompt.cancelSymbol);
+
+  await expect(
+    askQuestion({
+      question: {
+        title: {
+          type: 'text',
+          message: 'Title',
+        },
+      },
+      interactiveLogger: new InteractiveLogger(),
+    }),
+  ).rejects.toBeInstanceOf(PromptCancelError);
+});

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -1,0 +1,26 @@
+import type { Writable } from 'node:stream';
+
+import { describe, expect, it, vi } from 'vitest';
+
+const mockedYoctoSpinner = vi.hoisted(() =>
+  vi.fn(() => ({ text: '', stop: vi.fn() })),
+);
+
+vi.mock('yocto-spinner', () => ({
+  default: mockedYoctoSpinner,
+}));
+
+import { Logger } from '../src/logger.js';
+
+describe('Logger', () => {
+  it('disables dependency signal handlers for the spinner', () => {
+    new Logger({ write: () => true } as unknown as Writable);
+
+    expect(mockedYoctoSpinner).toHaveBeenCalledOnce();
+    expect(mockedYoctoSpinner).toHaveBeenCalledWith(
+      expect.objectContaining({
+        handleSignals: false,
+      }),
+    );
+  });
+});

--- a/tests/pdf-interrupt.test.ts
+++ b/tests/pdf-interrupt.test.ts
@@ -72,6 +72,7 @@ function setupPdfBuild(pdf: Page['pdf'], closeBrowser = vi.fn(async () => {})) {
 describe('buildPDF cancellation', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockedPostProcessLoad.mockReset();
     mockedGetViewerFullUrl.mockResolvedValue('http://localhost:13000/viewer');
   });
 
@@ -183,5 +184,32 @@ describe('buildPDF cancellation', () => {
     );
 
     await expect(buildPDF({ target, config })).rejects.toBe(protocolError);
+  });
+
+  it('passes the signal to PDF postprocess', async () => {
+    const controller = new AbortController();
+    const save = vi.fn<() => Promise<void>>(async () => {});
+    mockedPostProcessLoad.mockResolvedValue({
+      metadata: vi.fn<() => Promise<void>>(async () => {}),
+      toc: vi.fn<() => Promise<void>>(async () => {}),
+      setPageBoxes: vi.fn<() => Promise<void>>(async () => {}),
+      save,
+    });
+    setupPdfBuild(vi.fn(async () => new Uint8Array([1])));
+
+    await expect(
+      buildPDF({
+        target: { ...target, path: 'output.pdf' },
+        config,
+        signal: controller.signal,
+      }),
+    ).resolves.toBe('output.pdf');
+
+    expect(save).toHaveBeenCalledWith(
+      'output.pdf',
+      expect.objectContaining({
+        signal: controller.signal,
+      }),
+    );
   });
 });

--- a/tests/pdf-interrupt.test.ts
+++ b/tests/pdf-interrupt.test.ts
@@ -1,0 +1,187 @@
+import type { Browser, Page } from 'puppeteer-core';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { PdfOutput, ResolvedTaskConfig } from '../src/config/resolve.js';
+
+const mockedLaunchPreview = vi.hoisted(() => vi.fn());
+const mockedGetViewerFullUrl = vi.hoisted(() => vi.fn());
+const mockedPostProcessLoad = vi.hoisted(() => vi.fn());
+
+vi.mock('../src/browser.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../src/browser.js')>()),
+  launchPreview: mockedLaunchPreview,
+}));
+
+vi.mock('../src/server.js', () => ({
+  getViewerFullUrl: mockedGetViewerFullUrl,
+}));
+
+vi.mock('../src/output/pdf-postprocess.js', () => ({
+  PostProcess: {
+    load: mockedPostProcessLoad,
+  },
+}));
+
+import { buildPDF } from '../src/output/pdf.js';
+
+const target = {
+  format: 'pdf',
+  path: '/tmp/output.pdf',
+  renderMode: 'local',
+  preflight: undefined,
+  preflightOption: [],
+  cmyk: false,
+  replaceImage: [],
+} satisfies PdfOutput;
+
+const config = {
+  entries: [],
+  entryContextDir: '/tmp',
+  workspaceDir: '/tmp',
+  timeout: 1000,
+  viewer: undefined,
+  image: undefined,
+} as unknown as ResolvedTaskConfig;
+
+function setupPdfBuild(pdf: Page['pdf'], closeBrowser = vi.fn(async () => {})) {
+  const page = {
+    waitForNetworkIdle: vi.fn(),
+    waitForFunction: vi.fn(),
+    emulateMediaType: vi.fn(),
+    evaluate: vi
+      .fn()
+      .mockResolvedValueOnce('ltr')
+      .mockResolvedValueOnce('2.43.0')
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]),
+    pdf,
+  } as unknown as Page;
+
+  const browser = {
+    protocol: 'cdp',
+    version: vi.fn(async () => 'Chrome/142.0.0.0'),
+    close: vi.fn(async () => {}),
+  } as unknown as Browser & { protocol: 'cdp' };
+
+  mockedLaunchPreview.mockResolvedValue({ browser, page, closeBrowser });
+
+  return { browser, closeBrowser, page };
+}
+
+describe('buildPDF cancellation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedGetViewerFullUrl.mockResolvedValue('http://localhost:13000/viewer');
+  });
+
+  it('rejects with the abort reason when cancellation happens during page.pdf()', async () => {
+    const controller = new AbortController();
+    const reason = new Error('cancelled');
+    const { closeBrowser } = setupPdfBuild(
+      vi.fn(() => {
+        controller.abort(reason);
+        return new Promise<Uint8Array>(() => {});
+      }),
+    );
+
+    await expect(
+      buildPDF({ target, config, signal: controller.signal }),
+    ).rejects.toBe(reason);
+    expect(closeBrowser).toHaveBeenCalledOnce();
+    expect(mockedPostProcessLoad).not.toHaveBeenCalled();
+  });
+
+  it('waits for browser closure before rejecting after cancellation', async () => {
+    const controller = new AbortController();
+    const reason = new Error('cancelled');
+    let resolveClose: (() => void) | undefined;
+    const closeBrowser = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveClose = resolve;
+        }),
+    );
+    setupPdfBuild(
+      vi.fn(() => {
+        controller.abort(reason);
+        return new Promise<Uint8Array>(() => {});
+      }),
+      closeBrowser,
+    );
+
+    let settled = false;
+    const result = buildPDF({
+      target,
+      config,
+      signal: controller.signal,
+    }).then(
+      () => {
+        settled = true;
+      },
+      (err) => {
+        settled = true;
+        return err;
+      },
+    );
+
+    await vi.waitFor(() => {
+      expect(closeBrowser).toHaveBeenCalledOnce();
+    });
+    expect(settled).toBe(false);
+
+    resolveClose?.();
+    await expect(result).resolves.toBe(reason);
+  });
+
+  it('normalizes page.pdf() errors that happen after cancellation', async () => {
+    const controller = new AbortController();
+    const reason = new Error('cancelled');
+    const protocolError = new Error(
+      'Protocol error (Page.printToPDF): Printing failed',
+    );
+    setupPdfBuild(
+      vi.fn(async () => {
+        controller.abort(reason);
+        throw protocolError;
+      }),
+    );
+
+    await expect(
+      buildPDF({ target, config, signal: controller.signal }),
+    ).rejects.toBe(reason);
+  });
+
+  it('normalizes browser evaluation errors that happen after cancellation', async () => {
+    const controller = new AbortController();
+    const reason = new Error('cancelled');
+    const protocolError = new Error(
+      'Protocol error (Runtime.callFunctionOn): Target closed',
+    );
+    const { closeBrowser, page } = setupPdfBuild(vi.fn());
+    vi.mocked(page.evaluate)
+      .mockReset()
+      .mockImplementationOnce(async () => {
+        controller.abort(reason);
+        throw protocolError;
+      });
+
+    await expect(
+      buildPDF({ target, config, signal: controller.signal }),
+    ).rejects.toBe(reason);
+    expect(closeBrowser).toHaveBeenCalledOnce();
+  });
+
+  it('keeps page.pdf() errors when the operation was not cancelled', async () => {
+    const protocolError = new Error(
+      'Protocol error (Page.printToPDF): Printing failed',
+    );
+    setupPdfBuild(
+      vi.fn(async () => {
+        throw protocolError;
+      }),
+    );
+
+    await expect(buildPDF({ target, config })).rejects.toBe(protocolError);
+  });
+});

--- a/tests/pdf-postprocess-interrupt.test.ts
+++ b/tests/pdf-postprocess-interrupt.test.ts
@@ -1,0 +1,116 @@
+import fs from 'node:fs';
+
+import { beforeEach, expect, it, vi } from 'vitest';
+
+import type * as UtilModule from '../src/util.js';
+
+const mockedRunContainer = vi.hoisted(() =>
+  vi.fn<
+    (options: { commandArgs: string[]; signal?: AbortSignal }) => Promise<void>
+  >(),
+);
+const mockedRegisterCleanupHandler = vi.hoisted(() =>
+  vi.fn<(message: string, handler: () => Promise<void>) => () => void>(),
+);
+
+vi.mock('../src/container.js', () => ({
+  collectVolumeArgs: vi.fn<(args: string[]) => string[]>((args) => args),
+  runContainer: mockedRunContainer,
+  toContainerPath: vi.fn<(path: string) => string>((path) => path),
+}));
+
+vi.mock('../src/util.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof UtilModule>()),
+  isInContainer: vi.fn<() => boolean>(() => false),
+  registerCleanupHandler: mockedRegisterCleanupHandler,
+}));
+
+import { PostProcess } from '../src/output/pdf-postprocess.js';
+
+function createPostProcess(document: any) {
+  return Object.assign(Object.create(PostProcess.prototype), {
+    document,
+  }) as PostProcess;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockedRegisterCleanupHandler.mockReturnValue(vi.fn<() => void>());
+});
+
+it('passes the signal to press-ready Docker preflight', async () => {
+  const controller = new AbortController();
+  const post = createPostProcess({
+    save: vi.fn<() => Promise<Uint8Array>>(async () => new Uint8Array([1])),
+  });
+
+  await post.save('output.pdf', {
+    preflight: 'press-ready',
+    preflightOption: [],
+    image: 'vivliostyle/cli',
+    cmyk: false,
+    cmykMap: {},
+    replaceImage: [],
+    signal: controller.signal,
+  });
+
+  expect(mockedRunContainer).toHaveBeenCalledWith(
+    expect.objectContaining({
+      signal: controller.signal,
+    }),
+  );
+});
+
+it('waits for press-ready before removing the temporary preflight input', async () => {
+  let finishPreflight: (() => void) | undefined;
+  mockedRunContainer.mockReturnValue(
+    new Promise<void>((resolve) => {
+      finishPreflight = resolve;
+    }),
+  );
+  const unregisterCleanupHandler = vi.fn<() => void>();
+  let cleanupHandler: (() => Promise<void>) | undefined;
+  mockedRegisterCleanupHandler.mockImplementation((_message, handler) => {
+    cleanupHandler = handler;
+    return unregisterCleanupHandler;
+  });
+  const post = createPostProcess({
+    save: vi.fn<() => Promise<Uint8Array>>(async () => new Uint8Array([1])),
+  });
+
+  const saving = post.save('output.pdf', {
+    preflight: 'press-ready',
+    preflightOption: [],
+    image: 'vivliostyle/cli',
+    cmyk: false,
+    cmykMap: {},
+    replaceImage: [],
+  });
+
+  await vi.waitFor(() => {
+    expect(mockedRunContainer).toHaveBeenCalledOnce();
+  });
+  const commandArgs = mockedRunContainer.mock.calls[0]?.[0].commandArgs;
+  expect(commandArgs).toBeDefined();
+  const input = commandArgs![commandArgs!.indexOf('-i') + 1];
+  expect(input).toBeDefined();
+  expect(fs.existsSync(input!)).toBe(true);
+
+  let cleanupSettled = false;
+  expect(cleanupHandler).toBeDefined();
+  const cleanup = cleanupHandler!().then(() => {
+    cleanupSettled = true;
+  });
+  await Promise.resolve();
+
+  expect(cleanupSettled).toBe(false);
+  expect(fs.existsSync(input!)).toBe(true);
+
+  finishPreflight?.();
+
+  await saving;
+  await cleanup;
+
+  expect(unregisterCleanupHandler).toHaveBeenCalledOnce();
+  expect(fs.existsSync(input!)).toBe(false);
+});

--- a/tests/process-termination.test.ts
+++ b/tests/process-termination.test.ts
@@ -74,6 +74,20 @@ describe('process termination', () => {
       expect(exit).toHaveBeenCalledWith(129);
     });
   });
+
+  it('runs cleanup handlers registered after previous cleanup completed', async () => {
+    const firstCleanup = vi.fn<() => void>();
+    const secondCleanup = vi.fn<() => void>();
+
+    registerCleanupHandler('first cleanup', firstCleanup);
+    await runCleanupHandlers();
+
+    registerCleanupHandler('second cleanup', secondCleanup);
+    await runCleanupHandlers();
+
+    expect(firstCleanup).toHaveBeenCalledOnce();
+    expect(secondCleanup).toHaveBeenCalledOnce();
+  });
 });
 
 // Node.js cannot generate catchable CTRL_C_EVENT or CTRL_BREAK_EVENT for a

--- a/tests/process-termination.test.ts
+++ b/tests/process-termination.test.ts
@@ -9,6 +9,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   registerCleanupHandler,
   registerTerminationHook,
+  runCleanupHandlers,
   setupProcessTermination,
 } from '../src/util.js';
 
@@ -22,12 +23,13 @@ describe('process termination', () => {
     vi.restoreAllMocks();
   });
 
-  it('waits for cleanup after invoking a termination signal listener', async () => {
+  it('waits for cleanup already in progress after repeated signals', async () => {
     const listeners = new Map<string, (...args: any[]) => void>();
-    vi.spyOn(process, 'once').mockImplementation((event, listener) => {
+    vi.spyOn(process, 'on').mockImplementation((event, listener) => {
       listeners.set(String(event), listener);
       return process;
     });
+    vi.spyOn(process, 'once').mockImplementation(() => process);
     const exit = vi
       .spyOn(process, 'exit')
       .mockImplementation((() => undefined) as never);
@@ -51,19 +53,24 @@ describe('process termination', () => {
     expect(listeners.has('SIGTERM')).toBe(true);
     expect(listeners.has('SIGHUP')).toBe(true);
 
-    // Invoke SIGHUP as a representative registered listener. This exercises
-    // the cross-platform termination path without emulating OS signal delivery;
-    // the POSIX subprocess tests below cover real delivery for all three signals.
+    const cleanupRun = runCleanupHandlers();
+    expect(runCleanupHandlers()).toBe(cleanupRun);
+    expect(cleanup).toHaveBeenCalledOnce();
+
+    // Invoke SIGHUP twice while normal cleanup is already in progress. This
+    // exercises both cleanup serialization and repeated signal handling.
+    listeners.get('SIGHUP')?.();
     listeners.get('SIGHUP')?.();
 
     expect(terminationHook).toHaveBeenCalledWith(129);
-    expect(cleanup).toHaveBeenCalledOnce();
     expect(regularCleanup).not.toHaveBeenCalled();
     expect(exit).not.toHaveBeenCalled();
 
     resolveCleanup?.();
+    await cleanupRun;
     await vi.waitFor(() => {
       expect(regularCleanup).toHaveBeenCalledOnce();
+      expect(exit).toHaveBeenCalledOnce();
       expect(exit).toHaveBeenCalledWith(129);
     });
   });
@@ -95,12 +102,18 @@ describeOnPosix('process termination signals', () => {
 
       let output = '';
       let signalSent = false;
+      let repeatedSignalTimeout: NodeJS.Timeout | undefined;
       const ready = new Promise<void>((resolve, reject) => {
         const handleOutput = (chunk: Buffer) => {
           output += chunk.toString();
           if (!signalSent && output.includes('READY\n')) {
             signalSent = true;
             child.kill(terminationSignal);
+            repeatedSignalTimeout = setTimeout(() => {
+              if (child.exitCode === null && child.signalCode === null) {
+                child.kill(terminationSignal);
+              }
+            }, 20);
             resolve();
           }
         };
@@ -136,6 +149,7 @@ describeOnPosix('process termination signals', () => {
         );
       } finally {
         clearTimeout(timeout);
+        clearTimeout(repeatedSignalTimeout);
         if (child.exitCode === null && child.signalCode === null) {
           child.kill('SIGKILL');
           await closed;

--- a/tests/process-termination.test.ts
+++ b/tests/process-termination.test.ts
@@ -1,0 +1,144 @@
+import { spawn } from 'node:child_process';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  registerCleanupHandler,
+  registerTerminationHook,
+  setupProcessTermination,
+} from '../src/util.js';
+
+const fixturePath = fileURLToPath(
+  new URL('./fixtures/process-termination.ts', import.meta.url),
+);
+const describeOnPosix = process.platform === 'win32' ? describe.skip : describe;
+
+describe('process termination', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('waits for cleanup after invoking a termination signal listener', async () => {
+    const listeners = new Map<string, (...args: any[]) => void>();
+    vi.spyOn(process, 'once').mockImplementation((event, listener) => {
+      listeners.set(String(event), listener);
+      return process;
+    });
+    const exit = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((() => undefined) as never);
+
+    let resolveCleanup: (() => void) | undefined;
+    const cleanup = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveCleanup = resolve;
+        }),
+    );
+    const terminationHook = vi.fn();
+    registerTerminationHook(terminationHook);
+    registerCleanupHandler('test cleanup', cleanup);
+
+    setupProcessTermination();
+
+    expect(listeners.has('SIGINT')).toBe(true);
+    expect(listeners.has('SIGTERM')).toBe(true);
+    expect(listeners.has('SIGHUP')).toBe(true);
+
+    // Invoke SIGHUP as a representative registered listener. This exercises
+    // the cross-platform termination path without emulating OS signal delivery;
+    // the POSIX subprocess tests below cover real delivery for all three signals.
+    listeners.get('SIGHUP')?.();
+
+    expect(terminationHook).toHaveBeenCalledWith(129);
+    expect(cleanup).toHaveBeenCalledOnce();
+    expect(exit).not.toHaveBeenCalled();
+
+    resolveCleanup?.();
+    await vi.waitFor(() => {
+      expect(exit).toHaveBeenCalledWith(129);
+    });
+  });
+});
+
+// Node.js cannot generate catchable CTRL_C_EVENT or CTRL_BREAK_EVENT for a
+// child process on win32 using its public APIs. subprocess.kill() forcefully
+// terminates the process there, so Windows needs a native/PTY-based or manual
+// integration test rather than pretending this POSIX signal test is portable.
+describeOnPosix('process termination signals', () => {
+  it.each([
+    ['SIGINT', 130],
+    ['SIGTERM', 143],
+    ['SIGHUP', 129],
+  ] as const)(
+    'aborts active work and waits for cleanup after %s',
+    async (terminationSignal, exitCode) => {
+      const temporaryDirectory = await mkdtemp(
+        join(tmpdir(), 'vivliostyle-cli-signal-'),
+      );
+      const markerPath = join(temporaryDirectory, 'cleaned');
+      const child = spawn(
+        process.execPath,
+        ['--import', 'tsx', fixturePath, markerPath],
+        {
+          stdio: ['ignore', 'pipe', 'pipe'],
+        },
+      );
+
+      let output = '';
+      let signalSent = false;
+      const ready = new Promise<void>((resolve, reject) => {
+        const handleOutput = (chunk: Buffer) => {
+          output += chunk.toString();
+          if (!signalSent && output.includes('READY\n')) {
+            signalSent = true;
+            child.kill(terminationSignal);
+            resolve();
+          }
+        };
+        child.stdout.on('data', handleOutput);
+        child.stderr.on('data', handleOutput);
+        child.once('error', reject);
+        child.once('close', (code, signal) => {
+          if (!signalSent) {
+            reject(
+              new Error(
+                `Fixture exited before it was ready (code: ${code}, signal: ${signal})\n${output}`,
+              ),
+            );
+          }
+        });
+      });
+      const closed = new Promise<{
+        code: number | null;
+        signal: NodeJS.Signals | null;
+      }>((resolve, reject) => {
+        child.once('error', reject);
+        child.once('close', (code, signal) => resolve({ code, signal }));
+      });
+      const timeout = setTimeout(() => child.kill('SIGKILL'), 4_000);
+
+      try {
+        await ready;
+        const result = await closed;
+
+        expect(result).toEqual({ code: exitCode, signal: null });
+        await expect(readFile(markerPath, 'utf8')).resolves.toBe(
+          JSON.stringify({ aborted: true, exitCode }),
+        );
+      } finally {
+        clearTimeout(timeout);
+        if (child.exitCode === null && child.signalCode === null) {
+          child.kill('SIGKILL');
+          await closed;
+        }
+        await rm(temporaryDirectory, { recursive: true, force: true });
+      }
+    },
+    10_000,
+  );
+});

--- a/tests/process-termination.test.ts
+++ b/tests/process-termination.test.ts
@@ -33,15 +33,17 @@ describe('process termination', () => {
       .mockImplementation((() => undefined) as never);
 
     let resolveCleanup: (() => void) | undefined;
-    const cleanup = vi.fn(
+    const cleanup = vi.fn<() => Promise<void>>(
       () =>
         new Promise<void>((resolve) => {
           resolveCleanup = resolve;
         }),
     );
-    const terminationHook = vi.fn();
+    const regularCleanup = vi.fn<() => void>();
+    const terminationHook = vi.fn<(exitCode: number) => void>();
     registerTerminationHook(terminationHook);
-    registerCleanupHandler('test cleanup', cleanup);
+    registerCleanupHandler('regular cleanup', regularCleanup);
+    registerCleanupHandler('priority cleanup', cleanup, { prepend: true });
 
     setupProcessTermination();
 
@@ -56,10 +58,12 @@ describe('process termination', () => {
 
     expect(terminationHook).toHaveBeenCalledWith(129);
     expect(cleanup).toHaveBeenCalledOnce();
+    expect(regularCleanup).not.toHaveBeenCalled();
     expect(exit).not.toHaveBeenCalled();
 
     resolveCleanup?.();
     await vi.waitFor(() => {
+      expect(regularCleanup).toHaveBeenCalledOnce();
       expect(exit).toHaveBeenCalledWith(129);
     });
   });

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -14,6 +14,7 @@ const mockedBrowserModule = vi.hoisted(() => ({
   launchPreview: vi.fn().mockResolvedValue({
     page: {
       on: vi.fn(),
+      off: vi.fn(),
       bringToFront: vi.fn(),
       locator: vi.fn().mockReturnValue({
         focus: vi.fn(),
@@ -22,10 +23,14 @@ const mockedBrowserModule = vi.hoisted(() => ({
     browser: {
       close: vi.fn(),
     },
+    closeBrowser: vi.fn(),
   }),
 }));
 
-vi.mock('../src/browser', () => mockedBrowserModule);
+vi.mock('../src/browser', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../src/browser.js')>()),
+  ...mockedBrowserModule,
+}));
 
 const launchPreviewSpy = vi.spyOn(mockedBrowserModule, 'launchPreview');
 

--- a/tests/theme-interrupt.test.ts
+++ b/tests/theme-interrupt.test.ts
@@ -1,0 +1,192 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type MockTree = {
+  children: Map<
+    string,
+    {
+      path: string;
+      resolved?: string;
+    }
+  >;
+};
+
+const mockedArborist = vi.hoisted(() => ({
+  buildIdealTree: vi.fn<() => Promise<MockTree>>(),
+  reify: vi.fn<(options?: unknown) => Promise<MockTree>>(),
+}));
+const mockedRegisterCleanupHandler = vi.hoisted(() =>
+  vi.fn<
+    (
+      message: string,
+      handler: () => Promise<void>,
+      options?: { prepend?: boolean },
+    ) => () => void
+  >(),
+);
+
+vi.mock('@npmcli/arborist', () => ({
+  default: class Arborist {
+    buildIdealTree = mockedArborist.buildIdealTree;
+    reify = mockedArborist.reify;
+  },
+}));
+
+vi.mock('../src/util.js', () => ({
+  DetailError: class DetailError extends Error {
+    constructor(
+      message: string | undefined,
+      readonly detail: string | undefined,
+    ) {
+      super(message);
+    }
+  },
+  registerCleanupHandler: mockedRegisterCleanupHandler,
+}));
+
+import type { ParsedTheme } from '../src/config/resolve.js';
+import { installThemeDependencies } from '../src/processor/theme.js';
+
+const themeIndexes = new Set<ParsedTheme>([
+  {
+    type: 'package',
+    name: 'example-theme',
+    specifier: 'example-theme',
+    location: '/themes/node_modules/example-theme',
+    registry: true,
+  },
+]);
+
+describe('theme installation cancellation', () => {
+  let cleanupHandler: (() => Promise<void>) | undefined;
+  let themesDir: string;
+  const unregisterCleanup = vi.fn<() => void>();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    cleanupHandler = undefined;
+    themesDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'vivliostyle-theme-interrupt-'),
+    );
+    mockedArborist.buildIdealTree.mockResolvedValue({
+      children: new Map(),
+    });
+    mockedRegisterCleanupHandler.mockImplementation((_message, handler) => {
+      cleanupHandler = handler;
+      return unregisterCleanup;
+    });
+  });
+
+  afterEach(() => {
+    fs.rmSync(themesDir, { recursive: true, force: true });
+  });
+
+  it('waits for Arborist rollback and preserves the abort reason', async () => {
+    const controller = new AbortController();
+    const abortReason = new Error('interrupted');
+    const arboristError = new Error('process terminated');
+    let rejectReify: ((error: Error) => void) | undefined;
+    mockedArborist.reify.mockReturnValue(
+      new Promise((_, reject) => {
+        rejectReify = reject;
+      }),
+    );
+
+    const installation = installThemeDependencies({
+      themesDir,
+      themeIndexes,
+      signal: controller.signal,
+    });
+
+    await vi.waitFor(() => {
+      expect(cleanupHandler).toBeDefined();
+    });
+    expect(mockedRegisterCleanupHandler).toHaveBeenCalledWith(
+      'Waiting for theme installation rollback',
+      expect.any(Function),
+      { prepend: true },
+    );
+    controller.abort(abortReason);
+
+    let cleanupSettled = false;
+    const cleanup = cleanupHandler?.().then(() => {
+      cleanupSettled = true;
+    });
+    await Promise.resolve();
+    expect(cleanupSettled).toBe(false);
+
+    rejectReify?.(arboristError);
+
+    await cleanup;
+    await expect(installation).rejects.toBe(abortReason);
+    expect(unregisterCleanup).toHaveBeenCalledOnce();
+  });
+
+  it('keeps reporting non-cancellation reify errors as installation errors', async () => {
+    const arboristError = new Error('installation failed');
+    mockedArborist.reify.mockRejectedValue(arboristError);
+
+    const installation = installThemeDependencies({
+      themesDir,
+      themeIndexes,
+    });
+
+    await expect(installation).rejects.toMatchObject({
+      message: 'An error occurred during the installation of the theme',
+    });
+    expect(unregisterCleanup).toHaveBeenCalledOnce();
+  });
+
+  it('finishes local theme linking before reporting cancellation', async () => {
+    const controller = new AbortController();
+    const abortReason = new Error('interrupted');
+    const sourcePath = path.join(themesDir, 'source-theme');
+    const installedPath = path.join(themesDir, 'node_modules', 'example-theme');
+    fs.mkdirSync(sourcePath);
+    fs.mkdirSync(installedPath, { recursive: true });
+    mockedArborist.reify.mockImplementation(async () => {
+      controller.abort(abortReason);
+      return {
+        children: new Map([
+          [
+            'example-theme',
+            {
+              path: installedPath,
+              resolved: 'file:source-theme',
+            },
+          ],
+        ]),
+      };
+    });
+
+    await expect(
+      installThemeDependencies({
+        themesDir,
+        themeIndexes,
+        signal: controller.signal,
+      }),
+    ).rejects.toBe(abortReason);
+
+    expect(fs.realpathSync(installedPath)).toBe(fs.realpathSync(sourcePath));
+    expect(unregisterCleanup).toHaveBeenCalledOnce();
+  });
+
+  it('does not start Arborist work when already aborted', async () => {
+    const controller = new AbortController();
+    const abortReason = new Error('interrupted');
+    controller.abort(abortReason);
+
+    await expect(
+      installThemeDependencies({
+        themesDir,
+        themeIndexes,
+        signal: controller.signal,
+      }),
+    ).rejects.toBe(abortReason);
+    expect(mockedArborist.buildIdealTree).not.toHaveBeenCalled();
+    expect(mockedArborist.reify).not.toHaveBeenCalled();
+  });
+});

--- a/tests/util.test.ts
+++ b/tests/util.test.ts
@@ -1,0 +1,70 @@
+import fs from 'node:fs';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, expect, it, vi } from 'vitest';
+
+const streamZipMock = vi.hoisted(() => ({
+  finishExtraction: undefined as (() => void) | undefined,
+}));
+
+vi.mock('node-stream-zip', async () => {
+  const { EventEmitter } = await import('node:events');
+  const fs = await import('node:fs');
+  const { join } = await import('node:path');
+
+  return {
+    default: class extends EventEmitter {
+      constructor() {
+        super();
+        queueMicrotask(() => this.emit('ready'));
+      }
+
+      extract(_entry: null, destination: string, callback: () => void) {
+        fs.mkdirSync(destination, { recursive: true });
+        fs.writeFileSync(join(destination, 'partial'), '');
+        streamZipMock.finishExtraction = callback;
+      }
+
+      close(callback: () => void) {
+        callback();
+      }
+    },
+  };
+});
+
+import { openEpub, runCleanupHandlers } from '../src/util.js';
+
+let temporaryDirectory: string | undefined;
+
+afterEach(async () => {
+  if (temporaryDirectory) {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  }
+});
+
+it('removes partial EPUB output when cleanup starts during extraction', async () => {
+  temporaryDirectory = await mkdtemp(join(tmpdir(), 'vivliostyle-cli-epub-'));
+  const outputDirectory = join(temporaryDirectory, 'output');
+  const opening = openEpub('input.epub', outputDirectory);
+
+  await vi.waitFor(() => {
+    expect(fs.existsSync(join(outputDirectory, 'partial'))).toBe(true);
+  });
+
+  let cleanupFinished = false;
+  const cleanup = runCleanupHandlers().then(() => {
+    cleanupFinished = true;
+  });
+  await Promise.resolve();
+
+  expect(cleanupFinished).toBe(false);
+  expect(fs.existsSync(outputDirectory)).toBe(true);
+
+  streamZipMock.finishExtraction?.();
+  await opening;
+  await cleanup;
+
+  expect(fs.existsSync(outputDirectory)).toBe(false);
+});

--- a/tests/vite-plugin-browser.test.ts
+++ b/tests/vite-plugin-browser.test.ts
@@ -1,0 +1,83 @@
+import type { Page } from 'puppeteer-core';
+import type { ViteDevServer } from 'vite';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { ResolvedTaskConfig } from '../src/config/resolve.js';
+import type { ParsedVivliostyleInlineConfig } from '../src/config/schema.js';
+
+const mockedLaunchPreview = vi.hoisted(() => vi.fn());
+const mockedGetViewerFullUrl = vi.hoisted(() => vi.fn());
+const mockedReloadConfig = vi.hoisted(() => vi.fn());
+
+vi.mock('../src/browser.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../src/browser.js')>()),
+  launchPreview: mockedLaunchPreview,
+}));
+
+vi.mock('../src/server.js', () => ({
+  getViewerFullUrl: mockedGetViewerFullUrl,
+}));
+
+vi.mock('../src/vite/plugin-util.js', () => ({
+  reloadConfig: mockedReloadConfig,
+}));
+
+import { vsBrowserPlugin } from '../src/vite/vite-plugin-browser.js';
+
+const config = {} as ResolvedTaskConfig;
+
+describe('vsBrowserPlugin cancellation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedGetViewerFullUrl.mockResolvedValue('http://localhost:13000/viewer');
+    mockedReloadConfig.mockResolvedValue(config);
+  });
+
+  it('passes the signal and normalizes page setup errors after cancellation', async () => {
+    const controller = new AbortController();
+    const reason = new Error('cancelled');
+    const protocolError = new Error(
+      'Protocol error (Runtime.callFunctionOn): Target closed',
+    );
+    const closeBrowser = vi.fn(async () => {});
+    const page = {
+      on: vi.fn(),
+      off: vi.fn(),
+      bringToFront: vi.fn(async () => {
+        controller.abort(reason);
+        throw protocolError;
+      }),
+    } as unknown as Page;
+    mockedLaunchPreview.mockResolvedValue({
+      page,
+      closeBrowser,
+    });
+
+    const plugin = vsBrowserPlugin({
+      config,
+      inlineConfig: {
+        openViewer: true,
+        signal: controller.signal,
+      } as ParsedVivliostyleInlineConfig,
+    });
+    const server = {
+      listen: vi.fn(async () => server),
+      close: vi.fn(async () => {}),
+      config: {},
+    } as unknown as ViteDevServer;
+    const configureServer = plugin.configureServer;
+    expect(typeof configureServer).toBe('function');
+    if (typeof configureServer !== 'function') {
+      return;
+    }
+    configureServer(server);
+
+    await expect(server.listen()).rejects.toBe(reason);
+    expect(mockedLaunchPreview).toHaveBeenCalledWith(
+      expect.objectContaining({
+        signal: controller.signal,
+      }),
+    );
+    expect(closeBrowser).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/vite-server-cleanup.test.ts
+++ b/tests/vite-server-cleanup.test.ts
@@ -1,0 +1,119 @@
+import type {
+  InlineConfig,
+  PreviewServer,
+  ResolvedConfig as ResolvedViteConfig,
+  ViteDevServer,
+} from 'vite';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockedVite = vi.hoisted(() => ({
+  createServer: vi.fn<(config?: InlineConfig) => Promise<ViteDevServer>>(),
+  preview: vi.fn<(config?: InlineConfig) => Promise<PreviewServer>>(),
+}));
+const mockedRegisterCleanupHandler = vi.hoisted(() =>
+  vi.fn<
+    (
+      message: string,
+      handler: () => Promise<void>,
+    ) => () => (() => Promise<void>) | undefined
+  >(),
+);
+
+vi.mock('vite', () => mockedVite);
+
+vi.mock('../src/util.js', () => ({
+  getDefaultEpubOpfPath: () => '',
+  isValidUri: () => false,
+  openEpub: async () => {},
+  registerCleanupHandler: mockedRegisterCleanupHandler,
+}));
+
+vi.mock('../src/vite/vite-plugin-browser.js', () => ({
+  vsBrowserPlugin: () => ({ name: 'browser' }),
+}));
+
+vi.mock('../src/vite/vite-plugin-dev-server.js', () => ({
+  vsDevServerPlugin: () => ({ name: 'dev-server' }),
+}));
+
+vi.mock('../src/vite/vite-plugin-static-serve.js', () => ({
+  vsStaticServePlugin: () => ({ name: 'static-serve' }),
+}));
+
+vi.mock('../src/vite/vite-plugin-viewer.js', () => ({
+  vsViewerPlugin: () => ({ name: 'viewer' }),
+}));
+
+import type { ResolvedTaskConfig } from '../src/config/resolve.js';
+import type { ParsedVivliostyleInlineConfig } from '../src/config/schema.js';
+import { createViteServer } from '../src/server.js';
+
+const config = {
+  serverRootDir: '/server',
+  workspaceDir: '/workspace',
+} as ResolvedTaskConfig;
+const viteConfig = {
+  server: {},
+  preview: {},
+  cacheDir: '/cache',
+  root: '/server',
+} as ResolvedViteConfig;
+const inlineConfig = {} as ParsedVivliostyleInlineConfig;
+
+describe('Vite server cleanup', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    ['preview', mockedVite.createServer],
+    ['build', mockedVite.preview],
+  ] as const)(
+    'registers and shares %s server cleanup before launch completes',
+    async (mode, launchServer) => {
+      let resolveServer:
+        | ((server: ViteDevServer | PreviewServer) => void)
+        | undefined;
+      const closeLaunchedServer = vi.fn<() => Promise<void>>(async () => {});
+      const server = {
+        close: closeLaunchedServer,
+      } as unknown as ViteDevServer | PreviewServer;
+      launchServer.mockReturnValueOnce(
+        new Promise<ViteDevServer | PreviewServer>((resolve) => {
+          resolveServer = resolve;
+        }),
+      );
+      let cleanupHandler: (() => Promise<void>) | undefined;
+      mockedRegisterCleanupHandler.mockImplementationOnce(
+        (_message, handler) => {
+          cleanupHandler = handler;
+          return () => undefined;
+        },
+      );
+
+      const creatingServer = createViteServer({
+        config,
+        viteConfig,
+        inlineConfig,
+        mode,
+      });
+
+      expect(mockedRegisterCleanupHandler).toHaveBeenCalledWith(
+        'Closing Vite server',
+        expect.any(Function),
+      );
+      const cleanup = cleanupHandler?.();
+      expect(cleanup).toBeInstanceOf(Promise);
+      expect(closeLaunchedServer).not.toHaveBeenCalled();
+
+      resolveServer?.(server);
+      const launchedServer = await creatingServer;
+      await cleanup;
+
+      const directClose = launchedServer.close();
+      expect(directClose).toBe(cleanup);
+      await directClose;
+      expect(closeLaunchedServer).toHaveBeenCalledOnce();
+    },
+  );
+});

--- a/tests/vite-server-cleanup.test.ts
+++ b/tests/vite-server-cleanup.test.ts
@@ -15,6 +15,7 @@ const mockedRegisterCleanupHandler = vi.hoisted(() =>
     (
       message: string,
       handler: () => Promise<void>,
+      options?: { prepend?: boolean },
     ) => () => (() => Promise<void>) | undefined
   >(),
 );
@@ -101,6 +102,7 @@ describe('Vite server cleanup', () => {
       expect(mockedRegisterCleanupHandler).toHaveBeenCalledWith(
         'Closing Vite server',
         expect.any(Function),
+        { prepend: true },
       );
       const cleanup = cleanupHandler?.();
       expect(cleanup).toBeInstanceOf(Promise);

--- a/tests/workspace-cleanup.test.ts
+++ b/tests/workspace-cleanup.test.ts
@@ -1,0 +1,79 @@
+import fs from 'node:fs';
+import fsPromises from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+
+import type * as UtilModule from '../src/util.js';
+
+const mockedMove = vi.hoisted(() =>
+  vi.fn<(from: string, to: string) => Promise<void>>(),
+);
+const mockedRegisterCleanupHandler = vi.hoisted(() =>
+  vi.fn<(message: string, handler: () => Promise<void>) => () => void>(),
+);
+
+vi.mock('fs-extra/esm', async () => {
+  return {
+    copy: vi.fn<() => Promise<void>>(),
+    move: mockedMove.mockImplementation(async (from, to) => {
+      await fsPromises.rename(from, to);
+    }),
+  };
+});
+
+vi.mock('../src/util.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof UtilModule>();
+  return {
+    ...actual,
+    registerCleanupHandler: mockedRegisterCleanupHandler,
+  };
+});
+
+import type { ResolvedTaskConfig } from '../src/config/resolve.js';
+import { cleanupWorkspace } from '../src/processor/compile.js';
+
+let temporaryDirectory: string | undefined;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockedRegisterCleanupHandler.mockReturnValue(vi.fn<() => void>());
+});
+
+afterEach(() => {
+  if (temporaryDirectory) {
+    fs.rmSync(temporaryDirectory, { recursive: true, force: true });
+  }
+});
+
+it('unregisters workspace cleanup handler after cleanup failure', async () => {
+  temporaryDirectory = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'vivliostyle-workspace-cleanup-'),
+  );
+  const entryContextDir = path.join(temporaryDirectory, 'entry');
+  const workspaceDir = path.join(temporaryDirectory, 'workspace');
+  const themesDir = path.join(workspaceDir, 'themes');
+  fs.mkdirSync(entryContextDir);
+  fs.mkdirSync(themesDir, { recursive: true });
+
+  const cleanupError = new Error('cleanup failed');
+  mockedMove.mockRejectedValueOnce(cleanupError);
+  const unregisterCleanupHandler = vi.fn<() => void>();
+  mockedRegisterCleanupHandler.mockReturnValue(unregisterCleanupHandler);
+
+  await expect(
+    cleanupWorkspace({
+      entryContextDir,
+      workspaceDir,
+      themesDir,
+      entries: [],
+    } as unknown as ResolvedTaskConfig),
+  ).rejects.toBe(cleanupError);
+
+  expect(mockedRegisterCleanupHandler).toHaveBeenCalledWith(
+    'Waiting for workspace cleanup',
+    expect.any(Function),
+  );
+  expect(unregisterCleanupHandler).toHaveBeenCalledOnce();
+});


### PR DESCRIPTION
# Run CLI subcommands in-process so cleanup can complete

Closes #828

## Summary

Run `build`, `preview`, `create`, and `init` in the root CLI process so Vivliostyle CLI can own termination, abort active work, and await cleanup before exiting.

This prevents Ctrl+C from racing with signal handlers installed by Commander.js, Puppeteer, and yocto-spinner, which could leave temporary files, Vite resources, or browser processes behind.

## Problem

Vivliostyle CLI previously used Commander.js stand-alone executable subcommands. The root command spawned a subcommand process, while Commander.js, Puppeteer, yocto-spinner, and Vivliostyle CLI could all install their own signal or exit handling.

When Ctrl+C arrived, those handlers could race. In particular, a handler outside Vivliostyle CLI could call `process.exit()` or terminate the child process before Vivliostyle CLI finished its asynchronous cleanup handlers. Depending on the execution stage, this could leave resources such as `.vite`, `.vs-*` files or directories, Vite servers, or browser processes behind.

## Approach

Move subcommand execution into the root CLI process and make Vivliostyle CLI the lifecycle owner for one command invocation:

- parse and dispatch the selected subcommand in-process;
- disable signal handling in dependencies where the dependency exposes an option;
- notify active work through a shared `AbortSignal`;
- await registered cleanup handlers before exiting;
- preserve existing command entry points and CLI compatibility behavior.

## What Changed

### CLI Lifecycle Ownership

- Dispatch `build`, `preview`, `create`, and `init` in-process, loading only the selected side-effect-free runner before execution.
- Keep thin executable wrappers for `@vivliostyle/cli/commands/*`, preserving direct subcommand entry points and `create-book` behavior.
- Resolve the root CLI entry point through its real path so npm/pnpm bin symlinks execute the bundled CLI normally.
- Handle `SIGINT`, `SIGTERM`, and `SIGHUP` in the CLI, abort active work, run cleanup, and then exit with the corresponding code.
- Disable Puppeteer and yocto-spinner process-signal handling so the CLI remains the single lifecycle owner.

### Cleanup and Cancellation

- Serialize concurrent cleanup requests so repeated signals cannot bypass an already-running cleanup.
- Keep signal listeners active while cleanup is in progress, and allow cleanup handlers registered after a completed cleanup run to execute in later runs within the same process.
- Treat interactive prompt cancellation as a non-error command exit without calling `process.exit()` from the prompt layer.
- Propagate cancellation through long-running paths and normalize expected interruption errors back to the original CLI abort reason.

### Resource-Specific Handling

- Keep `vivliostyle preview` active until its Vite server closes, and run cleanup when the server is closed through the normal preview lifetime.
- Register Vite server cleanup before asynchronous server startup completes, so interrupted startup can still close the launched server.
- Make browser shutdown idempotent, register cleanup before asynchronous launch completes, and share shutdown between cancellation and cleanup.
- Because `page.pdf()` does not currently accept an `AbortSignal`, cancel an in-flight PDF operation by closing the browser, then normalize the resulting Puppeteer error to the original abort reason.
- Propagate cancellation through PDF postprocessing and `press-ready` Docker preflight, and remove temporary preflight input only after in-flight preflight work has settled.
- Register temporary EPUB cleanup before extraction starts, and wait for in-flight extraction before removing partial output.
- Abort and await dependency-installation and Docker child processes before exiting.
- Wait for temporary directory creation, workspace cleanup, and project-template download to settle before removing partial output.
- Keep Arborist's process-signal handling enabled because its in-flight `reify()` operation owns stage-specific rollback. The CLI gives the corresponding wait handler priority, waits for `reify()` to settle, and normalizes its termination error to the original CLI abort reason.

### Compatibility

- Preserve root help, version output, command help, unknown-command diagnostics, spelling suggestions, and raw arguments including the `--` delimiter[^1].
- Preserve each bundled `dist/commands/*.js` entry point as directly executable.
- Preserve `create-book` side-effect import behavior.

## Verification

### macOS

- `pnpm install --frozen-lockfile`
- `pnpm lint`
- `pnpm fmt:check`
- `pnpm run build:typecheck`
- `pnpm run build:cli`
- `pnpm run build:create-book`
- `pnpm test`
- Manual build/preview interruption checks at multiple execution stages.

### Windows

- `pnpm run build:typecheck`
- `pnpm lint`
- `pnpm run build:cli`
- Focused cleanup/interruption suites, including build, preview, create, init, browser, Vite server, PDF, EPUB, Docker, dependency installation, template download, prompt cancellation, and process-termination coverage.
- Bundled CLI smoke checks for root help, version output, subcommand help, direct `dist/commands/*.js` entry points, `create-book` help, unknown-command diagnostics, and option-like input paths after `--`.
- Manual build/preview interruption checks at multiple execution stages.

### Added Regression Coverage

- POSIX subprocess tests which send real `SIGINT`, `SIGTERM`, and `SIGHUP`, verify that active work is aborted before asynchronous cleanup completes, and verify the corresponding exit code.
- Repeated-signal coverage while cleanup is already in progress.
- Preview server lifetime cleanup.
- Browser shutdown sharing between cancellation and cleanup.
- PDF cancellation and PDF postprocessing/preflight interruption.
- Vite server startup cleanup.
- Temporary EPUB extraction cleanup.
- Arborist rollback waiting and abort-reason normalization.
- Docker and dependency-installation interruption.
- Project-template download interruption.
- Bin symlink execution.
- Prompt cancellation.
- Workspace cleanup failure and cleanup handler unregistering.

## Scope / Non-goals

This change addresses lifecycle ownership for one CLI command per process.

It does not make concurrent JavaScript API calls safe or introduce a per-execution resource context.

Graceful cleanup also cannot be guaranteed if a parent process, build tool, or task runner force-terminates the CLI without delivering a catchable termination signal and allowing time for cleanup.

This change does not attempt to abort or roll back persistent download caches owned by external installers. In particular, `@puppeteer/browsers` may populate the browser cache when no compatible browser is available, and `@bluwy/giget-core` may populate its template cache when downloading a remote project template. The CLI now waits for its own temporary directories and registered cleanup work before removing partial output, but interrupted external downloads can still leave cache artifacts managed by those packages. Handling that would require upstream `AbortSignal` support, cache-staging changes, or cache-specific recovery logic and is intentionally left out of this PR.

Arborist is a deliberate exception to centralized signal ownership. It does not expose an option to disable signal handling, an `AbortSignal` interface, or a public rollback API. Process signals therefore continue to be handled internally during `reify()`, while the CLI waits for that operation to settle before exiting. Cancellation that is delivered only through the JavaScript API cannot interrupt an in-flight `reify()` and is observed after it settles. Fully centralizing this path would require upstream Arborist support or process isolation and is outside this change.

The real-signal subprocess tests are skipped on Windows. Node.js does not expose a public API for generating catchable `CTRL_C_EVENT` or `CTRL_BREAK_EVENT` notifications for a child process in the same way POSIX signals can be sent; `subprocess.kill()` terminates the process instead. A future Windows integration test should use a native helper, console/PTY harness, or equivalent platform-specific mechanism. The current Windows tests still cover listener registration and the termination/cleanup sequence without emulating OS console control events.

[^1]: This changes an edge case in the previous stand-alone executable subcommand path: Commander.js removed the `--` delimiter before spawning the subcommand, causing a following operand beginning with `-` to be interpreted as an option. The in-process dispatcher preserves the delimiter for the existing subcommand parser, matching Commander.js's documented `--` semantics and [POSIX Utility Syntax Guideline 10](https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap12.html#tag_12_02).
