### PR TITLE
feat: Update Vivliostyle.js to 2.44.0: Pagination progress event, Bug Fixes

### DIFF
--- a/.changeset/giant-rats-hang.md
+++ b/.changeset/giant-rats-hang.md
@@ -1,0 +1,5 @@
+---
+'@vivliostyle/cli': minor
+---
+
+Update Vivliostyle.js to 2.44.0: Pagination progress event, Bug Fixes

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@puppeteer/browsers": "3.0.4",
     "@vivliostyle/jsdom": "25.0.1-vivliostyle-cli.2",
     "@vivliostyle/vfm": "2.7.0",
-    "@vivliostyle/viewer": "2.43.2",
+    "@vivliostyle/viewer": "2.44.0",
     "ajv": "8.18.0",
     "ajv-formats": "3.0.1",
     "archiver": "7.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: 2.7.0
         version: 2.7.0(typescript@6.0.3)
       '@vivliostyle/viewer':
-        specifier: 2.43.2
-        version: 2.43.2
+        specifier: 2.44.0
+        version: 2.44.0
       ajv:
         specifier: 8.18.0
         version: 8.18.0
@@ -2888,8 +2888,8 @@ packages:
   '@vitest/utils@4.1.9':
     resolution: {integrity: sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==}
 
-  '@vivliostyle/core@2.43.2':
-    resolution: {integrity: sha512-l4c6nv83C2GrYrVYJV9LhcVoq8gKihtdS1rXEdbHu6jvsXSOzMy2l3njFih40jRIcWy/4gx9L/rnSkPUMkCx/Q==}
+  '@vivliostyle/core@2.44.0':
+    resolution: {integrity: sha512-nLfFlSyAhSzHUlShuvDImTYRR9j1q9GMjci3DT45hnO3h8fyBRIIBFq4Qe2pzEQ4UrCt73MSeAQuyXMIYRriRA==}
     engines: {node: '>=20'}
 
   '@vivliostyle/jsdom@25.0.1-vivliostyle-cli.2':
@@ -2906,8 +2906,8 @@ packages:
     engines: {node: '>= 20'}
     hasBin: true
 
-  '@vivliostyle/viewer@2.43.2':
-    resolution: {integrity: sha512-Vh0w1MtS466EvAaGEoXEwter7lDwHKA0ige3mEmX2liLLHzCLjvTaAsGR3eZzA93pclUfh5YLrQRnrYDNaP2Mg==}
+  '@vivliostyle/viewer@2.44.0':
+    resolution: {integrity: sha512-myNqxw/Iq1v4c32fr8O8zRtds/9komati7vaf9f8BBjUrONr6sshM0bto8xaMXPipHTcWC6YaMyuqNjoFNmLAw==}
     engines: {node: '>=20'}
 
   '@zachleat/heading-anchors@1.0.5':
@@ -9269,7 +9269,7 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  '@vivliostyle/core@2.43.2':
+  '@vivliostyle/core@2.44.0':
     dependencies:
       fast-diff: 1.3.0
 
@@ -9346,9 +9346,9 @@ snapshots:
       - supports-color
       - typescript
 
-  '@vivliostyle/viewer@2.43.2':
+  '@vivliostyle/viewer@2.44.0':
     dependencies:
-      '@vivliostyle/core': 2.43.2
+      '@vivliostyle/core': 2.44.0
       i18next-ko: 3.0.1
       knockout: 3.5.3
 


### PR DESCRIPTION
https://github.com/vivliostyle/vivliostyle.js/releases/tag/v2.44.0

### Features

- Add paginationprogress event to CoreViewer
- Add document href to pagination progress payload

### Bug Fixes

- Guard against null xmldoc from store.load
- Compute pagination progress fraction against all spine items
- Make text-spacing filler widths independent of installed fonts
- Restore target-counter references for redirected chapter URLs
- Exclude Fullwidth Semicolon from Chromium vo=Tr fallback
- Fix Vertical vo=Tr character rotation on Chromium
- Fix long line-policy footnote fragmentation
- Prevent long footnotes from being dropped during target-counter() rerendering
- prevent rendering hang with footnote-policy: line