### PR TITLE
fix: Update Vivliostyle.js to 2.44.1: Bug Fixes

### DIFF
--- a/.changeset/bold-sides-care.md
+++ b/.changeset/bold-sides-care.md
@@ -1,0 +1,5 @@
+---
+'@vivliostyle/cli': patch
+---
+
+Update Vivliostyle.js to 2.44.1: Bug Fixes

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@puppeteer/browsers": "3.0.4",
     "@vivliostyle/jsdom": "25.0.1-vivliostyle-cli.2",
     "@vivliostyle/vfm": "2.7.0",
-    "@vivliostyle/viewer": "2.44.0",
+    "@vivliostyle/viewer": "2.44.1",
     "ajv": "8.18.0",
     "ajv-formats": "3.0.1",
     "archiver": "7.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: 2.7.0
         version: 2.7.0(typescript@6.0.3)
       '@vivliostyle/viewer':
-        specifier: 2.44.0
-        version: 2.44.0
+        specifier: 2.44.1
+        version: 2.44.1
       ajv:
         specifier: 8.18.0
         version: 8.18.0
@@ -2885,8 +2885,8 @@ packages:
   '@vitest/utils@4.1.9':
     resolution: {integrity: sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==}
 
-  '@vivliostyle/core@2.44.0':
-    resolution: {integrity: sha512-nLfFlSyAhSzHUlShuvDImTYRR9j1q9GMjci3DT45hnO3h8fyBRIIBFq4Qe2pzEQ4UrCt73MSeAQuyXMIYRriRA==}
+  '@vivliostyle/core@2.44.1':
+    resolution: {integrity: sha512-J0G35Qt2I4sKZFLuV2DM1ZpgGn3SnEHtdEB/wQaaNGvh+TnAlz6jnvl1QuCLpvjwYgvVikXrxghGO82D4mL4Ew==}
     engines: {node: '>=20'}
 
   '@vivliostyle/jsdom@25.0.1-vivliostyle-cli.2':
@@ -2903,8 +2903,8 @@ packages:
     engines: {node: '>= 20'}
     hasBin: true
 
-  '@vivliostyle/viewer@2.44.0':
-    resolution: {integrity: sha512-myNqxw/Iq1v4c32fr8O8zRtds/9komati7vaf9f8BBjUrONr6sshM0bto8xaMXPipHTcWC6YaMyuqNjoFNmLAw==}
+  '@vivliostyle/viewer@2.44.1':
+    resolution: {integrity: sha512-qQqHiagvl73iuDQoevvSCaVlaEvZD2R35luMQgHlrzHeY35ZNeCvwS/NzyP+WYWLbdSzDdooXALASWU+bIExJw==}
     engines: {node: '>=20'}
 
   '@zachleat/heading-anchors@1.0.5':
@@ -9267,7 +9267,7 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  '@vivliostyle/core@2.44.0':
+  '@vivliostyle/core@2.44.1':
     dependencies:
       fast-diff: 1.3.0
 
@@ -9344,9 +9344,9 @@ snapshots:
       - supports-color
       - typescript
 
-  '@vivliostyle/viewer@2.44.0':
+  '@vivliostyle/viewer@2.44.1':
     dependencies:
-      '@vivliostyle/core': 2.44.0
+      '@vivliostyle/core': 2.44.1
       i18next-ko: 3.0.1
       knockout: 3.5.3
 


### PR DESCRIPTION
https://github.com/vivliostyle/vivliostyle.js/releases/tag/v2.44.1

### Bug Fixes

- Collect spine total offsets before reporting pagination progress
- Keep the pagination progress href monotonic
- Restore Theme Base TOC styling with `target-counter()`