### PR TITLE
feat: Add TOC compose option

### DIFF
--- a/.changeset/fuzzy-dodos-build.md
+++ b/.changeset/fuzzy-dodos-build.md
@@ -1,0 +1,5 @@
+---
+'@vivliostyle/cli': minor
+---
+
+Add `toc.compose` to customize the contents of the table of contents navigation element.

--- a/docs/api-javascript.md
+++ b/docs/api-javascript.md
@@ -22,6 +22,7 @@
 - [`Metadata`](#metadata)
 - [`StructuredDocument`](#structureddocument)
 - [`StructuredDocumentSection`](#structureddocumentsection)
+- [`TocCompose`](#toccompose)
 - [`VivliostyleConfigSchema`](#vivliostyleconfigschema)
 - [`VivliostylePackageMetadata`](#vivliostylepackagemetadata)
 - [`VivliostylePackageMetadata`](#vivliostylepackagemetadata)
@@ -1293,6 +1294,30 @@ https://github.com/vivliostyle/vivliostyle-cli/blob/main/docs/config.md
 ##### level
 
 > **level**: `number`
+
+***
+
+### TocCompose
+
+> **TocCompose** = (`{ h }`) => (`{
+  heading,
+  content,
+}`) => `ElementContent`[]
+
+#### Parameters
+
+##### \{ h \}
+
+###### h
+
+`h`
+
+#### Returns
+
+(`{
+  heading,
+  content,
+}`) => `ElementContent`[]
 
 ***
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -538,7 +538,10 @@ type CopyAssetConfig = {
 - `TocConfig`
 
   - `title`: string  
-    Title of the generated ToC document.
+    Title used for the generated ToC heading and publication manifest entry.
+
+  - `compose`: ({ h }: { h: typeof import("hastscript").h }) => ({ heading, content }: { heading: import("hast").Element & { tagName: "h2"; children: [import("hast").Text] }; content: import("hast").Element }) => import("hast").ElementContent[]  
+    Function to compose the contents of the ToC navigation element.
 
   - `htmlPath`: string  
     Location where the generated ToC document will be saved. (default: `index.html`)
@@ -557,6 +560,20 @@ type CopyAssetConfig = {
 ```ts
 type TocConfig = {
   title?: string;
+  compose?: ({
+    h,
+  }: {
+    h: typeof import("hastscript").h;
+  }) => ({
+    heading,
+    content,
+  }: {
+    heading: import("hast").Element & {
+      tagName: "h2";
+      children: [import("hast").Text];
+    };
+    content: import("hast").Element;
+  }) => import("hast").ElementContent[];
   htmlPath?: string;
   sectionDepth?: number;
   transformDocumentList?: (

--- a/examples/table-of-contents/README.md
+++ b/examples/table-of-contents/README.md
@@ -4,7 +4,8 @@
 
 With the `toc` option, we can generate a file with a table of contents. The `toc` option can be a string, boolean or an object with the following properties.
 
-- `title`: Specify the title of the generated ToC document. (default: Table of Contents)
+- `title`: Specify the title used for the generated ToC heading and publication manifest entry. (default: Table of Contents)
+- `compose`: Specify a function to compose the contents of the ToC navigation element.
 - `htmlPath`: Specify the location where the generated ToC document will be saved. (default: index.html)
 - `sectionDepth`: Specify the depth of the section to be included in the ToC document. (default: 0)
 - `transformDocumentList`, `transformSectionList`: Specify the transform function to be used when generating the ToC document.

--- a/src/config/resolve.ts
+++ b/src/config/resolve.ts
@@ -25,6 +25,7 @@ import type {
   StructuredDocument,
   StructuredDocumentSection,
   ThemeConfig,
+  TocCompose,
 } from '../config/schema.js';
 import {
   CONTAINER_LOCAL_HOSTNAME,
@@ -127,6 +128,7 @@ export interface ContentsEntry {
   template?: EntrySource;
   target: string;
   tocTitle: string;
+  compose?: TocCompose;
   sectionDepth: number;
   transform: {
     transformDocumentList:
@@ -1288,6 +1290,9 @@ function resolveComposedProjectConfig({
   const tocConfig = {
     // oxlint-disable-next-line typescript/no-deprecated
     tocTitle: config.toc?.title ?? config?.tocTitle ?? TOC_TITLE,
+    ...(config.toc?.compose && {
+      compose: config.toc.compose,
+    }),
     target: upath.resolve(workspaceDir, config.toc?.htmlPath ?? TOC_FILENAME),
     sectionDepth: config.toc?.sectionDepth ?? 0,
     transform: {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -72,6 +72,16 @@ type HastElement = import('hast').ElementContent | import('hast').Root;
 export type HastTransformFunction<T> = (
   nodeList: T[],
 ) => (propsList: { children: HastElement | HastElement[] }[]) => HastElement;
+export type TocCompose = ({ h }: { h: typeof import('hastscript').h }) => ({
+  heading,
+  content,
+}: {
+  heading: import('hast').Element & {
+    tagName: 'h2';
+    children: [import('hast').Text];
+  };
+  content: import('hast').Element;
+}) => import('hast').ElementContent[];
 
 export const ValidString = v.pipe(
   v.string(),
@@ -523,7 +533,17 @@ export const TocConfig = v.pipe(
       title: v.pipe(
         ValidString,
         v.description($`
-          Title of the generated ToC document.
+          Title used for the generated ToC heading and publication manifest entry.
+        `),
+      ),
+      compose: v.pipe(
+        v.custom<TocCompose>((input) => typeof input === 'function'),
+        v.metadata({
+          typeString:
+            '({ h }: { h: typeof import("hastscript").h }) => ({ heading, content }: { heading: import("hast").Element & { tagName: "h2"; children: [import("hast").Text] }; content: import("hast").Element }) => import("hast").ElementContent[]',
+        }),
+        v.description($`
+          Function to compose the contents of the ToC navigation element.
         `),
       ),
       htmlPath: v.pipe(

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ export { defineConfig } from './config/define.js';
 export type {
   StructuredDocument,
   StructuredDocumentSection,
+  TocCompose,
   VivliostyleConfigSchema,
   VivliostylePackageMetadata,
 } from './config/schema.js';

--- a/src/processor/compile.ts
+++ b/src/processor/compile.ts
@@ -302,6 +302,7 @@ export async function transformManuscript(
       manifestPath,
       distDir: upath.dirname(contentsEntry.target),
       tocTitle: contentsEntry.tocTitle,
+      compose: contentsEntry.compose,
       sectionDepth: contentsEntry.sectionDepth,
       styleOptions: contentsEntry,
       transform: contentsEntry.transform,

--- a/src/processor/html.tsx
+++ b/src/processor/html.tsx
@@ -9,6 +9,7 @@ import jsdom, {
 import DOMPurify, { type WindowLike } from 'dompurify';
 import type { RootContent } from 'hast';
 import { toHtml } from 'hast-util-to-html';
+import { h } from 'hastscript';
 import upath from 'upath';
 import MIMEType from 'whatwg-mimetype';
 
@@ -16,6 +17,7 @@ import type { ManuscriptEntry } from '../config/resolve.js';
 import type {
   StructuredDocument,
   StructuredDocumentSection,
+  TocCompose,
 } from '../config/schema.js';
 import { Logger } from '../logger.js';
 import { decodePublicationManifest } from '../output/webbook.js';
@@ -366,6 +368,10 @@ export const defaultTocTransform = {
     },
 };
 
+export const defaultTocCompose: TocCompose =
+  () =>
+  ({ heading, content }) => [heading, content];
+
 export function generateDefaultTocHtml({
   language,
   title,
@@ -390,7 +396,7 @@ export function generateDefaultTocHtml({
   return toHtml([{ type: 'doctype' }, toc], { upperDoctype: true });
 }
 
-export async function generateTocListSection({
+export async function generateTocListElement({
   entries,
   distDir,
   sectionDepth,
@@ -400,7 +406,7 @@ export async function generateTocListSection({
   distDir: string;
   sectionDepth: number;
   transform?: Partial<typeof defaultTocTransform>;
-}): Promise<string> {
+}): Promise<import('hast').Element> {
   const {
     transformDocumentList = defaultTocTransform.transformDocumentList,
     transformSectionList = defaultTocTransform.transformSectionList,
@@ -448,7 +454,8 @@ export async function generateTocListSection({
     }),
   );
 
-  return toHtml(docToc, { allowDangerousHtml: true });
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+  return docToc as import('hast').Element;
 }
 
 export async function processTocHtml(
@@ -461,9 +468,11 @@ export async function processTocHtml(
     distDir,
     sectionDepth,
     transform,
-  }: Parameters<typeof generateTocListSection>[0] & {
+    compose = defaultTocCompose,
+  }: Parameters<typeof generateTocListElement>[0] & {
     manifestPath: string;
     tocTitle: string;
+    compose?: TocCompose;
     styleOptions?: Parameters<typeof getTocHtmlStyle>[0];
   },
 ): Promise<JSDOM> {
@@ -492,15 +501,19 @@ export async function processTocHtml(
 
   const nav = document.querySelector('nav, [role="doc-toc"]');
   if (nav && !nav.hasChildNodes()) {
-    const h2 = document.createElement('h2');
-    h2.textContent = tocTitle;
-    nav.append(h2);
-    nav.innerHTML += await generateTocListSection({
-      entries,
-      distDir,
-      sectionDepth,
-      transform,
+    const composed = compose({ h })({
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+      heading: h('h2', tocTitle) as Parameters<
+        ReturnType<TocCompose>
+      >[0]['heading'],
+      content: await generateTocListElement({
+        entries,
+        distDir,
+        sectionDepth,
+        transform,
+      }),
     });
+    nav.innerHTML = toHtml(composed, { allowDangerousHtml: true });
   }
   return dom;
 }

--- a/tests/toc.test.ts
+++ b/tests/toc.test.ts
@@ -84,6 +84,79 @@ it('supports boolean toc config', async () => {
   expect(li.item(2).innerHTML).toBe('<a href="c.html">C</a>');
 });
 
+it('composes generated ToC navigation', async () => {
+  vol.fromJSON({
+    '/work/chapter.md': '# Chapter',
+  });
+  await runCommand(['build'], {
+    cwd: '/work',
+    config: {
+      title: 'Publication title',
+      entry: ['chapter.md'],
+      output: [],
+      toc: {
+        title: 'Contents',
+        compose:
+          ({ h }) =>
+          ({ heading, content }) => [
+            h(
+              'h1',
+              { ...heading.properties, id: 'toc-heading' },
+              ...heading.children,
+            ),
+            h('p', { className: ['toc-description'] }, 'Select a chapter'),
+            content,
+            h('p', { className: ['toc-note'] }, 'End of contents'),
+          ],
+      },
+    },
+  });
+
+  const workDir = vol.toJSON('/work/.vivliostyle', {}, true);
+  const document = new JSDOM(workDir['index.html']!).window.document;
+  const nav = document.querySelector('nav[role="doc-toc"]')!;
+  expect(nav.children[0].outerHTML).toBe('<h1 id="toc-heading">Contents</h1>');
+  expect(nav.children[1].outerHTML).toBe(
+    '<p class="toc-description">Select a chapter</p>',
+  );
+  expect(nav.children[2].tagName).toBe('OL');
+  expect(nav.children[3].outerHTML).toBe(
+    '<p class="toc-note">End of contents</p>',
+  );
+
+  const manifest = JSON.parse(workDir['publication.json']!);
+  expect(manifest.readingOrder[0].name).toBe('Contents');
+});
+
+it('omits generated ToC heading', async () => {
+  vol.fromJSON({
+    '/work/chapter.md': '# Chapter',
+  });
+  await runCommand(['build'], {
+    cwd: '/work',
+    config: {
+      title: 'Publication title',
+      entry: ['chapter.md'],
+      output: [],
+      toc: {
+        title: 'Contents',
+        compose:
+          () =>
+          ({ content }) => [content],
+      },
+    },
+  });
+
+  const workDir = vol.toJSON('/work/.vivliostyle', {}, true);
+  const document = new JSDOM(workDir['index.html']!).window.document;
+  const nav = document.querySelector('nav[role="doc-toc"]')!;
+  expect(nav.children).toHaveLength(1);
+  expect(nav.firstElementChild!.tagName).toBe('OL');
+
+  const manifest = JSON.parse(workDir['publication.json']!);
+  expect(manifest.readingOrder[0].name).toBe('Contents');
+});
+
 it('supports object toc config', async () => {
   vol.fromJSON({
     '/work/manuscript/a.md': '# A',


### PR DESCRIPTION
`toc`に、目次ナビゲーション要素`<nav role="doc-toc">`の内部を組み立てるオプション`compose: ({ h }) => ({ heading, content }) => hast.ElementContent[]`を追加するPRです。

`heading`は`toc.title`をテキストに持つ`h2`要素、`content`は`transformDocumentList`・`transformSectionList`適用後の目次リスト要素です。既定では`[heading, content]`を返し、従来と同一の出力になります。