### PR TITLE
fix: Load config files without a local `@vivliostyle/cli` install

### DIFF
--- a/.changeset/proud-configs-resolve.md
+++ b/.changeset/proud-configs-resolve.md
@@ -1,0 +1,5 @@
+---
+"@vivliostyle/cli": patch
+---
+
+Load config files importing `@vivliostyle/cli` even when the package is not installed in the user's project (e.g. when the CLI is invoked via a global install or npx), by resolving such imports to the running CLI package itself.

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -1,5 +1,5 @@
 import fs from 'node:fs';
-import { createRequire } from 'node:module';
+import { createRequire, registerHooks } from 'node:module';
 import { pathToFileURL } from 'node:url';
 
 import terminalLink from 'terminal-link';
@@ -9,10 +9,12 @@ import { cyan, underline } from 'yoctocolors';
 
 import { Logger } from '../logger.js';
 import {
+  cliRoot,
   cwd as defaultRoot,
   DetailError,
   parseJsonc,
   prettifySchemaError,
+  readPackageJson,
   toError,
 } from '../util.js';
 import {
@@ -22,6 +24,49 @@ import {
 } from './schema.js';
 
 const require = createRequire(import.meta.url);
+
+let importFallbackRegistered = false;
+
+// Config files import `@vivliostyle/cli` to use `defineConfig`, but the
+// package may not be installed in the user's project (e.g. when the CLI is
+// invoked via a global install or npx). Resolve such imports to the running
+// CLI package itself so that loading the config file does not fail.
+// `registerHooks` requires Node.js >= 22.15; on older versions the import
+// fails as before.
+function registerConfigImportFallback(): void {
+  if (importFallbackRegistered || typeof registerHooks !== 'function') {
+    return;
+  }
+  importFallbackRegistered = true;
+  const selfPackageName = readPackageJson(
+    upath.join(cliRoot, 'package.json'),
+  ).name;
+  if (!selfPackageName) {
+    return;
+  }
+  registerHooks({
+    resolve(specifier, context, nextResolve) {
+      if (
+        specifier !== selfPackageName &&
+        !specifier.startsWith(`${selfPackageName}/`)
+      ) {
+        return nextResolve(specifier, context);
+      }
+      try {
+        return nextResolve(specifier, context);
+      } catch (error) {
+        try {
+          return nextResolve(specifier, {
+            ...context,
+            parentURL: import.meta.url,
+          });
+        } catch {
+          throw error;
+        }
+      }
+    },
+  });
+}
 
 export function locateVivliostyleConfig({
   config,
@@ -58,6 +103,7 @@ export async function loadVivliostyleConfig({
       jsonRaw = fs.readFileSync(absPath, 'utf8');
       parsedConfig = parseJsonc(jsonRaw);
     } else {
+      registerConfigImportFallback();
       // Clear require cache to reload CJS config files
       Reflect.deleteProperty(require.cache, require.resolve(absPath));
       const url = pathToFileURL(absPath);

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -1,5 +1,5 @@
 import fs from 'node:fs';
-import { createRequire, registerHooks } from 'node:module';
+import { createRequire } from 'node:module';
 import { pathToFileURL } from 'node:url';
 
 import terminalLink from 'terminal-link';
@@ -34,7 +34,11 @@ let importFallbackRegistered = false;
 // `registerHooks` requires Node.js >= 22.15; on older versions the import
 // fails as before.
 function registerConfigImportFallback(): void {
-  if (importFallbackRegistered || typeof registerHooks !== 'function') {
+  if (importFallbackRegistered) {
+    return;
+  }
+  const { registerHooks } = process.getBuiltinModule('node:module');
+  if (typeof registerHooks !== 'function') {
     return;
   }
   importFallbackRegistered = true;

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -59,6 +59,11 @@ function registerConfigImportFallback(): void {
       try {
         return nextResolve(specifier, context);
       } catch (error) {
+        // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- inspect the Node.js error code on the caught value
+        const code = (error as NodeJS.ErrnoException).code;
+        if (code !== 'ERR_MODULE_NOT_FOUND' && code !== 'MODULE_NOT_FOUND') {
+          throw error;
+        }
         try {
           return nextResolve(specifier, {
             ...context,

--- a/tests/config-import-fallback.test.ts
+++ b/tests/config-import-fallback.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+
+import { loadVivliostyleConfig } from '../src/config/load.js';
+import { resolveFixture } from './command-util.js';
+
+describe('config files importing @vivliostyle/cli without local installation', () => {
+  it('falls back to the running CLI package', async () => {
+    const config = await loadVivliostyleConfig({
+      cwd: resolveFixture('config-import-fallback'),
+    });
+    expect(config?.tasks[0].title).toBe('Import Fallback');
+  });
+});

--- a/tests/fixtures/config-import-fallback/package.json
+++ b/tests/fixtures/config-import-fallback/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "config-import-fallback",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/tests/fixtures/config-import-fallback/vivliostyle.config.js
+++ b/tests/fixtures/config-import-fallback/vivliostyle.config.js
@@ -1,0 +1,7 @@
+// @ts-check
+import { defineConfig } from '@vivliostyle/cli';
+
+export default defineConfig({
+  title: 'Import Fallback',
+  entry: ['manuscript.md'],
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,13 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     include: ['**/src/__tests__/*.+(ts|tsx|js)', '**/tests/*.test.(ts|tsx|js)'],
+    server: {
+      deps: {
+        // Load this fixture with the native Node.js resolver rather than
+        // Vite's module runner to test the module resolution fallback
+        external: [/fixtures\/config-import-fallback/v],
+      },
+    },
     coverage: {
       provider: 'v8',
       include: ['schemas/**', 'src/**'],


### PR DESCRIPTION
Config files created by templates import `@vivliostyle/cli` to use `defineConfig`, which fails with `ERR_MODULE_NOT_FOUND` when the package is not installed in the user's project (e.g. when the CLI is invoked via a global install or npx). This PR makes the CLI resolve such imports to the running CLI package itself, without changing the config file structure.

- Register a `node:module` `registerHooks` resolve hook just before importing a config file: normal resolution is tried first (a locally installed package always wins), and only on failure is the specifier re-resolved against the running CLI via package self-reference
- Read the package name from the CLI's own package.json instead of hardcoding it
- Works for `.js`/`.ts` config files and subpath imports; on Node.js < 22.15 (no `registerHooks`) the behavior is unchanged
- Add a test with a fixture that has no local `@vivliostyle/cli`; the fixture is externalized in the Vitest config so the config import goes through the native Node.js resolver instead of Vite's module runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YQZ5haQGt3GQ9quSRjuTVx