### PR TITLE
Give the browser a writable `HOME` for UIDs missing from `/etc/passwd`.

### DIFF
--- a/.changeset/browser-writable-home.md
+++ b/.changeset/browser-writable-home.md
@@ -1,0 +1,5 @@
+---
+'@vivliostyle/cli': patch
+---
+
+Give the browser a writable `HOME` for UIDs missing from `/etc/passwd`.

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+import os from 'node:os';
 
 import type {
   BrowserPlatform,
@@ -216,9 +217,17 @@ async function launchBrowser({
     protocolTimeout,
   } satisfies LaunchOptions;
   Logger.debug('launchOptions %O', launchOptions);
+  // Browsers store transient data that never affects rendering (crash dumps,
+  // profiles.ini) under HOME (chrome_paths_linux.cc, nsXREDirProvider.cpp). A
+  // container UID with no /etc/passwd entry (e.g. `docker run --user`)
+  // gets the unwritable HOME `/`, so the browser cannot launch (see #835).
+  const env: NodeJS.ProcessEnv = { ...process.env, LANG: 'en.UTF-8' };
+  if (process.platform === 'linux' && !isWritableDir(env.HOME)) {
+    env.HOME = os.tmpdir();
+  }
   const browserLaunch = puppeteer.launch({
     ...launchOptions,
-    env: { ...process.env, LANG: 'en.UTF-8' },
+    env,
     handleSIGINT: false,
     handleSIGTERM: false,
     handleSIGHUP: false,
@@ -230,6 +239,18 @@ async function launchBrowser({
   const browser = await browserLaunch;
   const [browserContext] = browser.browserContexts();
   return { browser, browserContext, closeBrowser };
+}
+
+function isWritableDir(dir: string | undefined): boolean {
+  if (!dir) {
+    return false;
+  }
+  try {
+    fs.accessSync(dir, fs.constants.W_OK);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function getPuppeteerCacheDir() {

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,5 +1,4 @@
 import fs from 'node:fs';
-import os from 'node:os';
 
 import type {
   BrowserPlatform,
@@ -26,6 +25,7 @@ import {
   isRunningOnWSL,
   registerCleanupHandler,
   toError,
+  useTmpDirectory,
 } from './util.js';
 
 /* oxlint-disable typescript/no-unsafe-type-assertion */
@@ -223,7 +223,7 @@ async function launchBrowser({
   // gets the unwritable HOME `/`, so the browser cannot launch (see #835).
   const env: NodeJS.ProcessEnv = { ...process.env, LANG: 'en.UTF-8' };
   if (process.platform === 'linux' && !isWritableDir(env.HOME)) {
-    env.HOME = os.tmpdir();
+    [env.HOME] = await useTmpDirectory();
   }
   const browserLaunch = puppeteer.launch({
     ...launchOptions,
@@ -246,7 +246,10 @@ function isWritableDir(dir: string | undefined): boolean {
     return false;
   }
   try {
-    fs.accessSync(dir, fs.constants.W_OK);
+    if (!fs.statSync(dir).isDirectory()) {
+      return false;
+    }
+    fs.accessSync(dir, fs.constants.W_OK | fs.constants.X_OK);
     return true;
   } catch {
     return false;

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -217,11 +217,12 @@ async function launchBrowser({
     protocolTimeout,
   } satisfies LaunchOptions;
   Logger.debug('launchOptions %O', launchOptions);
+  // #416: set Chromium language to English to avoid locale-dependent issues
+  const env: NodeJS.ProcessEnv = { ...process.env, LANG: 'en.UTF-8' };
   // Browsers store transient data that never affects rendering (crash dumps,
   // profiles.ini) under HOME (chrome_paths_linux.cc, nsXREDirProvider.cpp). A
   // container UID with no /etc/passwd entry (e.g. `docker run --user`)
   // gets the unwritable HOME `/`, so the browser cannot launch (see #835).
-  const env: NodeJS.ProcessEnv = { ...process.env, LANG: 'en.UTF-8' };
   if (process.platform === 'linux' && !isWritableDir(env.HOME)) {
     [env.HOME] = await useTmpDirectory();
   }

--- a/tests/browser.test.ts
+++ b/tests/browser.test.ts
@@ -1,10 +1,17 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import os from 'node:os';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockedLaunch = vi.hoisted(() =>
   vi.fn<(options?: unknown) => Promise<unknown>>(),
 );
 const mockedRegisterCleanupHandler = vi.hoisted(() =>
   vi.fn<(message: string, handler: () => void | Promise<void>) => void>(),
+);
+const mockedUseTmpDirectory = vi.hoisted(() =>
+  vi.fn<() => Promise<[string, () => void]>>(() =>
+    Promise.resolve(['/tmp/vivliostyle-home-test', () => {}]),
+  ),
 );
 
 vi.mock('../src/node-modules.js', () => ({
@@ -20,6 +27,7 @@ vi.mock('../src/util.js', async (importOriginal) => {
   return {
     ...actual,
     registerCleanupHandler: mockedRegisterCleanupHandler,
+    useTmpDirectory: mockedUseTmpDirectory,
   };
 });
 
@@ -173,5 +181,88 @@ describe('launchPreview', () => {
     await cleanup;
     expect(browserClose).toHaveBeenCalledOnce();
     await expect(launching).rejects.toThrow(Error);
+  });
+});
+
+describe('writable HOME fallback', () => {
+  const originalPlatform = process.platform;
+  const setPlatform = (value: NodeJS.Platform) => {
+    Object.defineProperty(process, 'platform', {
+      value,
+      configurable: true,
+    });
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedLaunch.mockResolvedValue({
+      browserContexts: () => [
+        {
+          pages: () => [],
+          newPage: () => ({
+            setViewport: vi.fn<() => void>(),
+            on: vi.fn<() => void>(),
+            authenticate: vi.fn<() => void>(),
+            goto: vi.fn<() => void>(),
+          }),
+        },
+      ],
+      close: vi.fn<() => void>(),
+    });
+  });
+
+  afterEach(() => {
+    setPlatform(originalPlatform);
+    vi.unstubAllEnvs();
+  });
+
+  const launch = () =>
+    launchPreview({
+      mode: 'build',
+      url: 'https://example.com',
+      config: {
+        browser: {
+          type: 'chrome',
+          tag: 'stable',
+          executablePath: process.execPath,
+        },
+        proxy: undefined,
+        sandbox: false,
+        ignoreHttpsErrors: false,
+        timeout: 1000,
+      },
+    });
+
+  const launchedEnv = () =>
+    (mockedLaunch.mock.calls[0][0] as { env: NodeJS.ProcessEnv }).env;
+
+  it('replaces an unwritable HOME with a temp directory on Linux', async () => {
+    setPlatform('linux');
+    vi.stubEnv('HOME', '/__vivliostyle_nonexistent_home__');
+
+    await launch();
+
+    expect(mockedUseTmpDirectory).toHaveBeenCalledOnce();
+    expect(launchedEnv().HOME).toBe('/tmp/vivliostyle-home-test');
+  });
+
+  it('keeps a writable HOME untouched on Linux', async () => {
+    setPlatform('linux');
+    vi.stubEnv('HOME', os.tmpdir());
+
+    await launch();
+
+    expect(mockedUseTmpDirectory).not.toHaveBeenCalled();
+    expect(launchedEnv().HOME).toBe(os.tmpdir());
+  });
+
+  it('does not touch HOME on non-Linux platforms', async () => {
+    setPlatform('darwin');
+    vi.stubEnv('HOME', '/__vivliostyle_nonexistent_home__');
+
+    await launch();
+
+    expect(mockedUseTmpDirectory).not.toHaveBeenCalled();
+    expect(launchedEnv().HOME).toBe('/__vivliostyle_nonexistent_home__');
   });
 });


### PR DESCRIPTION
closes: #835 

補足として、Puppeteerはtempdir基準の`--user-data-dir`をChromeに与えており、多くの一時ファイルはここに作成されます https://github.com/puppeteer/puppeteer/blob/puppeteer-core-v25.1.0/packages/puppeteer-core/src/node/BrowserLauncher.ts#L490-L496

ただしクラッシュレポートは意図的に`HOME`に収められており、ここで問題になります。 https://github.com/chromium/chromium/blob/e44bf5d2837ae8a8b51feb6025022cfc81bf3865/chrome/common/chrome_paths.cc#L216-L224

Firefoxでは`--profile`に同じ一時ディレクトリを与えていますが、これとは別に`~/.mozilla/firefox/profiles.ini`に書き込みます。 https://github.com/mozilla-firefox/firefox/blob/d9a7ad7e3099ffe62328af33ee458054337f2cd2/toolkit/profile/nsToolkitProfileService.cpp#L996-L1005