### PR TITLE
fix: 日本語版Basicテンプレートのcustom.cssに欠落していたセクションを追加

### DIFF
--- a/.changeset/fix-basic-ja-custom-css.md
+++ b/.changeset/fix-basic-ja-custom-css.md
@@ -1,0 +1,5 @@
+---
+"@vivliostyle/cli": patch
+---
+
+fix: 日本語版Basicテンプレートのcustom.cssに欠落していたセクションを追加

--- a/templates/basic-ja/custom.css
+++ b/templates/basic-ja/custom.css
@@ -97,4 +97,154 @@
    * 注: Prism.js CSS モジュールを追加でインクルードするか、
    * それを含むテーマを使用する必要があります（例: @vivliostyle/theme-techbook）
    * =================================== */
+
+  /* コードブロックのスタイル */
+  /* --vs-prism--background: #101842; */
+  /* --vs-prism--color: #eff4b8; */
+  /* --vs-prism--color-comment: #869db7; */
+  /* --vs-prism--block-code-padding: 0.5em 1.5em; */
+
+  /* ===================================
+   * 脚注
+   * =================================== */
+
+  /* 脚注参照マーカー */
+  /* --vs-footnote--call-content: "[" counter(footnote) "]"; */
+
+  /* 脚注テキストのサイズ */
+  /* --vs-footnote--call-font-size: 0.8em; */
+
+  /* 脚注エリアの余白 */
+  /* --vs-footnote--area-before-margin-inline: 2em; */
+
+  /* ===================================
+   * 目次
+   * =================================== */
+
+  /* 目次のインデント */
+  /* --vs-toc--indent-level-1: 0; */
+  /* --vs-toc--indent-level-2: 1em; */
+  /* --vs-toc--indent-level-3: 2em; */
+
+  /* 目次のページ番号スタイル */
+  /* --vs-toc--page-counter-style: roman; */
+  /* --vs-toc--page-leader-content: leader(' ✻ ') ' '; */
+
+  /* ===================================
+   * 章番号
+   * =================================== */
+
+  /* 見出しに章番号を表示 */
+  /* --vs-section--marker-display: inline; */
+
+  /* h2 見出しに章番号を表示 */
+  /* --vs-section--h2-marker-display: inline; */
+  /* --vs-section--h2-marker-content: counter(vs-counter-sec-h2) ". "; */
+
+  /* 章番号参照の書式 */
+  /* --vs-section--call-content: '†' target-counters(attr(href), vs-counter-sections,'.', decimal); */
+
+  /* ===================================
+   * 相互参照
+   * =================================== */
+
+  /* 図表番号参照の書式 */
+  /* --vs-crossref--counter-style: decimal; */
+  /* --vs-crossref--marker-cite-content: "[" target-counter(attr(href), citation) "]"; */
+
+  /* ===================================
+   * 表
+   * =================================== */
+
+  /* 表の罫線 */
+  /* --vs--table-border-width-column: 2px; */
+  /* --vs--table-border-color: #cccccc; */
+
+  /* セルの余白 */
+  /* --vs--table-cell-padding-block: 1em; */
+
+  /* ===================================
+   * 引用
+   * =================================== */
+
+  /* --vs--blockquote-font-size: 0.95em; */
+  /* --vs--blockquote-margin-inline: 2em 0; */
+
+  /* ===================================
+   * リスト
+   * =================================== */
+
+  /* --vs--ul-list-style-type: "▶︎"; */
+  /* --vs--ul-minimum-inline-indent-size: 3rem; */
+  /* --vs--ol-list-style-type: lower-roman; */
+  /* --vs--ol-padding-inline-start: 2.5em; */
+
+  /* ===================================
+   * 段組みレイアウト
+   * =================================== */
+  /* column-count: 2; */
+  /* column-gap: 2em; */
+  /* column-rule: 1px solid var(--vs-border-color); */
 }
+
+/* ===================================
+ * カスタムページレイアウト
+ * =================================== */
+
+/* ヘッダーなしの最初のページ */
+
+/* @page :first {
+  @top-left { content: none; }
+  @top-right { content: none; }
+} */
+
+/* 左右ページで異なるレイアウトを指定 */
+
+/* @page :left {
+  --vs-page--mbox-content-bottom-left: counter(page);
+}
+
+@page :right {
+  --vs-page--mbox-content-bottom-right: counter(page);
+} */
+
+/* ===================================
+ * カスタム要素スタイル
+ * =================================== */
+
+/* 例: 最初の段落を強調表示 */
+
+/* p:first-of-type {
+  font-style: italic;
+  font-size: 1.1em;
+  font-weight: 500;
+} */
+
+/* 例: 表紙ページのスタイル */
+/*
+.cover {
+  text-align: center;
+  page-break-after: always;
+}
+
+.cover h1 {
+  font-size: 3rem;
+  margin-top: 5em;
+}
+*/
+
+/* 例: カスタムコンテナのスタイル */
+
+/* .note {
+  padding: 1em;
+  margin-block: var(--vs-spacing-rlh);
+  border-left: 4px solid #4a90e2;
+  background-color: #f0f8ff;
+}
+
+.warning {
+  padding: 1em;
+  margin-block: var(--vs-spacing-rlh);
+  border-left: 4px solid #e24a4a;
+  background-color: #fff0f0;
+} */

