### PR TITLE
refactor: Store the theme resolution cache under the workspace directory

### DIFF
--- a/.changeset/fresh-ghosts-reply.md
+++ b/.changeset/fresh-ghosts-reply.md
@@ -1,0 +1,5 @@
+---
+'@vivliostyle/cli': patch
+---
+
+Store the theme resolution cache under the workspace directory instead of the global npm cache.

--- a/src/processor/compile.ts
+++ b/src/processor/compile.ts
@@ -131,7 +131,6 @@ export async function cleanupWorkspace({
 export async function prepareThemeDirectory({
   themesDir,
   themeIndexes,
-  workspaceDir,
 }: ResolvedTaskConfig): Promise<string[]> {
   // Backward compatibility: v8 to v9
   if (
@@ -145,15 +144,9 @@ export async function prepareThemeDirectory({
   }
 
   // install theme packages
-  if (
-    await checkThemeInstallationNecessity({
-      themesDir,
-      themeIndexes,
-      workspaceDir,
-    })
-  ) {
+  if (await checkThemeInstallationNecessity({ themesDir, themeIndexes })) {
     Logger.startLogging('Installing theme files');
-    await installThemeDependencies({ themesDir, themeIndexes, workspaceDir });
+    await installThemeDependencies({ themesDir, themeIndexes });
   }
 
   // copy theme files

--- a/src/processor/compile.ts
+++ b/src/processor/compile.ts
@@ -131,6 +131,7 @@ export async function cleanupWorkspace({
 export async function prepareThemeDirectory({
   themesDir,
   themeIndexes,
+  workspaceDir,
 }: ResolvedTaskConfig): Promise<string[]> {
   // Backward compatibility: v8 to v9
   if (
@@ -144,9 +145,15 @@ export async function prepareThemeDirectory({
   }
 
   // install theme packages
-  if (await checkThemeInstallationNecessity({ themesDir, themeIndexes })) {
+  if (
+    await checkThemeInstallationNecessity({
+      themesDir,
+      themeIndexes,
+      workspaceDir,
+    })
+  ) {
     Logger.startLogging('Installing theme files');
-    await installThemeDependencies({ themesDir, themeIndexes });
+    await installThemeDependencies({ themesDir, themeIndexes, workspaceDir });
   }
 
   // copy theme files

--- a/src/processor/theme.ts
+++ b/src/processor/theme.ts
@@ -6,6 +6,11 @@ import upath from 'upath';
 import type { ResolvedTaskConfig } from '../config/resolve.js';
 import { DetailError } from '../util.js';
 
+function getThemeInstallCacheDir(workspaceDir: string): string {
+  // see https://github.com/npm/cli/blob/arborist-v9.1.7/workspaces/arborist/lib/arborist/index.js#L104
+  return upath.join(workspaceDir, '.npm', '_cacache');
+}
+
 function* iterateSymlinksInThemesNodeModules(
   themesDir: string,
 ): Generator<string> {
@@ -44,7 +49,11 @@ function removeThemesDirIfBrokenSymlinks(themesDir: string): void {
 export async function checkThemeInstallationNecessity({
   themesDir,
   themeIndexes,
-}: Pick<ResolvedTaskConfig, 'themesDir' | 'themeIndexes'>): Promise<boolean> {
+  workspaceDir,
+}: Pick<
+  ResolvedTaskConfig,
+  'themesDir' | 'themeIndexes' | 'workspaceDir'
+>): Promise<boolean> {
   removeThemesDirIfBrokenSymlinks(themesDir);
   if (!fs.existsSync(themesDir)) {
     return [...themeIndexes].some((theme) => theme.type === 'package');
@@ -52,6 +61,7 @@ export async function checkThemeInstallationNecessity({
 
   const commonOpt = {
     path: themesDir,
+    cache: getThemeInstallCacheDir(workspaceDir),
     lockfileVersion: 3,
     installLinks: true,
   };
@@ -72,13 +82,18 @@ export function getLocalThemePaths({
 export async function installThemeDependencies({
   themesDir,
   themeIndexes,
-}: Pick<ResolvedTaskConfig, 'themesDir' | 'themeIndexes'>): Promise<void> {
+  workspaceDir,
+}: Pick<
+  ResolvedTaskConfig,
+  'themesDir' | 'themeIndexes' | 'workspaceDir'
+>): Promise<void> {
   fs.mkdirSync(themesDir, { recursive: true });
   removeThemesDirIfBrokenSymlinks(themesDir);
 
   try {
     const commonOpt = {
       path: themesDir,
+      cache: getThemeInstallCacheDir(workspaceDir),
       lockfileVersion: 3,
       installLinks: true,
     };

--- a/src/processor/theme.ts
+++ b/src/processor/theme.ts
@@ -6,9 +6,10 @@ import upath from 'upath';
 import type { ResolvedTaskConfig } from '../config/resolve.js';
 import { DetailError } from '../util.js';
 
-function getThemeInstallCacheDir(workspaceDir: string): string {
-  // see https://github.com/npm/cli/blob/arborist-v9.1.7/workspaces/arborist/lib/arborist/index.js#L104
-  return upath.join(workspaceDir, '.npm', '_cacache');
+function getThemeInstallCacheDir(themesDir: string): string {
+  // Layout follows Arborist's default cache location:
+  // https://github.com/npm/cli/blob/arborist-v9.1.7/workspaces/arborist/lib/arborist/index.js#L104
+  return upath.join(themesDir, '.npm', '_cacache');
 }
 
 function* iterateSymlinksInThemesNodeModules(
@@ -49,11 +50,7 @@ function removeThemesDirIfBrokenSymlinks(themesDir: string): void {
 export async function checkThemeInstallationNecessity({
   themesDir,
   themeIndexes,
-  workspaceDir,
-}: Pick<
-  ResolvedTaskConfig,
-  'themesDir' | 'themeIndexes' | 'workspaceDir'
->): Promise<boolean> {
+}: Pick<ResolvedTaskConfig, 'themesDir' | 'themeIndexes'>): Promise<boolean> {
   removeThemesDirIfBrokenSymlinks(themesDir);
   if (!fs.existsSync(themesDir)) {
     return [...themeIndexes].some((theme) => theme.type === 'package');
@@ -61,7 +58,7 @@ export async function checkThemeInstallationNecessity({
 
   const commonOpt = {
     path: themesDir,
-    cache: getThemeInstallCacheDir(workspaceDir),
+    cache: getThemeInstallCacheDir(themesDir),
     lockfileVersion: 3,
     installLinks: true,
   };
@@ -82,18 +79,14 @@ export function getLocalThemePaths({
 export async function installThemeDependencies({
   themesDir,
   themeIndexes,
-  workspaceDir,
-}: Pick<
-  ResolvedTaskConfig,
-  'themesDir' | 'themeIndexes' | 'workspaceDir'
->): Promise<void> {
+}: Pick<ResolvedTaskConfig, 'themesDir' | 'themeIndexes'>): Promise<void> {
   fs.mkdirSync(themesDir, { recursive: true });
   removeThemesDirIfBrokenSymlinks(themesDir);
 
   try {
     const commonOpt = {
       path: themesDir,
-      cache: getThemeInstallCacheDir(workspaceDir),
+      cache: getThemeInstallCacheDir(themesDir),
       lockfileVersion: 3,
       installLinks: true,
     };

--- a/tests/builder.test.ts
+++ b/tests/builder.test.ts
@@ -90,8 +90,8 @@ it('generate workspace directory', async () => {
   ).toBeTruthy();
 });
 
-it('stores the theme resolution cache under the workspace directory', async () => {
-  // Build from a clean workspace so the theme install actually runs.
+it('keeps the theme resolution cache across builds', async () => {
+  // Build from a clean workspace so the theme install runs and writes the cache.
   fs.rmSync(resolveFixture('builder/.vs-workspace'), {
     recursive: true,
     force: true,
@@ -99,7 +99,12 @@ it('stores the theme resolution cache under the workspace directory', async () =
   await runCommand(['build', '-c', 'workspace.config.js'], {
     cwd: resolveFixture('builder'),
   });
-  const cacheDir = resolveFixture('builder/.vs-workspace/.npm/_cacache');
+  // A rebuild runs cleanupWorkspace, which only preserves themesDir, then skips
+  // the install; the cache must survive because it lives under themesDir.
+  await runCommand(['build', '-c', 'workspace.config.js'], {
+    cwd: resolveFixture('builder'),
+  });
+  const cacheDir = resolveFixture('builder/.vs-workspace/themes/.npm/_cacache');
   expect(fs.existsSync(cacheDir)).toBe(true);
   expect(fs.statSync(cacheDir).isDirectory()).toBe(true);
 });

--- a/tests/builder.test.ts
+++ b/tests/builder.test.ts
@@ -90,6 +90,20 @@ it('generate workspace directory', async () => {
   ).toBeTruthy();
 });
 
+it('stores the theme resolution cache under the workspace directory', async () => {
+  // Build from a clean workspace so the theme install actually runs.
+  fs.rmSync(resolveFixture('builder/.vs-workspace'), {
+    recursive: true,
+    force: true,
+  });
+  await runCommand(['build', '-c', 'workspace.config.js'], {
+    cwd: resolveFixture('builder'),
+  });
+  const cacheDir = resolveFixture('builder/.vs-workspace/.npm/_cacache');
+  expect(fs.existsSync(cacheDir)).toBe(true);
+  expect(fs.statSync(cacheDir).isDirectory()).toBe(true);
+});
+
 it('generate files with entryContext', async () => {
   await runCommand(['build', '-c', 'entryContext.config.js'], {
     cwd: resolveFixture('builder'),


### PR DESCRIPTION
closes: #835

Arboristが`$HOME`以下に書き込むのは認識しづらい挙動です。`themesDir`以下を明示すれば、Vivliostyle CLIの実行ユーザーが必ず書き込めるため、参照Issueのような不都合を起こしません。
