### PR TITLE
fix: Add `<!DOCTYPE html>` to generated TOC files

### DIFF
--- a/.changeset/happy-poets-hug.md
+++ b/.changeset/happy-poets-hug.md
@@ -2,4 +2,4 @@
 "@vivliostyle/cli": patch
 ---
 
-Add `<!DOCTYPE html>` to generated TOC files
+Add `<!DOCTYPE html>` to the generated table of contents and cover documents

--- a/.changeset/happy-poets-hug.md
+++ b/.changeset/happy-poets-hug.md
@@ -1,0 +1,5 @@
+---
+"@vivliostyle/cli": patch
+---
+
+Add `<!DOCTYPE html>` to generated TOC files

--- a/src/processor/html.tsx
+++ b/src/processor/html.tsx
@@ -385,7 +385,7 @@ export function generateDefaultTocHtml({
       </body>
     </html>
   );
-  return toHtml(toc);
+  return `<!DOCTYPE html>\n${toHtml(toc)}`;
 }
 
 export async function generateTocListSection({

--- a/src/processor/html.tsx
+++ b/src/processor/html.tsx
@@ -7,6 +7,7 @@ import jsdom, {
   JSDOM,
 } from '@vivliostyle/jsdom';
 import DOMPurify, { type WindowLike } from 'dompurify';
+import type { RootContent } from 'hast';
 import { toHtml } from 'hast-util-to-html';
 import upath from 'upath';
 import MIMEType from 'whatwg-mimetype';
@@ -372,6 +373,7 @@ export function generateDefaultTocHtml({
   language?: string;
   title?: string;
 }): string {
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
   const toc = (
     <html lang={language}>
       <head>
@@ -384,8 +386,8 @@ export function generateDefaultTocHtml({
         <nav id="toc" role="doc-toc" />
       </body>
     </html>
-  );
-  return `<!DOCTYPE html>\n${toHtml(toc)}`;
+  ) as RootContent;
+  return toHtml([{ type: 'doctype' }, toc], { upperDoctype: true });
 }
 
 export async function generateTocListSection({
@@ -536,6 +538,7 @@ export function generateDefaultCoverHtml({
   language?: string;
   title?: string;
 }): string {
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
   const toc = (
     <html lang={language}>
       <head>
@@ -549,8 +552,8 @@ export function generateDefaultCoverHtml({
         </section>
       </body>
     </html>
-  );
-  return toHtml(toc);
+  ) as RootContent;
+  return toHtml([{ type: 'doctype' }, toc], { upperDoctype: true });
 }
 
 // oxlint-disable-next-line require-await -- Keep the Promise return type for the await-based call sites

--- a/tests/__snapshots__/cover.test.ts.snap
+++ b/tests/__snapshots__/cover.test.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`generateCoverHtml > cover.html 1`] = `
-"<!doctype html>
+"<!DOCTYPE html>
 <html lang=\\"ja\\"
   ><head
     ><meta charset=\\"utf-8\\" /><title>Book title</title

--- a/tests/__snapshots__/cover.test.ts.snap
+++ b/tests/__snapshots__/cover.test.ts.snap
@@ -1,7 +1,8 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`generateCoverHtml > cover.html 1`] = `
-"<html lang=\\"ja\\"
+"<!doctype html>
+<html lang=\\"ja\\"
   ><head
     ><meta charset=\\"utf-8\\" /><title>Book title</title
     ><style data-vv-style=\\"\\">

--- a/tests/__snapshots__/epub.test.ts.snap
+++ b/tests/__snapshots__/epub.test.ts.snap
@@ -285,6 +285,7 @@ exports[`generate EPUB from vivliostyle.config.js > content.opf 1`] = `
 
 exports[`generate EPUB from vivliostyle.config.js > cover document%.xhtml 1`] = `
 "<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
+<!doctype html>
 <html
   xmlns=\\"http://www.w3.org/1999/xhtml\\"
   xmlns:epub=\\"http://www.idpf.org/2007/ops\\"

--- a/tests/__snapshots__/epub.test.ts.snap
+++ b/tests/__snapshots__/epub.test.ts.snap
@@ -285,7 +285,7 @@ exports[`generate EPUB from vivliostyle.config.js > content.opf 1`] = `
 
 exports[`generate EPUB from vivliostyle.config.js > cover document%.xhtml 1`] = `
 "<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
-<!doctype html>
+<!DOCTYPE html>
 <html
   xmlns=\\"http://www.w3.org/1999/xhtml\\"
   xmlns:epub=\\"http://www.idpf.org/2007/ops\\"
@@ -317,7 +317,7 @@ exports[`generate EPUB from vivliostyle.config.js > cover document%.xhtml 1`] = 
 
 exports[`generate EPUB from vivliostyle.config.js > index file%.xhtml 1`] = `
 "<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
-<!doctype html>
+<!DOCTYPE html>
 <html
   xmlns=\\"http://www.w3.org/1999/xhtml\\"
   xmlns:epub=\\"http://www.idpf.org/2007/ops\\"

--- a/tests/__snapshots__/epub.test.ts.snap
+++ b/tests/__snapshots__/epub.test.ts.snap
@@ -316,6 +316,7 @@ exports[`generate EPUB from vivliostyle.config.js > cover document%.xhtml 1`] = 
 
 exports[`generate EPUB from vivliostyle.config.js > index file%.xhtml 1`] = `
 "<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
+<!doctype html>
 <html
   xmlns=\\"http://www.w3.org/1999/xhtml\\"
   xmlns:epub=\\"http://www.idpf.org/2007/ops\\"

--- a/tests/__snapshots__/toc.test.ts.snap
+++ b/tests/__snapshots__/toc.test.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`generates ToC html > toc.html 1`] = `
-"<!doctype html>
+"<!DOCTYPE html>
 <html lang=\\"ja\\"
   ><head
     ><meta charset=\\"utf-8\\" /><title>Book title</title

--- a/tests/__snapshots__/toc.test.ts.snap
+++ b/tests/__snapshots__/toc.test.ts.snap
@@ -1,7 +1,8 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`generates ToC html > toc.html 1`] = `
-"<html lang=\\"ja\\"
+"<!doctype html>
+<html lang=\\"ja\\"
   ><head
     ><meta charset=\\"utf-8\\" /><title>Book title</title
     ><style data-vv-style=\\"\\">

--- a/tests/__snapshots__/webbook.test.ts.snap
+++ b/tests/__snapshots__/webbook.test.ts.snap
@@ -14,7 +14,7 @@ exports[`copy webpub assets properly 1`] = `
 `;
 
 exports[`generate webpub from a data URI input > html 1`] = `
-"<!doctype html>
+"<!DOCTYPE html>
 <html lang=\\"en\\"
   ><head
     ><meta charset=\\"UTF-8\\" /><title></title
@@ -36,7 +36,7 @@ exports[`generate webpub from a data URI input > tree 1`] = `
 `;
 
 exports[`generate webpub from a plain HTML > entry 1`] = `
-"<!doctype html>
+"<!DOCTYPE html>
 <html lang=\\"ja\\"
   ><head>
     <link rel=\\"stylesheet\\" type=\\"text/css\\" href=\\"style.css\\" />

--- a/tests/command-util.ts
+++ b/tests/command-util.ts
@@ -31,7 +31,10 @@ export const formatHtml = async (content: string): Promise<string> => {
     printWidth: 80,
     htmlWhitespaceSensitivity: 'strict',
   });
-  return code;
+  // oxfmt lowercases the doctype; keep the original casing so snapshots
+  // reflect the actual output (XHTML requires an uppercase `<!DOCTYPE`).
+  const doctype = content.match(/<!doctype\b[^>]*>/iv)?.[0];
+  return doctype ? code.replace(/<!doctype\b[^>]*>/iv, doctype) : code;
 };
 
 const runningServers = new Set<ViteDevServer>();

--- a/tests/fixtures/cmyk/blend-mode.html
+++ b/tests/fixtures/cmyk/blend-mode.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
   <head>
     <title>Test</title>

--- a/tests/fixtures/toc/manuscript/section.html
+++ b/tests/fixtures/toc/manuscript/section.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <title>Section Example</title>

--- a/tests/toc.test.ts
+++ b/tests/toc.test.ts
@@ -214,7 +214,7 @@ it('customize ToC document', async () => {
 });
 
 describe('sectionized document', () => {
-  const sectionHtml = `<!doctype html>
+  const sectionHtml = `<!DOCTYPE html>
 <html lang="en">
   <head>
     <title>Section Example</title>

--- a/tests/toc.test.ts
+++ b/tests/toc.test.ts
@@ -34,6 +34,7 @@ it('generates ToC html', async () => {
   assert(isWebPubConfig(config));
   const content = await transformManuscript(config.entries[0], config);
   assert(content);
+  expect(content).toMatch(/^<!DOCTYPE html>/v);
   expect(await formatHtml(content)).toMatchSnapshot('toc.html');
 });
 


### PR DESCRIPTION
fix #872