### PR TITLE
fix(build): down-level output to the engines.node floor

### DIFF
--- a/.changeset/early-llamas-remain.md
+++ b/.changeset/early-llamas-remain.md
@@ -1,0 +1,5 @@
+---
+'@vivliostyle/cli': patch
+---
+
+Down-level the build to the `engines.node` floor (>=22.12.0) so the CLI no longer crashes with `SyntaxError: Unexpected identifier '_'` on Node 22.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,6 +64,9 @@ jobs:
           cache: pnpm
       - run: pnpm install
       - run: pnpm build:cli
+      - name: Check the built CLI has no syntax errors on Node ${{ matrix.node }}
+        shell: bash
+        run: find dist -name '*.js' -print0 | xargs -0 -n1 node --check
       - run: pnpm test
   build-and-push-image:
     runs-on: ubuntu-latest

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
     'src/commands/init.ts',
     'src/commands/preview.ts',
   ],
-  target: false,
+  target: 'node22.12',
   fixedExtension: false,
   deps: {
     onlyBundle: [/^@types\/.*/v],


### PR DESCRIPTION
ビルドを変更した影響でNode.js 22では実行できない構文を残したままリリースされています。修正と、Actionsでのテストを追加してリリース前に検証されるようにします。

```shellsession
$ node --version && npx --yes @vivliostyle/cli@11.0.3 preview test.md
v22.20.0
file:///home/mukai/.npm/_npx/487708ec071c7f5b/node_modules/@vivliostyle/cli/dist/preview-D04EAlzs.js:21
                using _ = Logger.startLogging("Start preview");
                      ^

SyntaxError: Unexpected identifier '_'
    at compileSourceTextModule (node:internal/modules/esm/utils:346:16)
    at ModuleLoader.moduleStrategy (node:internal/modules/esm/translators:107:18)
    at #translate (node:internal/modules/esm/loader:546:20)
    at afterLoad (node:internal/modules/esm/loader:596:29)
    at ModuleLoader.loadAndTranslate (node:internal/modules/esm/loader:601:12)
    at #createModuleJob (node:internal/modules/esm/loader:624:36)
    at #getJobFromResolveResult (node:internal/modules/esm/loader:343:34)
    at ModuleLoader.getModuleJobForImport (node:internal/modules/esm/loader:311:41)

Node.js v22.20.0
```