### PR TITLE
fix: Separate progress checkpoint text from transient spinner text

### DIFF
--- a/.changeset/flat-squids-drop.md
+++ b/.changeset/flat-squids-drop.md
@@ -1,0 +1,5 @@
+---
+"@vivliostyle/cli": patch
+---
+
+Fix the progress logs during PDF builds, which printed transient pagination progress repeatedly when no TTY is attached and could drop the `Building pages` line.

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -110,7 +110,7 @@ export class Logger {
       return;
     }
     if (this.#loggerInstance) {
-      this.#loggerInstance.#spinnerInstance.text = text;
+      this.#loggerInstance.#setCheckpointText(text);
       return this.#loggerInstance;
     }
     this.#loggerInstance = new Logger(this.#stderr);
@@ -122,19 +122,25 @@ export class Logger {
     if (this.#logLevel === 0) {
       return;
     }
-    if (!this.#spinner || !this.isInteractive) {
+    const instance = this.#loggerInstance;
+    if (!instance || !this.isInteractive) {
       this.logInfo(text);
       return;
     }
-    const currentMsg = this.#spinner?.text;
-    this.logUpdate(currentMsg);
-    this.#spinner.stop(`${infoSymbol} ${text}\n`);
+    const spinner = instance.#spinnerInstance;
+    spinner.stop(
+      this.#nonBlockingLogPrinted
+        ? undefined
+        : `${infoSymbol} ${instance.#checkpointText}`,
+    );
+    this.#nonBlockingLogPrinted = true;
+    spinner.start();
+    spinner.stop(`${infoSymbol} ${text}\n`);
     return {
       [Symbol.dispose](): void {
         if (Logger.isInteractive) {
           Logger.#console.log('');
-          Logger.#spinner?.start(currentMsg);
-          Logger.#nonBlockingLogPrinted = true;
+          Logger.#spinner?.start();
         }
       },
     };
@@ -148,16 +154,19 @@ export class Logger {
   }
 
   static logUpdate(...messages: unknown[]): void {
-    if (!this.#spinner || !this.isInteractive) {
+    const instance = this.#loggerInstance;
+    if (!instance || !this.isInteractive) {
       this.logInfo(...messages);
       return;
     }
-    this.#spinner.stop(
+    instance.#spinnerInstance.stop(
       this.#nonBlockingLogPrinted
         ? undefined
-        : `${infoSymbol} ${this.#spinner.text}`,
+        : `${infoSymbol} ${instance.#checkpointText}`,
     );
-    this.#spinner.start(messages.join(' '));
+    const text = messages.join(' ');
+    instance.#setCheckpointText(text);
+    instance.#spinnerInstance.start();
     this.#nonBlockingLogPrinted = false;
   }
 
@@ -171,7 +180,6 @@ export class Logger {
       return;
     }
     this.#spinner.text = messages.join(' ');
-    this.#nonBlockingLogPrinted = true;
   }
 
   static getMessage(message: string, symbol?: string): string {
@@ -182,7 +190,8 @@ export class Logger {
     logMethod: 'warn' | 'error' | 'info',
     message: string,
   ) {
-    if (!this.#spinner || !this.isInteractive) {
+    const instance = this.#loggerInstance;
+    if (!instance || !this.isInteractive) {
       const line = this.#logPrefix ? `${this.#logPrefix} ${message}` : message;
       if (this.#logLevel >= 3) {
         this.debug(line);
@@ -191,10 +200,16 @@ export class Logger {
       }
       return;
     }
-    this.logUpdate(this.#spinner.text);
+    const spinner = instance.#spinnerInstance;
+    spinner.stop(
+      this.#nonBlockingLogPrinted
+        ? undefined
+        : `${infoSymbol} ${instance.#checkpointText}`,
+    );
     this.#nonBlockingLogPrinted = true;
-    this.#spinner.stop(message);
-    this.#spinner.start();
+    spinner.start();
+    spinner.stop(message);
+    spinner.start();
   }
 
   static logSuccess(...messages: unknown[]): void {
@@ -299,6 +314,7 @@ export class Logger {
   }
 
   #spinnerInstance: Spinner;
+  #checkpointText = '';
   #disposeSpinnerCleanupHandler: (() => void) | undefined;
 
   constructor(stream: Writable) {
@@ -313,8 +329,14 @@ export class Logger {
     });
   }
 
+  #setCheckpointText(text: string) {
+    this.#checkpointText = text;
+    this.#spinnerInstance.text = text;
+  }
+
   #start(text: string) {
-    this.#spinnerInstance.start(text);
+    this.#setCheckpointText(text);
+    this.#spinnerInstance.start();
     this.#disposeSpinnerCleanupHandler = registerCleanupHandler(
       'Stopping spinner',
       () => {
@@ -328,7 +350,7 @@ export class Logger {
     this.#spinnerInstance.stop(
       Logger.#nonBlockingLogPrinted
         ? undefined
-        : `${infoSymbol} ${this.#spinnerInstance.text}`,
+        : `${infoSymbol} ${this.#checkpointText}`,
     );
     Logger.#loggerInstance = undefined;
   }

--- a/src/output/pdf.ts
+++ b/src/output/pdf.ts
@@ -117,14 +117,8 @@ export async function buildPDF({
     if (entry && entry !== lastEntry) {
       if (lastEntry) {
         Logger.logInfo(stringifyEntry(lastEntry));
-        lastEntry = entry;
-        Logger.startLogging(renderBuildingText());
-      } else {
-        lastEntry = entry;
-        Logger.logUpdateProgress(renderBuildingText());
-        Logger.logInfo('Building pages');
       }
-      return;
+      lastEntry = entry;
     }
 
     Logger.logUpdateProgress(renderBuildingText());

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -1,12 +1,27 @@
-import type { Writable } from 'node:stream';
+import { PassThrough, type Writable } from 'node:stream';
 
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, type Mock, vi } from 'vitest';
+
+type MockSpinner = {
+  text: string;
+  start: Mock<(text?: string) => unknown>;
+  stop: Mock<(finalText?: string) => unknown>;
+};
 
 const mockedYoctoSpinner = vi.hoisted(() =>
-  vi.fn<() => { text: string; stop: () => void }>(() => ({
-    text: '',
-    stop: vi.fn<() => void>(),
-  })),
+  vi.fn<() => MockSpinner>(() => {
+    const spinner: MockSpinner = {
+      text: '',
+      start: vi.fn<(text?: string) => unknown>((text) => {
+        if (text !== undefined) {
+          spinner.text = text;
+        }
+        return spinner;
+      }),
+      stop: vi.fn<(finalText?: string) => unknown>(() => spinner),
+    };
+    return spinner;
+  }),
 );
 
 vi.mock('yocto-spinner', () => ({
@@ -14,6 +29,29 @@ vi.mock('yocto-spinner', () => ({
 }));
 
 import { Logger } from '../src/logger.js';
+
+const ttyStream = {
+  isTTY: true,
+  write: () => true,
+} as unknown as Writable;
+
+function setupInteractiveLogger() {
+  for (const name of ['VITEST', 'CI']) {
+    // oxlint-disable-next-line unicorn/no-useless-undefined -- undefined removes the variable from the stubbed env
+    vi.stubEnv(name, undefined);
+  }
+  vi.stubEnv('TERM', 'xterm');
+  Logger.setLogOptions({ logLevel: 'info', stderr: ttyStream });
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  Logger.setLogOptions({
+    logLevel: 'silent',
+    stdout: process.stdout,
+    stderr: process.stderr,
+  });
+});
 
 describe('Logger', () => {
   it('disables dependency signal handlers for the spinner', () => {
@@ -27,5 +65,60 @@ describe('Logger', () => {
         handleSignals: false,
       }),
     );
+  });
+
+  it('checkpoints the last durable text even after transient progress updates', () => {
+    setupInteractiveLogger();
+    using _ = Logger.startLogging('Start building')!;
+    const spinner = mockedYoctoSpinner.mock.results[0]!.value;
+
+    Logger.logUpdate('Building pages');
+    Logger.logUpdateProgress('Building pages (1 pages, 100%)');
+    expect(spinner.text).toBe('Building pages (1 pages, 100%)');
+    Logger.logUpdate('Building PDF');
+
+    // The transition must print the durable text set by logUpdate,
+    // not the transient progress text nor suppress the line entirely
+    expect(spinner.stop).toHaveBeenCalledWith('INFO Building pages');
+    expect(spinner.stop).not.toHaveBeenCalledWith(
+      expect.stringContaining('(1 pages, 100%)'),
+    );
+  });
+
+  it('checkpoints the durable text before a non-blocking log line', () => {
+    setupInteractiveLogger();
+    using _ = Logger.startLogging('Start building')!;
+    const spinner = mockedYoctoSpinner.mock.results[0]!.value;
+
+    Logger.logUpdate('Building pages');
+    Logger.logUpdateProgress('entry.md (3 pages, 4%)');
+    Logger.logInfo('entry.md');
+    Logger.logUpdate('Building PDF');
+
+    const printed = spinner.stop.mock.calls
+      .map(([text]: [string?]) => text)
+      .filter((text: string | undefined): text is string => text !== undefined);
+    expect(printed).toContain('INFO Building pages');
+    expect(printed).toContain('INFO entry.md');
+    expect(printed.indexOf('INFO Building pages')).toBeLessThan(
+      printed.indexOf('INFO entry.md'),
+    );
+    expect(printed).not.toContainEqual(
+      expect.stringContaining('(3 pages, 4%)'),
+    );
+  });
+
+  it('ignores logUpdateProgress when the output is not interactive', () => {
+    const written: string[] = [];
+    const stream = new PassThrough();
+    stream.on('data', (chunk) => {
+      written.push(String(chunk));
+    });
+    Logger.setLogOptions({ logLevel: 'info', stdout: stream, stderr: stream });
+
+    Logger.logUpdateProgress('entry.md (3 pages, 4%)');
+    Logger.logUpdate('Building pages');
+
+    expect(written.join('')).toBe('INFO Building pages\n');
   });
 });


### PR DESCRIPTION
#853 で作成した`logUpdateProgress`の不備を修正するPRです。「書き換わる一時テキスト」と「恒久化するテキスト」を区別していなかったことで発生していた問題を修正します。

1. TTYをアタッチしないケースの進捗出力が異常でした。`docker run --rm --volume .:/data ghcr.io/vivliostyle/cli:11.1.0 build`でも起こせます。
   ```
   $ npx --yes @vivliostyle/cli@11.1.0 build </dev/null 2>&1 | cat
   INFO Start building
   INFO Launching PDF build environment
   INFO Building pages
   INFO Building pages
   INFO content/index.md Vivliostyle で本を作ろう Vol. 6
   INFO content/maegaki.md まえがき (3 pages, 4%)
   INFO content/maegaki.md まえがき
   INFO content/spring-raining/index.md あなたが知らないかもしれない CSS 変数活用法 (5 pages, 9%)
   INFO content/spring-raining/index.md あなたが知らないかもしれない CSS 変数活用法
   INFO content/mh35/index.md GitLab CI/CD を用いた、Vivliostyle 組版事始め (13 pages, 33%)
   INFO content/mh35/index.md GitLab CI/CD を用いた、Vivliostyle 組版事始め
   INFO content/akabeko/index.md rem へ寄せてゆく (16 pages, 39%)
   INFO content/akabeko/index.md rem へ寄せてゆく
   INFO content/ogwata/index.md Vivliostyle Pub がフォントを扱う仕組み (23 pages, 57%)
   INFO content/ogwata/index.md Vivliostyle Pub がフォントを扱う仕組み
   INFO content/shinyu/index.md Vivliostyle.js における Web 標準 CSS サポートの大改善 (30 pages, 74%)
   INFO content/shinyu/index.md Vivliostyle.js における Web 標準 CSS サポートの大改善
   INFO content/atogaki.md 著者プロフィール (40 pages, 97%)
   INFO content/atogaki.md 著者プロフィール
   INFO Building PDF
   INFO Processing PDF
   SUCCESS Finished building tbf13-draft.pdf
   📕 Built successfully!
   ```
2. 単ファイルビルドで「INFO Building pages」が削除されていました。
   ```
   $ cat test.html
   <html></html>
   $ npx --yes @vivliostyle/cli@11.1.0 build test.html
   INFO Start building
   INFO Launching PDF build environment
   INFO Building PDF
   INFO Processing PDF
   SUCCESS Finished building output.pdf
   📗 Built successfully!
   ```
