### PR TITLE
fix: Survive viewer reloads while setting up the preview page

### DIFF
--- a/.changeset/quiet-pages-settle.md
+++ b/.changeset/quiet-pages-settle.md
@@ -1,0 +1,5 @@
+---
+"@vivliostyle/cli": patch
+---
+
+Keep the preview running when the viewer reloads during startup instead of failing with `Execution context was destroyed`.

--- a/src/vite/vite-plugin-browser.ts
+++ b/src/vite/vite-plugin-browser.ts
@@ -3,6 +3,7 @@ import type * as vite from 'vite';
 import { launchPreview, runBrowserOperationWithAbort } from '../browser.js';
 import type { ResolvedTaskConfig } from '../config/resolve.js';
 import type { ParsedVivliostyleInlineConfig } from '../config/schema.js';
+import { Logger } from '../logger.js';
 import { getViewerFullUrl } from '../server.js';
 import { getOsLocale, runCleanupHandlers } from '../util.js';
 import { reloadConfig } from './plugin-util.js';
@@ -28,15 +29,31 @@ export function vsBrowserPlugin({
   async function openPreviewPage() {
     const locale = getOsLocale();
     const url = await getViewerFullUrl(config);
-    const { page, closeBrowser: closeLaunchedBrowser } = await launchPreview({
+    let localeScriptId: string | undefined;
+    const {
+      page,
+      browser,
+      closeBrowser: closeLaunchedBrowser,
+    } = await launchPreview({
       mode: 'preview',
       url,
       signal: inlineConfig.signal,
       config,
-      /* v8 ignore next 4 */
-      onPageOpen: (openedPage) => {
+      onPageOpen: async (openedPage) => {
         // Terminate preview when the previewing page is closed
         openedPage.on('close', handlePageClose);
+        try {
+          ({ identifier: localeScriptId } =
+            await openedPage.evaluateOnNewDocument((lng) => {
+              // Vivliostyle Viewer uses `i18nextLng` in localStorage for UI language
+              window.localStorage.setItem('i18nextLng', lng);
+            }, locale));
+        } catch (error) {
+          if (inlineConfig.signal?.aborted) {
+            throw error;
+          }
+          Logger.debug('Failed to set up the viewer UI language', error);
+        }
       },
     });
 
@@ -49,24 +66,50 @@ export function vsBrowserPlugin({
       signal: inlineConfig.signal,
       closeBrowser,
       operation: async () => {
-        // Vivliostyle Viewer uses `i18nextLng` in localStorage for UI language
-        if (!import.meta.env?.VITEST) {
-          /* v8 ignore next 4 */
-          await page.evaluate((lng) => {
-            window.localStorage.setItem('i18nextLng', lng);
-          }, locale);
+        const continueUnlessPreviewIsEnding = async (
+          description: string,
+          setup: () => Promise<unknown>,
+        ) => {
+          try {
+            await setup();
+          } catch (error) {
+            if (
+              inlineConfig.signal?.aborted ||
+              (!browser.connected && !page.isClosed())
+            ) {
+              throw error;
+            }
+            Logger.debug(`Failed to ${description}`, error);
+          }
+        };
+        const registeredLocaleScriptId = localeScriptId;
+        if (registeredLocaleScriptId !== undefined) {
+          await continueUnlessPreviewIsEnding('remove the locale script', () =>
+            page.removeScriptToEvaluateOnNewDocument(registeredLocaleScriptId),
+          );
         }
         // Move focus from the address bar to the page
-        await page.bringToFront();
-        // Focus to the URL input box if available
-        if (!import.meta.env?.VITEST) {
-          /* v8 ignore next 6 */
-          await page.evaluate(() => {
-            document
-              .querySelector<HTMLInputElement>('#vivliostyle-input-url')
-              ?.focus();
-          });
-        }
+        await continueUnlessPreviewIsEnding('bring the page to front', () =>
+          page.bringToFront(),
+        );
+        // Focus to the URL input box if available.
+        // `waitForFunction` re-runs in the new document when a navigation
+        // destroys the execution context
+        await continueUnlessPreviewIsEnding('focus the URL input box', () =>
+          page.waitForFunction(
+            () => {
+              const urlInput = document.querySelector<HTMLInputElement>(
+                '#vivliostyle-input-url',
+              );
+              if (urlInput) {
+                urlInput.focus();
+                return true;
+              }
+              return document.readyState === 'complete';
+            },
+            { polling: 1000, signal: inlineConfig.signal },
+          ),
+        );
       },
     });
   }

--- a/tests/browser.test.ts
+++ b/tests/browser.test.ts
@@ -136,6 +136,51 @@ describe('launchPreview', () => {
     await Promise.all([directClose, cleanupClose]);
   });
 
+  it('runs onPageOpen to completion before navigating', async () => {
+    const calls: string[] = [];
+    mockedLaunch.mockResolvedValue({
+      browserContexts: () => [
+        {
+          pages: () => [],
+          newPage: () => ({
+            setViewport: vi.fn<() => void>(),
+            on: vi.fn<() => void>(),
+            authenticate: vi.fn<() => void>(),
+            goto: vi.fn<() => void>(() => {
+              calls.push('goto');
+            }),
+          }),
+        },
+      ],
+      close: vi.fn<() => void>(),
+    });
+
+    await launchPreview({
+      mode: 'preview',
+      url: 'https://example.com',
+      config: {
+        browser: {
+          type: 'chrome',
+          tag: 'stable',
+          executablePath: process.execPath,
+        },
+        proxy: undefined,
+        sandbox: false,
+        ignoreHttpsErrors: false,
+        timeout: 1000,
+      },
+      onPageOpen: async () => {
+        calls.push('onPageOpen:start');
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, 0);
+        });
+        calls.push('onPageOpen:end');
+      },
+    });
+
+    expect(calls).toEqual(['onPageOpen:start', 'onPageOpen:end', 'goto']);
+  });
+
   it('registers cleanup before browser launch completes', async () => {
     let resolveLaunch:
       | ((browser: {

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -17,12 +17,15 @@ const mockedBrowserModule = vi.hoisted(() => ({
       page: {
         on: vi.fn<() => void>(),
         off: vi.fn<() => void>(),
+        isClosed: vi.fn<() => boolean>().mockReturnValue(false),
         bringToFront: vi.fn<() => void>(),
+        waitForFunction: vi.fn<() => void>(),
         locator: vi.fn<() => { focus: () => void }>().mockReturnValue({
           focus: vi.fn<() => void>(),
         }),
       },
       browser: {
+        connected: true,
         close: vi.fn<() => void>(),
       },
       closeBrowser: vi.fn<() => void>(),

--- a/tests/vite-plugin-browser.test.ts
+++ b/tests/vite-plugin-browser.test.ts
@@ -1,11 +1,17 @@
 import type { Page } from 'puppeteer-core';
 import type { ViteDevServer } from 'vite';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { ResolvedTaskConfig } from '../src/config/resolve.js';
 import type { ParsedVivliostyleInlineConfig } from '../src/config/schema.js';
 
-const mockedLaunchPreview = vi.hoisted(() => vi.fn<() => Promise<unknown>>());
+const mockedLaunchPreview = vi.hoisted(() =>
+  vi.fn<
+    (
+      options: Parameters<typeof import('../src/browser.js').launchPreview>[0],
+    ) => Promise<unknown>
+  >(),
+);
 const mockedGetViewerFullUrl = vi.hoisted(() =>
   vi.fn<() => Promise<unknown>>(),
 );
@@ -45,6 +51,7 @@ describe('vsBrowserPlugin cancellation', () => {
     const page = {
       on: vi.fn<() => void>(),
       off: vi.fn<() => void>(),
+      isClosed: () => false,
       bringToFront: vi.fn<() => Promise<void>>(() => {
         controller.abort(reason);
         throw protocolError;
@@ -52,6 +59,7 @@ describe('vsBrowserPlugin cancellation', () => {
     } as unknown as Page;
     mockedLaunchPreview.mockResolvedValue({
       page,
+      browser: { connected: true },
       closeBrowser,
     });
 
@@ -79,5 +87,198 @@ describe('vsBrowserPlugin cancellation', () => {
       }),
     );
     expect(closeBrowser).toHaveBeenCalledOnce();
+  });
+});
+
+describe('vsBrowserPlugin page setup', () => {
+  const calls: string[] = [];
+  const page = {
+    on: vi.fn<() => void>(),
+    off: vi.fn<() => void>(),
+    isClosed: () => pageClosed,
+    evaluateOnNewDocument: vi
+      .fn<
+        (
+          fn: (lng: string) => void,
+          lng: string,
+        ) => Promise<{ identifier: string }>
+      >()
+      .mockImplementation(() => {
+        calls.push('evaluateOnNewDocument');
+        return Promise.resolve({ identifier: 'locale-script' });
+      }),
+    bringToFront: vi.fn<() => Promise<void>>().mockImplementation(() => {
+      calls.push('bringToFront');
+      return Promise.resolve();
+    }),
+    removeScriptToEvaluateOnNewDocument: vi
+      .fn<(id: string) => Promise<void>>()
+      .mockImplementation((id) => {
+        calls.push(`remove:${id}`);
+        return Promise.resolve();
+      }),
+    waitForFunction: vi
+      .fn<(fn: () => boolean, options: unknown) => Promise<unknown>>()
+      .mockImplementation(() => {
+        calls.push('waitForFunction');
+        return Promise.resolve();
+      }),
+  };
+  const browser = { connected: true };
+  let pageClosed = false;
+  const closeBrowser = vi.fn<() => Promise<void>>().mockResolvedValue();
+
+  function listenWithPlugin(signal?: AbortSignal) {
+    const plugin = vsBrowserPlugin({
+      config,
+      inlineConfig: {
+        openViewer: true,
+        signal,
+      } as ParsedVivliostyleInlineConfig,
+    });
+    const server = {
+      listen: vi
+        .fn<() => Promise<unknown>>()
+        .mockImplementation(() => Promise.resolve(server)),
+      close: vi.fn<() => Promise<void>>().mockResolvedValue(),
+      config: {},
+    } as unknown as ViteDevServer;
+    (plugin.configureServer as (server: ViteDevServer) => void)(server);
+    return server.listen();
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    calls.length = 0;
+    browser.connected = true;
+    pageClosed = false;
+    mockedGetViewerFullUrl.mockResolvedValue('http://localhost:13000/viewer');
+    mockedReloadConfig.mockResolvedValue(config);
+    mockedLaunchPreview.mockImplementation(async ({ onPageOpen }) => {
+      await onPageOpen?.(page as unknown as Page);
+      calls.push('goto');
+      return { page, browser, closeBrowser };
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('sets the viewer language before navigation and focuses the URL input after bringing the page to front', async () => {
+    const { signal } = new AbortController();
+    await expect(listenWithPlugin(signal)).resolves.toBeDefined();
+    expect(calls).toEqual([
+      'evaluateOnNewDocument',
+      'goto',
+      'remove:locale-script',
+      'bringToFront',
+      'waitForFunction',
+    ]);
+
+    const [setLanguage, lng] = page.evaluateOnNewDocument.mock.calls[0];
+    const setItem = vi.fn<(key: string, value: string) => void>();
+    vi.stubGlobal('window', { localStorage: { setItem } });
+    setLanguage(lng);
+    expect(setItem).toHaveBeenCalledWith('i18nextLng', 'en');
+
+    const [focusUrlInput, options] = page.waitForFunction.mock.calls[0];
+    const focus = vi.fn<() => void>();
+    const querySelector = vi
+      .fn<(selector: string) => { focus: () => void }>()
+      .mockReturnValue({ focus });
+    vi.stubGlobal('document', { querySelector, readyState: 'loading' });
+    expect(focusUrlInput()).toBe(true);
+    expect(querySelector).toHaveBeenCalledWith('#vivliostyle-input-url');
+    expect(focus).toHaveBeenCalledOnce();
+    expect(options).toEqual({ polling: 1000, signal });
+    expect((options as { signal: AbortSignal }).signal).toBe(signal);
+  });
+
+  it('waits for the URL input until the document has finished loading', async () => {
+    await listenWithPlugin();
+    const [focusUrlInput] = page.waitForFunction.mock.calls[0];
+    vi.stubGlobal('document', {
+      querySelector: () => null,
+      readyState: 'loading',
+    });
+    expect(focusUrlInput()).toBe(false);
+    vi.stubGlobal('document', {
+      querySelector: () => null,
+      readyState: 'complete',
+    });
+    expect(focusUrlInput()).toBe(true);
+  });
+
+  it('opens the preview even if the language setup fails', async () => {
+    page.evaluateOnNewDocument.mockRejectedValueOnce(
+      new Error('Protocol error (Page.addScriptToEvaluateOnNewDocument)'),
+    );
+    await expect(listenWithPlugin()).resolves.toBeDefined();
+    expect(page.removeScriptToEvaluateOnNewDocument).not.toHaveBeenCalled();
+    expect(calls).toEqual(['goto', 'bringToFront', 'waitForFunction']);
+  });
+
+  it('removes the locale script and focuses the URL input even if bringing the page to front fails', async () => {
+    page.bringToFront.mockRejectedValueOnce(
+      new Error('Protocol error (Page.bringToFront): Target closed'),
+    );
+    await expect(listenWithPlugin()).resolves.toBeDefined();
+    expect(calls).toEqual([
+      'evaluateOnNewDocument',
+      'goto',
+      'remove:locale-script',
+      'waitForFunction',
+    ]);
+  });
+
+  it('focuses the URL input even if removing the locale script fails', async () => {
+    page.removeScriptToEvaluateOnNewDocument.mockRejectedValueOnce(
+      new Error('Protocol error (Page.removeScriptToEvaluateOnNewDocument)'),
+    );
+    await expect(listenWithPlugin()).resolves.toBeDefined();
+    expect(page.waitForFunction).toHaveBeenCalledOnce();
+    expect(closeBrowser).not.toHaveBeenCalled();
+  });
+
+  it('opens the preview even if focusing the URL input times out', async () => {
+    page.waitForFunction.mockRejectedValueOnce(
+      new Error('Waiting failed: 30000ms exceeded'),
+    );
+    await expect(listenWithPlugin()).resolves.toBeDefined();
+    expect(closeBrowser).not.toHaveBeenCalled();
+  });
+
+  it('propagates cancellation while waiting for the URL input', async () => {
+    const controller = new AbortController();
+    const reason = new Error('cancelled');
+    page.waitForFunction.mockImplementationOnce(() => {
+      controller.abort(reason);
+      return Promise.reject(reason);
+    });
+    await expect(listenWithPlugin(controller.signal)).rejects.toBe(reason);
+    expect(closeBrowser).toHaveBeenCalledOnce();
+  });
+
+  it('opens the preview without failing if the page is closed during the page setup', async () => {
+    page.waitForFunction.mockImplementationOnce(() => {
+      pageClosed = true;
+      browser.connected = false;
+      return Promise.reject(
+        new Error('Protocol error (Runtime.callFunctionOn): Target closed'),
+      );
+    });
+    await expect(listenWithPlugin()).resolves.toBeDefined();
+    expect(closeBrowser).not.toHaveBeenCalled();
+  });
+
+  it('fails to open the preview if the browser is disconnected while the page is still open', async () => {
+    page.waitForFunction.mockImplementationOnce(() => {
+      browser.connected = false;
+      return Promise.reject(
+        new Error('Protocol error (Runtime.callFunctionOn): Target closed'),
+      );
+    });
+    await expect(listenWithPlugin()).rejects.toThrow('Target closed');
   });
 });


### PR DESCRIPTION
起動直後にpreviewが異常終了することがあります。Apple Silicon MacのDocker（Desktop）で、`--platform linux/amd64`エミュレーションかつ原稿ディレクトリをマウントする構成で見出しましたが、確実な再現は困難です。

```
INFO Start preview
INFO [vite] page reload .vivliostyle/chapter/manuscript.html
INFO [vite] page reload .vivliostyle/index.html
ERROR Error: Execution context was destroyed, most likely because of a navigation.
    at rewriteError (.../puppeteer-core/lib/puppeteer/cdp/ExecutionContext.js:454:15)
    ...
    at async operation (.../@vivliostyle/cli/dist/server-C_5O9k08.js:1209:5)
    at async runBrowserOperationWithAbort (.../dist/server-C_5O9k08.js:920:18)
    at async openPreviewPage (.../dist/server-C_5O9k08.js:1197:3)
    at async viteServer.listen (.../dist/server-C_5O9k08.js:1224:5)
```

エラーにある`dist/server-C_5O9k08.js:1209`は`src/vite/vite-plugin-browser.ts`の`openPreviewPage()`にある2つ目の`page.evaluate()`（`#vivliostyle-input-url`へのフォーカス）に対応します。`page.goto()`直後に`evaluate()`を2回呼びますが、その間にページが遷移するとPuppeteerが上記エラーを投げます。遷移の原因は`page reload`のログが示すとおりViteの`full-reload`です。`buildStart`で書き直した`.vivliostyle/**/*.html`をViteのwatcherが`.html`の変更として拾うと`full-reload`を送り、viewerに注入しているclientはこれを受けると無条件に`location.reload()`します。通常は起動時の書き込みがwatcherの初期スキャン（`.vivliostyle`配下への監視設置）より先に完了するため通知されず、通知が監視設置後まで遅れる状況、たとえば先述のバインドマウントやエミュレーションでこの衝突が起こりえます。Viteは未接続時に送った`full-reload`を保持して最初の接続時に再生するため、通知がブラウザ接続前に届いた場合もviewerはreloadします。

`goto`後の2つの`page.evaluate`を、それぞれ遷移に耐える形に置き換えます。

- `i18nextLng`の設定は`page.evaluateOnNewDocument`で`goto`の前に登録します。 #388 でPlaywrightの`page.addInitScript`として`goto`前に登録されていた元の形で、 #602 のPuppeteer移行時に一時的にコメントアウトされ（bf5a13d）、戻す際（a7d4268）に`goto`後の`evaluate`へ移ったものです。履歴から理由はわかりませんでした、すみません。現行の「起動時に1回だけ設定する」性質は、初回の`goto`完了後に`removeScriptToEvaluateOnNewDocument`で外すことで保っています。登録に失敗してもpreviewは続行し、`src/output/pdf.ts`の`evaluateOnNewDocument`と同じくdebugログに落とします。
- URL入力欄へのフォーカスは`bringToFront`の後という順序（cb48ff7）を保ったまま、`page.evaluate`を`page.waitForFunction`に変えます。`waitForFunction`はナビゲーションで実行コンテキストが破棄されると新しいドキュメントで再実行されます。再実行はHTMLのパース前に始まるので、述語は入力欄が現れた時点でフォーカスして完了とし、入力欄の無いviewerでは`document.readyState`が`complete`になった時点で打ち切ります。ポーリングは`pdf.ts`と同じ`polling: 1000`にし、ウィンドウが隠れて`requestAnimationFrame`が止まっても評価が続くようにしています。
- `goto`後の各手順（言語スクリプトの解除、`bringToFront`、フォーカス）はそれぞれ独立にbest-effortとし、失敗してもキャンセル中でなく、かつ「ページは開いたままブラウザだけ切断された」状態でなければpreviewを続行します。ページが閉じられた場合の終了処理は`close`イベント側に任せ、ブラウザ消失は従来どおり`listen()`の失敗として表面化します。

`launchPreview`が`onPageOpen`の完了を待ってから`goto`することのテストを`tests/browser.test.ts`に追加しています。

Assisted-by: Claude Code:claude-fable-5

<details>
<summary>How the AI was used</summary>

- The human author provided the failure log, chose to register the locale setup before navigation and to keep the focus after `bringToFront`, decided which review findings to adopt, and reviewed each revision of the diff.
- Claude Code mapped the stack trace to `openPreviewPage`, traced the reload path from the `buildStart` writes through Vite's `.html` full-reload to the viewer client's `location.reload()`, implemented the change and its tests, measured the startup writes against the watcher setup, and reproduced the reload right after `goto` on Xvfb.
- Independent AI reviewers examined the diff in repeated rounds; the human author evaluated their findings and retains responsibility for the final review and verification before submission.

</details>
