### PR TITLE
chore(deps): Update yocto-spinner to 1.2.2

### DIFF
--- a/.changeset/vast-animals-bake.md
+++ b/.changeset/vast-animals-bake.md
@@ -1,0 +1,5 @@
+---
+"@vivliostyle/cli": patch
+---
+
+Update yocto-spinner to 1.2.2

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "vite": "8.1.0",
     "w3c-xmlserializer": "5.0.0",
     "whatwg-mimetype": "4.0.0",
-    "yocto-spinner": "1.2.1",
+    "yocto-spinner": "1.2.2",
     "yoctocolors": "2.1.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -177,8 +177,8 @@ importers:
         specifier: 4.0.0
         version: 4.0.0
       yocto-spinner:
-        specifier: 1.2.1
-        version: 1.2.1
+        specifier: 1.2.2
+        version: 1.2.2
       yoctocolors:
         specifier: 2.1.1
         version: 2.1.1
@@ -7067,8 +7067,8 @@ packages:
     resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
     engines: {node: '>=12.20'}
 
-  yocto-spinner@1.2.1:
-    resolution: {integrity: sha512-9cbFWLhbiZp+820O4pkHGNncI7+MrUGzBOjw8NMG+ewsY+aG0DdEXnr19Smxao32YOjLZRMdn1UtaxcrXOYOIg==}
+  yocto-spinner@1.2.2:
+    resolution: {integrity: sha512-DODGl1wJjA/s5pnJFKau9lIYHT81lnhob1i3e1TjxZRxEhWRKl74nTbWE6H5KlkViQQTo/Z29YFdxzTZAMY3ng==}
     engines: {node: '>=18.19'}
 
   yoctocolors@2.1.1:
@@ -7329,7 +7329,7 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
-      js-yaml: 4.1.1
+      js-yaml: 4.3.0
       picomatch: 4.0.4
       retext-smartypants: 6.2.0
       shiki: 4.2.0
@@ -14276,7 +14276,7 @@ snapshots:
 
   yocto-queue@1.2.2: {}
 
-  yocto-spinner@1.2.1:
+  yocto-spinner@1.2.2:
     dependencies:
       yoctocolors: 2.1.1
 


### PR DESCRIPTION
see sindresorhus/yocto-spinner#19

Claude CodeのBashツールなど非TTYコンテキストで`script`コマンドを用いて子プロセスにTTYをアタッチすると幅0で割り当てられるのですが、その際に発生する不具合を解消したものです。ログ表示が不正な場合のエスケープシーケンスの調査などに役立ちます。