### PR TITLE
fix: Preserve HTML inputs with custom document processors

### DIFF
--- a/.changeset/calm-pages-remain.md
+++ b/.changeset/calm-pages-remain.md
@@ -1,0 +1,5 @@
+---
+"@vivliostyle/cli": patch
+---
+
+Preserve HTML and XHTML documents as native manuscript inputs when a root-level custom document processor is configured.

--- a/src/config/resolve.ts
+++ b/src/config/resolve.ts
@@ -1374,11 +1374,7 @@ function resolveComposedProjectConfig({
       const contentType = needsCustomContentType
         ? 'text/x-vivliostyle-custom'
         : rawContentType;
-      if (
-        !isManuscriptMediaType(contentType) ||
-        // disallow text/plain (for now)
-        contentType === 'text/plain'
-      ) {
+      if (!isManuscriptMediaType(contentType) || contentType === 'text/plain') {
         throw new Error(
           `Invalid manuscript type ${rawContentType} detected: ${entryPath}`,
         );

--- a/src/config/resolve.ts
+++ b/src/config/resolve.ts
@@ -1366,10 +1366,14 @@ function resolveComposedProjectConfig({
       const hasCustomProcessor =
         documentProcessor.processorFactory !== VFM ||
         documentProcessor.metadataReader !== readMetadata;
-      const contentType =
-        hasCustomProcessor && rawContentType !== 'text/markdown'
-          ? 'text/x-vivliostyle-custom'
-          : rawContentType;
+      const needsCustomContentType =
+        hasCustomProcessor &&
+        rawContentType !== 'text/markdown' &&
+        rawContentType !== 'text/html' &&
+        rawContentType !== 'application/xhtml+xml';
+      const contentType = needsCustomContentType
+        ? 'text/x-vivliostyle-custom'
+        : rawContentType;
       if (
         !isManuscriptMediaType(contentType) ||
         // disallow text/plain (for now)

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -512,6 +512,23 @@ it('allows non-markdown extensions when documentProcessor is provided', async ()
   expect(xyzEntry?.title).toBe('Custom Format Title');
 });
 
+it('preserves HTML processing when a root documentProcessor is provided', async () => {
+  const customProcessor = () => {
+    throw new Error('should not be called for HTML');
+  };
+
+  const config = await getTaskConfig(['build'], resolveFixture('config'), {
+    entry: ['sample.html'],
+    documentProcessor: customProcessor,
+  });
+
+  const htmlEntry = findFileEntry(config.entries, 'sample.html');
+  expect(htmlEntry).toBeDefined();
+  expect((htmlEntry as any).source.contentType).toBe('text/html');
+  expect((htmlEntry as any).source.documentProcessor).toBeUndefined();
+  expect(htmlEntry?.title).toBe('Miyako');
+});
+
 it('rejects text/plain files without documentProcessor', async () => {
   // .txt files are recognized as text/plain, which requires documentProcessor
   await expect(

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -529,6 +529,23 @@ it('preserves HTML processing when a root documentProcessor is provided', async 
   expect(htmlEntry?.title).toBe('Miyako');
 });
 
+it('preserves XHTML processing when a root documentProcessor is provided', async () => {
+  const customProcessor = () => {
+    throw new Error('should not be called for XHTML');
+  };
+
+  const config = await getTaskConfig(['build'], resolveFixture('config'), {
+    entry: ['sample.xhtml'],
+    documentProcessor: customProcessor,
+  });
+
+  const xhtmlEntry = findFileEntry(config.entries, 'sample.xhtml');
+  expect(xhtmlEntry).toBeDefined();
+  expect((xhtmlEntry as any).source.contentType).toBe('application/xhtml+xml');
+  expect((xhtmlEntry as any).source.documentProcessor).toBeUndefined();
+  expect(xhtmlEntry?.title).toBe('Sample XHTML');
+});
+
 it('rejects text/plain files without documentProcessor', async () => {
   // .txt files are recognized as text/plain, which requires documentProcessor
   await expect(

--- a/tests/fixtures/config/sample.xhtml
+++ b/tests/fixtures/config/sample.xhtml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+  <head>
+    <title>Sample XHTML</title>
+  </head>
+  <body></body>
+</html>


### PR DESCRIPTION
#680 で作り込んだバグで、configのルートで共通のカスタム`documentProcessor`を定義したとき、HTMLエントリがカスタム原稿扱いになって`documentProcessor`を通ってしまうようになっていました。