### PR TITLE
chore(docker): Remove no-op font purge from the fonts install step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,8 +37,6 @@ RUN set -x \
 RUN set -x \
   && apt-get update -qq \
   && apt-get upgrade -yqq \
-  # remove poor quality fonts
-  && apt-get purge -y ttf-unifont fonts-ipafont-gothic fonts-wqy-zenhei \
   # install all Noto fonts
   && apt-get install -y fonts-noto \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
#793 の一部です。

この行で削除されるはずのフォントは、実際にはインストールされていません。ディストロを切り替える前から存在する行なので古くなってしまったものと思います。

```shellsession
$ sed -n '1,39p' Dockerfile | docker build -t vivliostyle-cli:check-font -
$ docker run --rm --entrypoint dpkg vivliostyle-cli:check-font -l | grep font
ii  fontconfig-config              2.15.0-2.3                     amd64        generic font configuration library - configuration
ii  fonts-urw-base35               20200910-8                     all          font set metric-compatible with the 35 PostScript Level 2 Base Fonts
ii  libfontconfig1:amd64           2.15.0-2.3                     amd64        generic font configuration library - runtime
ii  libfontenc1:amd64              1:1.1.8-1+b2                   amd64        X11 font encoding library
ii  libfreetype6:amd64             2.13.3+dfsg-1+deb13u1          amd64        FreeType 2 font engine, shared library files
ii  xfonts-encodings               1:1.0.4-2.2                    all          Encodings for [X.Org](http://x.org/) fonts
ii  xfonts-utils                   1:7.7+7                        amd64        X Window System font utility programs
```