### PR TITLE
fix: reset replaceImage RegExp state between files

### DIFF
--- a/.changeset/calm-regexps-reset.md
+++ b/.changeset/calm-regexps-reset.md
@@ -1,0 +1,5 @@
+---
+"@vivliostyle/cli": patch
+---
+
+Fix `replaceImage` source matching with stateful regular expressions by resetting each expression before matching or replacing an independent file path.

--- a/src/config/resolve.ts
+++ b/src/config/resolve.ts
@@ -735,15 +735,22 @@ export function resolveTaskConfig(
       });
       return replaceImageOption.flatMap(({ source, replacement }) => {
         if (source instanceof RegExp) {
+          const matcher = new RegExp(source.source, source.flags);
           return allFiles
-            .filter((file) => source.test(file))
-            .map((file) => ({
-              source: upath.resolve(entryContextDir, file),
-              replacement: upath.resolve(
-                entryContextDir,
-                file.replace(source, replacement),
-              ),
-            }));
+            .filter((file) => {
+              matcher.lastIndex = 0;
+              return matcher.test(file);
+            })
+            .map((file) => {
+              matcher.lastIndex = 0;
+              return {
+                source: upath.resolve(entryContextDir, file),
+                replacement: upath.resolve(
+                  entryContextDir,
+                  file.replace(matcher, replacement),
+                ),
+              };
+            });
         }
         return {
           source: upath.resolve(entryContextDir, source),

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -563,6 +563,22 @@ it('rejects unknown extensions without documentProcessor', async () => {
   ).rejects.toThrow('Invalid manuscript type');
 });
 
+const resolveReplaceImageEntries = async (
+  source: RegExp,
+): Promise<{ source: string; replacement: string }[]> => {
+  const config = await getTaskConfig(['build'], resolveFixture('config'), {
+    entry: 'manuscript.md',
+    output: 'output.pdf',
+    pdfPostprocess: {
+      replaceImage: [{ source, replacement: 'img_cmyk.tiff' }],
+    },
+  });
+  const output = config.outputs[0] as unknown as {
+    replaceImage: { source: string; replacement: string }[];
+  };
+  return output.replaceImage;
+};
+
 it('supports pdfPostprocess configuration', async () => {
   const config = await getTaskConfig(['build'], resolveFixture('config'), {
     entry: 'manuscript.md',
@@ -588,6 +604,32 @@ it('supports pdfPostprocess configuration', async () => {
       },
     ],
   });
+});
+
+it('matches every replaceImage source with a global RegExp', async () => {
+  const expectedEntries = await resolveReplaceImageEntries(/\.md$/v);
+  expect(expectedEntries.length).toBeGreaterThan(1);
+
+  const globalSource = /\.md$/gv;
+  expect(await resolveReplaceImageEntries(globalSource)).toEqual(
+    expectedEntries,
+  );
+  expect(await resolveReplaceImageEntries(globalSource)).toEqual(
+    expectedEntries,
+  );
+});
+
+it('preserves sticky matching across independent source paths', async () => {
+  const searchableEntries = await resolveReplaceImageEntries(/[^\/]+\.md$/v);
+  const stickyEntries = await resolveReplaceImageEntries(/[^\/]+\.md$/vy);
+
+  expect(stickyEntries.length).toBeGreaterThan(1);
+  expect(stickyEntries.length).toBeLessThan(searchableEntries.length);
+  expect(
+    stickyEntries.every(({ replacement }) =>
+      replacement.endsWith('img_cmyk.tiff'),
+    ),
+  ).toBe(true);
 });
 
 it('pdfPostprocess takes precedence over legacy pressReady option', async () => {


### PR DESCRIPTION
#766 のうち、`replaceImage`の`source`に指定する正規表現の不具合を分離したPRです。

`g` / `y`フラグを持つ正規表現は、`test()`が成功すると`lastIndex`を更新します。現在の実装は同じ正規表現をファイル一覧の照合に繰り返し使うため、あるファイルの照合結果が次のファイルの開始位置に持ち越され、本来マッチするファイルを飛ばすことがあります。

このPRでは、設定に渡された正規表現の状態を変更しないよう複製し、ファイルごとに照合と置換の前に`lastIndex`を0へ戻します。

Assisted-by: Codex:gpt-5

<details>
<summary>How the AI was used</summary>

- The human author split the regular-expression fix from #766, limited the change to RegExp state handling, and required the sticky flag to retain its standard matching semantics.
- Codex implemented the fix, regression tests, and changeset, then ran the CLI build, targeted tests, type-checker, linter, and formatter.
- Two independent Codex reviewers inspected an earlier implementation and identified that removing the sticky flag changed its matching semantics. The human author evaluated that finding, rejected the implementation, and directed the current design.

</details>
