### PR TITLE
fix: Show interactive UI when running directly inside the container

### DIFF
--- a/.changeset/interactive-spinner-in-container.md
+++ b/.changeset/interactive-spinner-in-container.md
@@ -1,0 +1,5 @@
+---
+'@vivliostyle/cli': patch
+---
+
+Show the interactive spinner when running the CLI inside the container image on an interactive terminal instead of falling back to plain logs.

--- a/src/core/build.ts
+++ b/src/core/build.ts
@@ -28,7 +28,7 @@ export async function build(
   inlineConfig: ParsedVivliostyleInlineConfig,
   { containerForkMode = false }: { containerForkMode?: boolean } = {},
 ): Promise<void> {
-  Logger.setLogOptions(inlineConfig);
+  Logger.setLogOptions({ ...inlineConfig, containerForkMode });
   if (containerForkMode) {
     Logger.setLogPrefix(gray('[Docker]'));
   }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -276,8 +276,8 @@ export class Logger {
     if (signal) {
       this.#signal = signal;
     }
-    if (containerForkMode) {
-      this.#containerForkMode = true;
+    if (containerForkMode !== undefined) {
+      this.#containerForkMode = containerForkMode;
     }
   }
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -6,7 +6,7 @@ import debug from 'debug';
 import yoctoSpinner, { type Spinner } from 'yocto-spinner';
 import { blueBright, greenBright, redBright, yellowBright } from 'yoctocolors';
 
-import { isInContainer, registerCleanupHandler } from './util.js';
+import { registerCleanupHandler } from './util.js';
 
 export const isUnicodeSupported =
   process.platform !== 'win32' || Boolean(process.env.WT_SESSION);
@@ -45,6 +45,11 @@ export class Logger {
   static #stdout: Writable = process.stdout;
   static #stderr: Writable = process.stderr;
   static #signal: AbortSignal | undefined;
+  /**
+   * True in the forked build subprocess (renderMode: docker),
+   * which logs non-interactively.
+   */
+  static #containerForkMode = false;
 
   static debug = debug('vs-cli');
 
@@ -92,8 +97,7 @@ export class Logger {
       !('CI' in process.env) &&
       !import.meta.env?.VITEST &&
       !debug.enabled('vs-cli') &&
-      // Prevent stream output in docker container so that not to spawn process
-      !isInContainer()
+      !this.#containerForkMode
     );
   }
 
@@ -234,6 +238,7 @@ export class Logger {
     stdout,
     stderr,
     signal,
+    containerForkMode,
   }: {
     logLevel?: 'silent' | 'info' | 'verbose' | 'debug';
     logger?: LoggerInterface;
@@ -241,6 +246,7 @@ export class Logger {
     stdout?: Writable;
     stderr?: Writable;
     signal?: AbortSignal;
+    containerForkMode?: boolean;
   }): void {
     if (logLevel) {
       this.#logLevel = (
@@ -269,6 +275,9 @@ export class Logger {
     }
     if (signal) {
       this.#signal = signal;
+    }
+    if (containerForkMode) {
+      this.#containerForkMode = true;
     }
   }
 


### PR DESCRIPTION
Vivliostyle CLI自身が起動したコンテナを判定する方法を改善するPRです。

現在の実装では、コンテナに対話的に入って（`docker run -it`）ビルドしても、スピナー（や、 #853 の進捗表示）が出ません。

```
$ docker run -it --rm -v .:/data --entrypoint bash ghcr.io/vivliostyle/cli:11.0.4
vivliostyle@e853d5c9b5c4:/data$ vivliostyle build manuscript.md
INFO Start building
INFO Launching PDF build environment
INFO Building pages
INFO Building PDF
INFO Processing PDF
SUCCESS Finished building output.pdf
📙 Built successfully!
```

問題は、この箇所の`isInContainer()`が、自身が立ち上げたコンテナか、ユーザーが自分でコンテナを叩いているのかを区別しないことにあります。`containerForkMode`を判定に使用することで区別できるようになります。

```typescript
  static get isInteractive(): boolean {
    return (
      !this.#customLogger &&
      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- #stderr is typed Writable; read the tty-only isTTY flag
      (this.#stderr as WriteStream).isTTY &&
      process.env.TERM !== 'dumb' &&
      !('CI' in process.env) &&
      !import.meta.env?.VITEST &&
      !debug.enabled('vs-cli') &&
      // Prevent stream output in docker container so that not to spawn process
      !isInContainer()
    );
  }
```