--- a/tests/__snapshots__/create.test.ts.snap
+++ b/tests/__snapshots__/create.test.ts.snap
@@ -247,7 +247,157 @@ Object {
    * 注: Prism.js CSS モジュールを追加でインクルードするか、
    * それを含むテーマを使用する必要があります（例: @vivliostyle/theme-techbook）
    * =================================== */
+
+  /* コードブロックのスタイル */
+  /* --vs-prism--background: #101842; */
+  /* --vs-prism--color: #eff4b8; */
+  /* --vs-prism--color-comment: #869db7; */
+  /* --vs-prism--block-code-padding: 0.5em 1.5em; */
+
+  /* ===================================
+   * 脚注
+   * =================================== */
+
+  /* 脚注参照マーカー */
+  /* --vs-footnote--call-content: \\"[\\" counter(footnote) \\"]\\"; */
+
+  /* 脚注テキストのサイズ */
+  /* --vs-footnote--call-font-size: 0.8em; */
+
+  /* 脚注エリアの余白 */
+  /* --vs-footnote--area-before-margin-inline: 2em; */
+
+  /* ===================================
+   * 目次
+   * =================================== */
+
+  /* 目次のインデント */
+  /* --vs-toc--indent-level-1: 0; */
+  /* --vs-toc--indent-level-2: 1em; */
+  /* --vs-toc--indent-level-3: 2em; */
+
+  /* 目次のページ番号スタイル */
+  /* --vs-toc--page-counter-style: roman; */
+  /* --vs-toc--page-leader-content: leader(' ✻ ') ' '; */
+
+  /* ===================================
+   * 章番号
+   * =================================== */
+
+  /* 見出しに章番号を表示 */
+  /* --vs-section--marker-display: inline; */
+
+  /* h2 見出しに章番号を表示 */
+  /* --vs-section--h2-marker-display: inline; */
+  /* --vs-section--h2-marker-content: counter(vs-counter-sec-h2) \\". \\"; */
+
+  /* 章番号参照の書式 */
+  /* --vs-section--call-content: '†' target-counters(attr(href), vs-counter-sections,'.', decimal); */
+
+  /* ===================================
+   * 相互参照
+   * =================================== */
+
+  /* 図表番号参照の書式 */
+  /* --vs-crossref--counter-style: decimal; */
+  /* --vs-crossref--marker-cite-content: \\"[\\" target-counter(attr(href), citation) \\"]\\"; */
+
+  /* ===================================
+   * 表
+   * =================================== */
+
+  /* 表の罫線 */
+  /* --vs--table-border-width-column: 2px; */
+  /* --vs--table-border-color: #cccccc; */
+
+  /* セルの余白 */
+  /* --vs--table-cell-padding-block: 1em; */
+
+  /* ===================================
+   * 引用
+   * =================================== */
+
+  /* --vs--blockquote-font-size: 0.95em; */
+  /* --vs--blockquote-margin-inline: 2em 0; */
+
+  /* ===================================
+   * リスト
+   * =================================== */
+
+  /* --vs--ul-list-style-type: \\"▶︎\\"; */
+  /* --vs--ul-minimum-inline-indent-size: 3rem; */
+  /* --vs--ol-list-style-type: lower-roman; */
+  /* --vs--ol-padding-inline-start: 2.5em; */
+
+  /* ===================================
+   * 段組みレイアウト
+   * =================================== */
+  /* column-count: 2; */
+  /* column-gap: 2em; */
+  /* column-rule: 1px solid var(--vs-border-color); */
 }
+
+/* ===================================
+ * カスタムページレイアウト
+ * =================================== */
+
+/* ヘッダーなしの最初のページ */
+
+/* @page :first {
+  @top-left { content: none; }
+  @top-right { content: none; }
+} */
+
+/* 左右ページで異なるレイアウトを指定 */
+
+/* @page :left {
+  --vs-page--mbox-content-bottom-left: counter(page);
+}
+
+@page :right {
+  --vs-page--mbox-content-bottom-right: counter(page);
+} */
+
+/* ===================================
+ * カスタム要素スタイル
+ * =================================== */
+
+/* 例: 最初の段落を強調表示 */
+
+/* p:first-of-type {
+  font-style: italic;
+  font-size: 1.1em;
+  font-weight: 500;
+} */
+
+/* 例: 表紙ページのスタイル */
+/*
+.cover {
+  text-align: center;
+  page-break-after: always;
+}
+
+.cover h1 {
+  font-size: 3rem;
+  margin-top: 5em;
+}
+*/
+
+/* 例: カスタムコンテナのスタイル */
+
+/* .note {
+  padding: 1em;
+  margin-block: var(--vs-spacing-rlh);
+  border-left: 4px solid #4a90e2;
+  background-color: #f0f8ff;
+}
+
+.warning {
+  padding: 1em;
+  margin-block: var(--vs-spacing-rlh);
+  border-left: 4px solid #e24a4a;
+  background-color: #fff0f0;
+} */
 ",
   "/work/project-name/draft/01_cover.md": "---
 class: cover-page


### PR DESCRIPTION
## Summary

- `templates/basic-ja/custom.css`(日本語版)が `templates/basic/custom.css`(英語版、250行)に対して100行しかなく、後半のセクション(Footnotes 〜 Custom Element Styles)がまるごと欠落していた
- 英語版の内容に合わせて日本語訳を追記し、行数・構造を英語版と一致させた
- `pnpm create` で `basic-ja` テンプレートを生成した際の出力を検証するスナップショットテスト(`tests/create.test.ts`)を更新

Fixes #862

## Test plan

- [x] `pnpm lint`
- [x] `pnpm build:cli`
- [x] `pnpm vitest run tests/create.test.ts`(スナップショット更新後、pass)
- [x] `pnpm test`(pre-push hookで全体実行、pass)
- [x] `templates/basic-ja/custom.css` と `templates/basic/custom.css` の行数・構造(コメント以外)が一致することを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)