### PR TITLE
feat: Update Vivliostyle.js to 2.45.0: Support CSS Cascade Layers

### DIFF
--- a/.changeset/hot-toes-fly.md
+++ b/.changeset/hot-toes-fly.md
@@ -1,0 +1,5 @@
+---
+"@vivliostyle/cli": minor
+---
+
+Update Vivliostyle.js to 2.45.0: Support CSS Cascade Layers

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@types/command-exists": "1.2.3",
     "@vivliostyle/jsdom": "25.0.1-vivliostyle-cli.2",
     "@vivliostyle/vfm": "2.7.2",
-    "@vivliostyle/viewer": "2.44.1",
+    "@vivliostyle/viewer": "2.45.0",
     "ajv": "8.18.0",
     "ajv-formats": "3.0.1",
     "archiver": "7.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,8 +42,8 @@ importers:
         specifier: 2.7.2
         version: 2.7.2(typescript@6.0.3)
       '@vivliostyle/viewer':
-        specifier: 2.44.1
-        version: 2.44.1
+        specifier: 2.45.0
+        version: 2.45.0
       ajv:
         specifier: 8.18.0
         version: 8.18.0
@@ -2888,8 +2888,8 @@ packages:
   '@vitest/utils@4.1.9':
     resolution: {integrity: sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==}
 
-  '@vivliostyle/core@2.44.1':
-    resolution: {integrity: sha512-J0G35Qt2I4sKZFLuV2DM1ZpgGn3SnEHtdEB/wQaaNGvh+TnAlz6jnvl1QuCLpvjwYgvVikXrxghGO82D4mL4Ew==}
+  '@vivliostyle/core@2.45.0':
+    resolution: {integrity: sha512-ugKexK0/srYpY5GtiyReehpgvfko5Wy1GyMvQNwYW3ybiwL41af3JVE8PoiGvY1Y6MgKNSm8wXf2CZrb6t9mZg==}
     engines: {node: '>=20'}
 
   '@vivliostyle/jsdom@25.0.1-vivliostyle-cli.2':
@@ -2930,8 +2930,8 @@ packages:
     engines: {node: '>= 22'}
     hasBin: true
 
-  '@vivliostyle/viewer@2.44.1':
-    resolution: {integrity: sha512-qQqHiagvl73iuDQoevvSCaVlaEvZD2R35luMQgHlrzHeY35ZNeCvwS/NzyP+WYWLbdSzDdooXALASWU+bIExJw==}
+  '@vivliostyle/viewer@2.45.0':
+    resolution: {integrity: sha512-KLdn2lkkMnJ3WLfE29s275nI8GAFMzk8El7ZUtM/MvlvGjWQWGQk0cAVq6rizZW+DgK91BXgEyGsUfTT1HY0hQ==}
     engines: {node: '>=20'}
 
   '@zachleat/heading-anchors@1.0.5':
@@ -9297,7 +9297,7 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  '@vivliostyle/core@2.44.1':
+  '@vivliostyle/core@2.45.0':
     dependencies:
       fast-diff: 1.3.0
 
@@ -9448,9 +9448,9 @@ snapshots:
       - supports-color
       - typescript
 
-  '@vivliostyle/viewer@2.44.1':
+  '@vivliostyle/viewer@2.45.0':
     dependencies:
-      '@vivliostyle/core': 2.44.1
+      '@vivliostyle/core': 2.45.0
       i18next-ko: 3.0.1
       knockout: 3.5.3
 


### PR DESCRIPTION
https://github.com/vivliostyle/vivliostyle.js/releases/tag/v2.45.0

### Features

