### PR TITLE
chore(deps): Upgrade pnpm to 11.10.0

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-save-exact=true
-ignore-workspace-root-check=true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ Key areas:
 
 ## Development Commands
 
-Use pnpm. The repository declares `pnpm@10.28.2` and requires Node `>=22.12.0`.
+Use pnpm. The repository declares `pnpm@11.10.0` and requires Node `>=22.12.0`.
 
 - Install dependencies: `pnpm install`
 - Build everything: `pnpm build` (bundles the CLI and create-book with tsdown, then builds docs; it does not type-check)

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "oxfmt": "0.56.0",
     "oxlint": "1.71.0",
     "oxlint-tsgolint": "0.23.0",
-    "pnpm": "10.28.2",
+    "pnpm": "11.10.0",
     "shx": "0.4.0",
     "supertest": "7.2.2",
     "tsdown": "0.22.3",
@@ -191,5 +191,5 @@
   "engines": {
     "node": ">=22.12.0"
   },
-  "packageManager": "pnpm@10.28.2"
+  "packageManager": "pnpm@11.10.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -283,8 +283,8 @@ importers:
         specifier: 0.23.0
         version: 0.23.0
       pnpm:
-        specifier: 10.28.2
-        version: 10.28.2
+        specifier: 11.10.0
+        version: 11.10.0
       shx:
         specifier: 0.4.0
         version: 0.4.0
@@ -5460,9 +5460,9 @@ packages:
   please-upgrade-node@3.2.0:
     resolution: {integrity: sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==}
 
-  pnpm@10.28.2:
-    resolution: {integrity: sha512-QYcvA3rSL3NI47Heu69+hnz9RI8nJtnPdMCPGVB8MdLI56EVJbmD/rwt9kC1Q43uYCPrsfhO1DzC1lTSvDJiZA==}
-    engines: {node: '>=18.12'}
+  pnpm@11.10.0:
+    resolution: {integrity: sha512-C3+LmAYAMZBMAX46QesYehbUDuuCm5XE+MsDaBdh/Eq1PdIZEVubRH9NzhoFohR2RGHn03AzkqnzL5URzoyGyA==}
+    engines: {node: '>=22.13'}
     hasBin: true
 
   postcss-nested@6.2.0:
@@ -12449,7 +12449,7 @@ snapshots:
     dependencies:
       semver-compare: 1.0.0
 
-  pnpm@10.28.2: {}
+  pnpm@11.10.0: {}
 
   postcss-nested@6.2.0(postcss@8.5.3):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,22 @@ packages:
   - examples/*
   - packages/*
 
-onlyBuiltDependencies:
-  - esbuild
-  - sharp
+allowBuilds:
+  esbuild: true
+  sharp: true
+
+saveExact: true
+ignoreWorkspaceRootCheck: true
+
+# Exempt from pnpm 11's 1-day supply-chain embargo the packages whose version
+# this repo pins deliberately and adopts the same day they ship: the
+# @vivliostyle/* scope (this repo tracks Vivliostyle.js) and pnpm itself (the
+# devDep mirrors the pinned packageManager). The embargo stays on for the rest.
+minimumReleaseAgeExclude:
+  - '@vivliostyle/*'
+  - 'pnpm'
+
+# pnpm 11 defaults this to "install", which makes the pre-commit hook
+# (`pnpm exec lint-staged`) try to purge and reinstall node_modules and abort
+# with no TTY when the modules dir drifts (e.g. right after pulling this bump).
+verifyDepsBeforeRun: false


### PR DESCRIPTION
## Summary

Upgrades the package manager from **pnpm 10.28.2 → 11.10.0** (latest), bumping both the `packageManager` field and the `pnpm` devDependency, and migrating the config to pnpm 11's breaking changes.

CI needs no workflow edits: every `pnpm/action-setup@v4` step is version-less and reads the version from `packageManager`.

## Config migration

| Change | Reason |
| --- | --- |
| `onlyBuiltDependencies` (list) → `allowBuilds` (map) | pnpm 11 removed the old build-dependency settings. |
| `.npmrc` (`save-exact`, `ignore-workspace-root-check`) → `pnpm-workspace.yaml` (`saveExact`, `ignoreWorkspaceRootCheck`); `.npmrc` deleted | pnpm 11 reads only auth/registry keys from `.npmrc`; both settings verified via `pnpm config get`. |
| `minimumReleaseAgeExclude: ['@vivliostyle/*', 'pnpm']` | pnpm 11's new default `minimumReleaseAge: 1440` adds a 1-day supply-chain embargo (freshly-published versions aren't resolved for 24h). Rather than disabling it globally, the embargo is **kept on for all dependencies** and only two scopes are exempted — the ones whose version this repo pins deliberately and adopts the same day they ship: `@vivliostyle/*` (this repo tracks Vivliostyle.js; the embargo otherwise blocked the locked `@vivliostyle/core@2.44.0` / `viewer@2.44.0`) and `pnpm` itself (the devDep mirrors the pinned `packageManager`; the embargo otherwise blocked `pnpm@11.10.0`). |
| `verifyDepsBeforeRun: false` | pnpm 11's new default (`install`) makes the `pnpm exec lint-staged` pre-commit hook try to purge+reinstall `node_modules` and abort with `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY` when the modules dir drifts (e.g. right after pulling this bump). `false` restores pnpm 10 behavior. |

## Notes on the known v11 lockfile bug

The v10→v11 non-idempotent lockfile re-resolution ([pnpm#11859](https://github.com/pnpm/pnpm/issues/11859)) is triggered by `catalog`/`overrides`/`patchedDependencies`, none of which this repo uses. Verified empirically: `pnpm install` re-resolves cleanly — the only lockfile change is the `pnpm` entry itself — and a second install reports "Already up to date".

## Verification (local, pnpm 11.10.0)

- `pnpm install` — clean, idempotent; supply-chain policy passes with the embargo on and the two scopes excluded
- `pnpm typecheck` — pass
- `pnpm build:cli` — pass
- `pnpm lint` / `pnpm fmt:check` — pass
- full `pnpm test` (coverage) — pass
- `pnpm publish -r --dry-run --report-summary --publish-branch …` — flags intact under pnpm 11's native publish flow (only fails on the expected unclean-tree git check)
- pre-commit / pre-push hooks run without the purge abort

🤖 Generated with [Claude Code](https://claude.com/claude-code)