### PR TITLE
fix(ci): Verify the working tree is clean after build in the test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,15 @@ jobs:
       - run: pnpm install
       - run: pnpm lint
       - run: pnpm fmt:check
+      - run: pnpm build
+      - name: Check for unclean working tree
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "::error::Working tree is unclean after 'pnpm build'. Run 'pnpm build' locally and commit the generated changes."
+            git status --porcelain
+            git diff
+            exit 1
+          fi
   build-and-test:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/docs/config.md
+++ b/docs/config.md
@@ -379,7 +379,7 @@ type ArticleEntryConfig = {
   - `format`: "pdf" | "epub" | "webpub"  
     Specifies the output format.
 
-  - `renderMode`: "local" | "docker"  
+  - ~~`renderMode`~~ _Deprecated_  
     If set to `docker`, Vivliostyle will render the PDF using a Docker container. (default: `local`)
     `renderMode: docker` is deprecated and may be removed in a future major release. See https://github.com/vivliostyle/vivliostyle-cli/issues/823
 


### PR DESCRIPTION
`pnpm build` regenerates docs, so stale generated files merged into main make the release workflow's `pnpm publish --dry-run` fail with ERR_PNPM_GIT_UNCLEAN. Run the build and check the working tree in CI to catch this at PR time.