- Support cascade layer order for name-defining at-rules ([b75551d](https://github.com/vivliostyle/vivliostyle.js/commit/b75551de859d920a42f44ecb64917ecfdb380d62)), closes [#2110](https://github.com/vivliostyle/vivliostyle.js/issues/2110)
- Support the `revert`, `revert-layer` and `revert-rule` keywords ([4e73752](https://github.com/vivliostyle/vivliostyle.js/commit/4e737526484207011cdc24403b2f23e243e9fb31)), closes [#2111](https://github.com/vivliostyle/vivliostyle.js/issues/2111)
- Add support for CSS Cascade Layers (`@layer`) ([535b919](https://github.com/vivliostyle/vivliostyle.js/commit/535b919981659c2fd94feadec164d09e9530adf4)), closes [#977](https://github.com/vivliostyle/vivliostyle.js/issues/977)
- Support :dir() and :any-link pseudo-classes ([#2093](https://github.com/vivliostyle/vivliostyle.js/issues/2093)) ([7551577](https://github.com/vivliostyle/vivliostyle.js/commit/75515773846fc477c504b6cd8df005f0ab69d34e))

### Bug Fixes

- Give the text-spacing filler font vertical metrics ([#2124](https://github.com/vivliostyle/vivliostyle.js/issues/2124)) ([fef988e](https://github.com/vivliostyle/vivliostyle.js/commit/fef988eb61acb7b9117d76200640c5b2c4b2f0ed))
- Leave a rollback with no fallback to the browser ([#2123](https://github.com/vivliostyle/vivliostyle.js/issues/2123)) ([0926c24](https://github.com/vivliostyle/vivliostyle.js/commit/0926c24731ace4fcfb432f1cd9eafb653872da3a))
- Map `@font-face` families used by ::marker ([#2122](https://github.com/vivliostyle/vivliostyle.js/issues/2122)) ([4e80f52](https://github.com/vivliostyle/vivliostyle.js/commit/4e80f52370468ab83ed2307a5c551dc96ad14204))
- Keep `@font-face` rules in cascade order in the view document ([3d2dba9](https://github.com/vivliostyle/vivliostyle.js/commit/3d2dba943666acbc9d81fa9bde224188faf2172b))
- Fix var() being dropped when a CSS property name is not lowercase ([a59a8c6](https://github.com/vivliostyle/vivliostyle.js/commit/a59a8c6f850046cdb4758b26e06922cb881ccebd))
- Fix background-position with var() being dropped on `@page` and root backgrounds ([58fc60a](https://github.com/vivliostyle/vivliostyle.js/commit/58fc60a1ac698904f670657a92e4fffbf8247486)), closes [#2116](https://github.com/vivliostyle/vivliostyle.js/issues/2116)
- Fix body content overflowing the page when writing-mode is specified on the body element ([6536276](https://github.com/vivliostyle/vivliostyle.js/commit/65362767936190df6aa09b5b922655220c5abbfb)), closes [#1122](https://github.com/vivliostyle/vivliostyle.js/issues/1122)
- Prevent writing-mode on the body element from being inherited by the page context ([610aaa6](https://github.com/vivliostyle/vivliostyle.js/commit/610aaa69a6270da04552f8853581211711ab47d5)), closes [#1122](https://github.com/vivliostyle/vivliostyle.js/issues/1122)
- Fix parser error with lowercase `<!doctype html>` ([ed69fee](https://github.com/vivliostyle/vivliostyle.js/commit/ed69feeea3f90113adcf0bd50f9e6f5aac4b07c9)), closes [#2101](https://github.com/vivliostyle/vivliostyle.js/issues/2101)
- Fix writing-mode at `@page` not working correctly ([2008273](https://github.com/vivliostyle/vivliostyle.js/commit/2008273fdd948fb4e1ab9c0c0d2093588b0b8d6e)), closes [#2001](https://github.com/vivliostyle/vivliostyle.js/issues/2001)
- Keep the view condition of a voided selector out of the next rule ([ac7974c](https://github.com/vivliostyle/vivliostyle.js/commit/ac7974ca36f3f77cfb53056a76d6658e31957cee))
- Void a rule whose selector uses a construct the parser rejects ([ef477da](https://github.com/vivliostyle/vivliostyle.js/commit/ef477da43adc5e27034cf0fd92e9337a5c879d0d))
- Treat a pseudo-element as an invalid alternative in a selector list ([04179e6](https://github.com/vivliostyle/vivliostyle.js/commit/04179e6720ab46a3269c98c17f7d2181da37e503))
- Take a rule into the cascade only once its selector list has parsed ([d8f7c2e](https://github.com/vivliostyle/vivliostyle.js/commit/d8f7c2e3cddd6df123eecbe93ce657c96e216032))
- Void an unforgiving selector list on an invalid alternative ([74a6fc9](https://github.com/vivliostyle/vivliostyle.js/commit/74a6fc9f5cbfd3b6f8447e33dadc376b4a2a167d))
- Ignore invalid selectors in a forgiving selector list ([5491851](https://github.com/vivliostyle/vivliostyle.js/commit/549185164646cf87ddbaf5db63bb289e52c75b4e))
- Load documents with reserved characters in filenames ([6439fa6](https://github.com/vivliostyle/vivliostyle.js/commit/6439fa6e8fd8f38c788b6600bc9768baba874d69)), closes [#2076](https://github.com/vivliostyle/vivliostyle.js/issues/2076)
- Fix the UA base stylesheet ignoring expressions and at-rules ([78861a0](https://github.com/vivliostyle/vivliostyle.js/commit/78861a0293428537abbd263f86baa55bf1e29b29))
- Resolve lh in calc() on the root font-size and line-height ([fe094a1](https://github.com/vivliostyle/vivliostyle.js/commit/fe094a1c21978d40e40404822a687fa25d5ff76b))
- Fix rlh and lh units resolving to zero ([d5886b0](https://github.com/vivliostyle/vivliostyle.js/commit/d5886b0aab52680f6410da397882215f39290278))
- Fix page navigation during background rendering ([1ea6dc6](https://github.com/vivliostyle/vivliostyle.js/commit/1ea6dc6571d017a96a5001d3c8e369d3b017e127)), closes [#2047](https://github.com/vivliostyle/vivliostyle.js/issues/2047)