### PR TITLE
chore: Unignore only the Claude skills the repository ships

### DIFF
--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -1,4 +1,0 @@
-*
-!.gitignore
-!skills
-!skills/**

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+/.claude/*
+!/.claude/skills/
+
 dist/
 tmp/
 *.pdf


### PR DESCRIPTION
#883 で追加されたgitignoreでは、skillsに個人用や一時的なスキルを置いたものがgitに追跡されてしまう問題がありました。これまではシステムグローバルのgitignoreで除去できていたのですが、追加されたgitignoreには勝てません。Vivliostyle CLI側で残したい`ai-policy-check`を明示的に追跡させるのがよりよいかと思います。