### PR TITLE
feat: add configurable CMYK compatibility checks

### DIFF
--- a/.changeset/quiet-colors-check.md
+++ b/.changeset/quiet-colors-check.md
@@ -1,0 +1,5 @@
+---
+'@vivliostyle/cli': minor
+---
+
+Add `cmyk.ifUnmappedColorsFound` and `cmyk.ifIncompatibleImagesFound` policies for unmapped RGB colors and images encountered by `replaceImage` whose color spaces are incompatible with Device CMYK. Deprecate `cmyk.warnUnmapped` while preserving its behavior.

--- a/docs/api-javascript.md
+++ b/docs/api-javascript.md
@@ -65,7 +65,7 @@ build({
 
 ###### cmyk?
 
-`boolean` \| \{ `mapOutput?`: `string`; `overrideMap?`: \[`string` \| \{ `b`: `number`; `g`: `number`; `r`: `number`; \}, \{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \}\][]; `reserveMap?`: \[`string` \| \{ `b`: `number`; `g`: `number`; `r`: `number`; \}, \{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \}\][]; `warnUnmapped?`: `boolean`; \} = `CmykSchema`
+`boolean` \| \{ `ifIncompatibleImagesFound?`: `"warn"` \| `"error"` \| `"ignore"`; `ifUnmappedColorsFound?`: `"warn"` \| `"error"` \| `"ignore"`; `mapOutput?`: `string`; `overrideMap?`: \[`string` \| \{ `b`: `number`; `g`: `number`; `r`: `number`; \}, \{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \}\][]; `reserveMap?`: \[`string` \| \{ `b`: `number`; `g`: `number`; `r`: `number`; \}, \{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \}\][]; `warnUnmapped?`: `boolean`; \} = `CmykSchema`
 
 ###### config?
 
@@ -297,7 +297,7 @@ Scaffold a new Vivliostyle project.
 
 ###### cmyk?
 
-`boolean` \| \{ `mapOutput?`: `string`; `overrideMap?`: \[`string` \| \{ `b`: `number`; `g`: `number`; `r`: `number`; \}, \{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \}\][]; `reserveMap?`: \[`string` \| \{ `b`: `number`; `g`: `number`; `r`: `number`; \}, \{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \}\][]; `warnUnmapped?`: `boolean`; \} = `CmykSchema`
+`boolean` \| \{ `ifIncompatibleImagesFound?`: `"warn"` \| `"error"` \| `"ignore"`; `ifUnmappedColorsFound?`: `"warn"` \| `"error"` \| `"ignore"`; `mapOutput?`: `string`; `overrideMap?`: \[`string` \| \{ `b`: `number`; `g`: `number`; `r`: `number`; \}, \{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \}\][]; `reserveMap?`: \[`string` \| \{ `b`: `number`; `g`: `number`; `r`: `number`; \}, \{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \}\][]; `warnUnmapped?`: `boolean`; \} = `CmykSchema`
 
 ###### config?
 
@@ -527,7 +527,7 @@ Scaffold a new Vivliostyle project.
 
 ###### cmyk?
 
-`boolean` \| \{ `mapOutput?`: `string`; `overrideMap?`: \[`string` \| \{ `b`: `number`; `g`: `number`; `r`: `number`; \}, \{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \}\][]; `reserveMap?`: \[`string` \| \{ `b`: `number`; `g`: `number`; `r`: `number`; \}, \{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \}\][]; `warnUnmapped?`: `boolean`; \} = `CmykSchema`
+`boolean` \| \{ `ifIncompatibleImagesFound?`: `"warn"` \| `"error"` \| `"ignore"`; `ifUnmappedColorsFound?`: `"warn"` \| `"error"` \| `"ignore"`; `mapOutput?`: `string`; `overrideMap?`: \[`string` \| \{ `b`: `number`; `g`: `number`; `r`: `number`; \}, \{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \}\][]; `reserveMap?`: \[`string` \| \{ `b`: `number`; `g`: `number`; `r`: `number`; \}, \{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \}\][]; `warnUnmapped?`: `boolean`; \} = `CmykSchema`
 
 ###### config?
 
@@ -777,7 +777,7 @@ Open a browser for previewing the publication.
 
 ###### cmyk?
 
-`boolean` \| \{ `mapOutput?`: `string`; `overrideMap?`: \[`string` \| \{ `b`: `number`; `g`: `number`; `r`: `number`; \}, \{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \}\][]; `reserveMap?`: \[`string` \| \{ `b`: `number`; `g`: `number`; `r`: `number`; \}, \{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \}\][]; `warnUnmapped?`: `boolean`; \} = `CmykSchema`
+`boolean` \| \{ `ifIncompatibleImagesFound?`: `"warn"` \| `"error"` \| `"ignore"`; `ifUnmappedColorsFound?`: `"warn"` \| `"error"` \| `"ignore"`; `mapOutput?`: `string`; `overrideMap?`: \[`string` \| \{ `b`: `number`; `g`: `number`; `r`: `number`; \}, \{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \}\][]; `reserveMap?`: \[`string` \| \{ `b`: `number`; `g`: `number`; `r`: `number`; \}, \{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \}\][]; `warnUnmapped?`: `boolean`; \} = `CmykSchema`
 
 ###### config?
 
@@ -1068,7 +1068,7 @@ interface to the schema, so a drift in either direction is rejected.
 | `browser.tag?` | `string` |
 | `browser.type` | `"chrome"` \| `"chromium"` \| `"firefox"` |
 | <a id="property-cliversion"></a> `cliVersion` | `string` |
-| <a id="property-cmyk"></a> `cmyk?` | `boolean` \| \{ `mapOutput?`: `string`; `overrideMap?`: \[`string` \| \{ `b`: `number`; `g`: `number`; `r`: `number`; \}, \{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \}\][]; `reserveMap?`: \[`string` \| \{ `b`: `number`; `g`: `number`; `r`: `number`; \}, \{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \}\][]; `warnUnmapped?`: `boolean`; \} |
+| <a id="property-cmyk"></a> `cmyk?` | `boolean` \| \{ `ifIncompatibleImagesFound?`: `"warn"` \| `"error"` \| `"ignore"`; `ifUnmappedColorsFound?`: `"warn"` \| `"error"` \| `"ignore"`; `mapOutput?`: `string`; `overrideMap?`: \[`string` \| \{ `b`: `number`; `g`: `number`; `r`: `number`; \}, \{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \}\][]; `reserveMap?`: \[`string` \| \{ `b`: `number`; `g`: `number`; `r`: `number`; \}, \{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \}\][]; `warnUnmapped?`: `boolean`; \} |
 | <a id="property-config"></a> `config?` | `string` |
 | <a id="property-configdata"></a> `configData?` | [`VivliostyleConfigSchema`](#vivliostyleconfigschema) \| `null` |
 | <a id="property-coreversion"></a> `coreVersion` | `string` |

--- a/docs/config.md
+++ b/docs/config.md
@@ -428,7 +428,7 @@ pdfPostprocess takes precedence.
 
   - `cmyk`: boolean | [CmykConfig](#cmykconfig)  
     Convert device-cmyk() colors to CMYK in the output PDF.
-    Can be a boolean or a config object with overrideMap and warnUnmapped options.
+    Can be a boolean or a config object.
 
   - `replaceImage`: ([ReplaceImageEntry](#replaceimageentry))[]  
     Replace images in the output PDF.
@@ -464,8 +464,19 @@ type PdfPostprocessConfig = {
     Each entry is a tuple of [rgb, {c, m, y, k}].
     RGB can be an object {r, g, b} with integers (0-10000) or a hex color string (e.g. "#ff0000").
 
-  - `warnUnmapped`: boolean  
-    Warn when RGB colors not mapped to CMYK are encountered. (default: true)
+  - ~~`warnUnmapped`~~ _Deprecated_  
+    Use `ifUnmappedColorsFound` instead.
+    `true` corresponds to `"warn"` and `false` to `"ignore"`.
+    When both are specified, `ifUnmappedColorsFound` takes precedence.
+
+  - `ifUnmappedColorsFound`: "warn" | "error" | "ignore"  
+    What to do when RGB colors not mapped to CMYK are encountered:
+    log a warning, fail the build, or do nothing. (default: warn)
+
+  - `ifIncompatibleImagesFound`: "warn" | "error" | "ignore"  
+    What to do when the replaceImage scan encounters images whose color
+    spaces are not DeviceCMYK or DeviceGray: log a warning, fail the build,
+    or do nothing. (default: warn)
 
   - `mapOutput`: string  
     Output the CMYK color map to a JSON file at the specified path.
@@ -477,6 +488,14 @@ type CmykConfig = {
   overrideMap?: "{tuple(Array)}"[];
   reserveMap?: "{tuple(Array)}"[];
   warnUnmapped?: boolean;
+  ifUnmappedColorsFound?:
+    | "warn"
+    | "error"
+    | "ignore";
+  ifIncompatibleImagesFound?:
+    | "warn"
+    | "error"
+    | "ignore";
   mapOutput?: string;
 };
 ```

--- a/examples/cmyk/README.md
+++ b/examples/cmyk/README.md
@@ -22,11 +22,13 @@ Images used in Vivliostyle must be displayable by a web browser. You reference a
 
 Replacement works when the original image stream is preserved, such as when only resizing is applied as in the example, but there are cases where replacement does not work when complex operations like filters are applied to the image. Additionally, replacement does not work if the image contains semi-transparent pixels. Only fully opaque RGB images (not RGBA) are supported.
 
-## Other options
+## Validation policies
 
-By design, this feature cannot produce PDFs that freely mix RGB and CMYK colors (more precisely, it can produce a PDF with unconverted RGB values left in place, but it cannot guarantee that arbitrary RGB and CMYK values will coexist correctly). Since stray RGB elements are usually undesirable in a CMYK workflow, `cmyk.warnUnmapped` (default: `true`) logs warnings for any RGB colors in the PDF that have not been mapped to CMYK.
+By design, this feature cannot produce PDFs that freely mix RGB and CMYK colors (more precisely, it can produce a PDF with unconverted RGB values left in place, but it cannot guarantee that arbitrary RGB and CMYK values will coexist correctly). `cmyk.ifUnmappedColorsFound` determines what happens when RGB colors remain outside the color map: `"warn"` logs a warning, `"error"` fails the build, and `"ignore"` continues without reporting them. The default is `"warn"`.
 
-This CMYK feature assumes that you are aware of and in control of every colored element in your document. For complex documents, that may not always be the case. `cmyk.overrideMap` is a last resort for silencing `cmyk.warnUnmapped` warnings: it forcibly replaces any remaining RGB values in the PDF with the specified CMYK values.
+Raster images require a separate check because replacing color operators does not change image data. During the same scan used by `replaceImage`, `cmyk.ifIncompatibleImagesFound` checks every encountered image, including images that do not match a replacement. It applies the same `"warn"`, `"error"`, and `"ignore"` policies when an image's color space is not DeviceCMYK or DeviceGray. The scan runs for `"warn"` and `"error"` even when no replacements are configured. The default is `"warn"`; disabling `cmyk` disables this check.
+
+The example config sets both policies to `"error"`, so the build fails if either an unmapped RGB color or an incompatible image remains. For complex documents where every color cannot be controlled at the source, `cmyk.overrideMap` can forcibly replace remaining RGB values with specified CMYK values.
 
 `mapOutput` is primarily a debugging tool. It writes the internal color mapping table to a file.
 

--- a/examples/cmyk/vivliostyle.config.js
+++ b/examples/cmyk/vivliostyle.config.js
@@ -5,6 +5,8 @@ export default defineConfig({
   entry: ['manuscript.html'],
   pdfPostprocess: {
     cmyk: {
+      ifUnmappedColorsFound: 'error',
+      ifIncompatibleImagesFound: 'error',
       reserveMap: [
         ['#80ffff', { c: 5000, m: 0, y: 0, k: 0 }],
         ['#808080', { c: 0, m: 0, y: 0, k: 5000 }],

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -152,6 +152,7 @@ export async function loadVivliostyleConfig({
 
 export function warnDeprecatedConfig(
   config: ParsedVivliostyleConfigSchema,
+  inlineOptions: Pick<InlineOptions, 'cmyk'> = {},
 ): void {
   /* oxlint-disable typescript/no-deprecated -- This function intentionally inspects deprecated config fields to emit migration warnings */
   if (config.tasks.some((task) => task.includeAssets)) {
@@ -196,6 +197,26 @@ export function warnDeprecatedConfig(
   ) {
     Logger.logWarn(
       "'preflightOption' property of output config was deprecated and will be removed in a future release. Please use 'pdfPostprocess.preflightOption' property instead.",
+    );
+  }
+
+  const cmykOptions = [
+    inlineOptions.cmyk,
+    config.inlineOptions.cmyk,
+    ...config.tasks.flatMap((task) => [
+      task.pdfPostprocess?.cmyk,
+      ...(task.output
+        ? [task.output].flat().map((o) => o.pdfPostprocess?.cmyk)
+        : []),
+    ]),
+  ];
+  if (
+    cmykOptions.some(
+      (cmyk) => typeof cmyk === 'object' && cmyk.warnUnmapped !== undefined,
+    )
+  ) {
+    Logger.logWarn(
+      "'warnUnmapped' property of cmyk configuration was deprecated and will be removed in a future release. Please use 'ifUnmappedColorsFound' property instead.",
     );
   }
   /* oxlint-enable typescript/no-deprecated */

--- a/src/config/resolve.ts
+++ b/src/config/resolve.ts
@@ -263,7 +263,8 @@ function resolveMapEntries(
 }
 
 export interface CmykConfig {
-  warnUnmapped: boolean;
+  ifUnmappedColorsFound: 'warn' | 'error' | 'ignore';
+  ifIncompatibleImagesFound: 'warn' | 'error' | 'ignore';
   overrideMap: CmykMapEntry[];
   reserveMap: CmykMapEntry[];
   mapOutput: string | undefined;
@@ -697,21 +698,31 @@ export function resolveTaskConfig(
   const outputs = ((): OutputConfig[] => {
     type CmykOption = NonNullable<typeof config.pdfPostprocess>['cmyk'];
     const resolveCmykConfig = (cmykOption: CmykOption): CmykConfig | false => {
-      // Config file object format takes priority
-      if (cmykOption && typeof cmykOption === 'object') {
+      const cmykObject =
+        cmykOption && typeof cmykOption === 'object'
+          ? cmykOption
+          : options.cmyk && typeof options.cmyk === 'object'
+            ? options.cmyk
+            : undefined;
+      if (cmykObject) {
         return {
-          warnUnmapped: cmykOption.warnUnmapped ?? true,
-          overrideMap: resolveMapEntries(cmykOption.overrideMap ?? []),
-          reserveMap: resolveMapEntries(cmykOption.reserveMap ?? []),
-          mapOutput: cmykOption.mapOutput
-            ? upath.resolve(context, cmykOption.mapOutput)
+          ifUnmappedColorsFound:
+            cmykObject.ifUnmappedColorsFound ??
+            // oxlint-disable-next-line typescript/no-deprecated -- preserve warnUnmapped behavior for existing configurations
+            (cmykObject.warnUnmapped === false ? 'ignore' : 'warn'),
+          ifIncompatibleImagesFound:
+            cmykObject.ifIncompatibleImagesFound ?? 'warn',
+          overrideMap: resolveMapEntries(cmykObject.overrideMap ?? []),
+          reserveMap: resolveMapEntries(cmykObject.reserveMap ?? []),
+          mapOutput: cmykObject.mapOutput
+            ? upath.resolve(context, cmykObject.mapOutput)
             : undefined,
         };
       }
-      // CLI --cmyk flag or cmykOption: true
       if (options.cmyk || cmykOption === true) {
         return {
-          warnUnmapped: true,
+          ifUnmappedColorsFound: 'warn',
+          ifIncompatibleImagesFound: 'warn',
           overrideMap: [],
           reserveMap: [],
           mapOutput: undefined,

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -308,10 +308,31 @@ const CmykConfigSchema = v.pipe(
           RGB can be an object {r, g, b} with integers (0-10000) or a hex color string (e.g. "#ff0000").
         `),
       ),
+      /** @deprecated */
       warnUnmapped: v.pipe(
         v.boolean(),
+        v.metadata({ deprecated: true }),
         v.description($`
-          Warn when RGB colors not mapped to CMYK are encountered. (default: true)
+          Use \`ifUnmappedColorsFound\` instead.
+          \`true\` corresponds to \`"warn"\` and \`false\` to \`"ignore"\`.
+          When both are specified, \`ifUnmappedColorsFound\` takes precedence.
+        `),
+      ),
+      ifUnmappedColorsFound: v.pipe(
+        v.picklist(['warn', 'error', 'ignore']),
+        v.metadata({ typeString: '"warn" | "error" | "ignore"' }),
+        v.description($`
+          What to do when RGB colors not mapped to CMYK are encountered:
+          log a warning, fail the build, or do nothing. (default: warn)
+        `),
+      ),
+      ifIncompatibleImagesFound: v.pipe(
+        v.picklist(['warn', 'error', 'ignore']),
+        v.metadata({ typeString: '"warn" | "error" | "ignore"' }),
+        v.description($`
+          What to do when the replaceImage scan encounters images whose color
+          spaces are not DeviceCMYK or DeviceGray: log a warning, fail the build,
+          or do nothing. (default: warn)
         `),
       ),
       mapOutput: v.pipe(
@@ -329,7 +350,7 @@ const CmykSchema = v.pipe(
   v.union([v.boolean(), CmykConfigSchema]),
   v.description($`
     Convert device-cmyk() colors to CMYK in the output PDF.
-    Can be a boolean or a config object with overrideMap and warnUnmapped options.
+    Can be a boolean or a config object.
   `),
 );
 

--- a/src/core/build.ts
+++ b/src/core/build.ts
@@ -37,7 +37,7 @@ export async function build(
   let vivliostyleConfig =
     (await loadVivliostyleConfig(inlineConfig)) ??
     setupConfigFromFlags(inlineConfig);
-  warnDeprecatedConfig(vivliostyleConfig);
+  warnDeprecatedConfig(vivliostyleConfig, inlineConfig);
   vivliostyleConfig = mergeInlineConfig(vivliostyleConfig, {
     ...inlineConfig,
     quick: false,

--- a/src/core/preview.ts
+++ b/src/core/preview.ts
@@ -21,7 +21,7 @@ export async function preview(
   let vivliostyleConfig =
     (await loadVivliostyleConfig(inlineConfig)) ??
     setupConfigFromFlags(inlineConfig);
-  warnDeprecatedConfig(vivliostyleConfig);
+  warnDeprecatedConfig(vivliostyleConfig, inlineConfig);
   vivliostyleConfig = mergeInlineConfig(vivliostyleConfig, inlineConfig);
   const { tasks, inlineOptions } = vivliostyleConfig;
   Logger.debug('preview > vivliostyleConfig %O', vivliostyleConfig);

--- a/src/output/cmyk.ts
+++ b/src/output/cmyk.ts
@@ -107,14 +107,15 @@ function processContents(
 export async function convertCmykColors({
   pdf,
   colorMap,
-  warnUnmapped,
+  unmappedColors,
 }: {
   pdf: Uint8Array;
   colorMap: CmykMap;
-  warnUnmapped: boolean;
+  unmappedColors: Set<string> | null;
 }): Promise<Uint8Array> {
   const mupdf = await importNodeModule('mupdf');
-  const warnedColors = new Set<string>();
+  const foundUnmappedColors = unmappedColors ?? new Set<string>();
+  const warnUnmapped = unmappedColors !== null;
   const processedXObjects = new Set<number>();
 
   using doc = disposable(
@@ -132,7 +133,13 @@ export async function convertCmykColors({
 
     const contents = pageObj.get('Contents');
     if (contents) {
-      processContents(contents, colorMap, warnUnmapped, warnedColors, mupdf);
+      processContents(
+        contents,
+        colorMap,
+        warnUnmapped,
+        foundUnmappedColors,
+        mupdf,
+      );
     }
 
     const resources = pageObj.get('Resources');
@@ -141,7 +148,7 @@ export async function convertCmykColors({
         resources,
         colorMap,
         warnUnmapped,
-        warnedColors,
+        foundUnmappedColors,
         mupdf,
         processedXObjects,
       );
@@ -167,12 +174,18 @@ export async function convertCmykColors({
         continue;
       }
       if (n.isStream()) {
-        processStream(n, colorMap, warnUnmapped, warnedColors, mupdf);
+        processStream(n, colorMap, warnUnmapped, foundUnmappedColors, mupdf);
       } else if (n.isDictionary()) {
         // Multiple appearance states
         n.forEach((val) => {
           if (val?.isStream()) {
-            processStream(val, colorMap, warnUnmapped, warnedColors, mupdf);
+            processStream(
+              val,
+              colorMap,
+              warnUnmapped,
+              foundUnmappedColors,
+              mupdf,
+            );
           }
         });
       }

--- a/src/output/image.ts
+++ b/src/output/image.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 
 import type * as mupdfType from 'mupdf';
 
-import type { ReplaceImageConfig } from '../config/resolve.js';
+import type { CmykConfig, ReplaceImageConfig } from '../config/resolve.js';
 import { Logger } from '../logger.js';
 import { importNodeModule } from '../node-modules.js';
 
@@ -60,6 +60,37 @@ interface ReplaceStats {
   total: number;
 }
 
+export interface DeviceCmykIncompatibleImage {
+  key: string | number;
+  colorSpace: string;
+  width: number;
+  height: number;
+  pageIndex: number;
+}
+
+function collectDeviceCmykIncompatibleImage(
+  image: mupdfType.Image,
+  key: string | number,
+  pageIndex: number,
+  found: DeviceCmykIncompatibleImage[],
+): void {
+  const colorSpace = image.getColorSpace()?.getName() ?? 'None';
+  if (
+    image.getImageMask() ||
+    colorSpace === 'DeviceCMYK' ||
+    colorSpace === 'DeviceGray'
+  ) {
+    return;
+  }
+  found.push({
+    key,
+    colorSpace,
+    width: image.getWidth(),
+    height: image.getHeight(),
+    pageIndex,
+  });
+}
+
 function addImagePreservingColorSpace(
   doc: mupdfType.PDFDocument,
   image: mupdfType.Image,
@@ -83,6 +114,7 @@ function addImagePreservingColorSpace(
 function replaceImagesInDocument(
   doc: mupdfType.PDFDocument,
   imagePairs: ImagePair[],
+  incompatibleImages: DeviceCmykIncompatibleImage[] | null,
 ): ReplaceStats {
   let replaced = 0;
   let total = 0;
@@ -119,18 +151,38 @@ function replaceImagesInDocument(
       total++;
 
       // Extract image from PDF
-      const pdfImage = doc.loadImage(value);
+      using pdfImage = disposable(doc.loadImage(value));
+      let replacementRef: mupdfType.PDFObject | undefined;
 
       // Find matching source image
       for (const pair of imagePairs) {
         if (imagesEqual(pdfImage, pair.srcImage)) {
-          const newImageRef = addImagePreservingColorSpace(doc, pair.destImage);
-          xobjects.put(key, newImageRef);
+          replacementRef = addImagePreservingColorSpace(doc, pair.destImage);
+          xobjects.put(key, replacementRef);
           replaced++;
           Logger.debug(
             `  Page ${i + 1}, ref "${key}": ${pair.sourcePath} -> ${pair.replacementPath}`,
           );
           break;
+        }
+      }
+
+      if (incompatibleImages) {
+        if (replacementRef) {
+          using replacementImage = disposable(doc.loadImage(replacementRef));
+          collectDeviceCmykIncompatibleImage(
+            replacementImage,
+            key,
+            i,
+            incompatibleImages,
+          );
+        } else {
+          collectDeviceCmykIncompatibleImage(
+            pdfImage,
+            key,
+            i,
+            incompatibleImages,
+          );
         }
       }
     }
@@ -142,22 +194,28 @@ function replaceImagesInDocument(
   return { replaced, total };
 }
 
-export async function replaceImages({
-  pdf,
-  replaceImageConfig,
-}: {
+export async function replaceImages(
+  pdf: Uint8Array,
+  {
+    replacements,
+    ifIncompatibleImagesFound,
+  }: {
+    replacements: ReplaceImageConfig;
+    ifIncompatibleImagesFound: CmykConfig['ifIncompatibleImagesFound'];
+  },
+): Promise<{
   pdf: Uint8Array;
-  replaceImageConfig: ReplaceImageConfig;
-}): Promise<Uint8Array> {
-  if (replaceImageConfig.length === 0) {
-    return pdf;
+  incompatibleImages: DeviceCmykIncompatibleImage[];
+}> {
+  if (replacements.length === 0 && ifIncompatibleImagesFound === 'ignore') {
+    return { pdf, incompatibleImages: [] };
   }
 
   const mupdf = await importNodeModule('mupdf');
 
   // Load image pairs
   const imagePairs: ImagePair[] = [];
-  for (const { source, replacement } of replaceImageConfig) {
+  for (const { source, replacement } of replacements) {
     let srcImage: mupdfType.Image;
     let destImage: mupdfType.Image;
 
@@ -195,8 +253,8 @@ export async function replaceImages({
     });
   }
 
-  if (imagePairs.length === 0) {
-    return pdf;
+  if (imagePairs.length === 0 && ifIncompatibleImagesFound === 'ignore') {
+    return { pdf, incompatibleImages: [] };
   }
 
   using doc = disposable(
@@ -207,10 +265,22 @@ export async function replaceImages({
     ) as mupdfType.PDFDocument,
   );
 
-  const stats = replaceImagesInDocument(doc, imagePairs);
+  const incompatibleImages: DeviceCmykIncompatibleImage[] = [];
+  const stats = replaceImagesInDocument(
+    doc,
+    imagePairs,
+    ifIncompatibleImagesFound === 'ignore' ? null : incompatibleImages,
+  );
   Logger.debug(`Replaced ${stats.replaced} of ${stats.total} images`);
+
+  if (imagePairs.length === 0) {
+    return { pdf, incompatibleImages };
+  }
 
   using outputBuffer = disposable(doc.saveToBuffer('compress'));
   // Create a copy to ensure the data remains valid after the buffer is destroyed
-  return new Uint8Array(outputBuffer.asUint8Array());
+  return {
+    pdf: new Uint8Array(outputBuffer.asUint8Array()),
+    incompatibleImages,
+  };
 }

--- a/src/output/pdf-postprocess.ts
+++ b/src/output/pdf-postprocess.ts
@@ -124,6 +124,7 @@ export class PostProcess {
     let pdf = await this.document.save();
     signal?.throwIfAborted();
 
+    const failures: string[] = [];
     if (cmyk) {
       const mergedMap: CmykMap = { ...cmykMap };
       for (const [rgb, cmykValue] of cmyk.overrideMap) {
@@ -132,11 +133,20 @@ export class PostProcess {
       }
 
       Logger.logInfo('Converting CMYK colors');
+      const unmappedColors =
+        cmyk.ifUnmappedColorsFound === 'ignore' ? null : new Set<string>();
       pdf = await convertCmykColors({
         pdf,
         colorMap: mergedMap,
-        warnUnmapped: cmyk.warnUnmapped,
+        unmappedColors,
       });
+      if (
+        cmyk.ifUnmappedColorsFound === 'error' &&
+        unmappedColors &&
+        unmappedColors.size > 0
+      ) {
+        failures.push(`${unmappedColors.size} RGB color(s) not mapped to CMYK`);
+      }
       signal?.throwIfAborted();
 
       if (cmyk.mapOutput) {
@@ -150,13 +160,37 @@ export class PostProcess {
       }
     }
 
-    if (replaceImage.length > 0) {
-      Logger.logInfo('Replacing images');
-      pdf = await replaceImages({
-        pdf,
-        replaceImageConfig: replaceImage,
+    const ifIncompatibleImagesFound = cmyk
+      ? cmyk.ifIncompatibleImagesFound
+      : 'ignore';
+    if (replaceImage.length > 0 || ifIncompatibleImagesFound !== 'ignore') {
+      if (replaceImage.length > 0) {
+        Logger.logInfo('Replacing images');
+      }
+      const result = await replaceImages(pdf, {
+        replacements: replaceImage,
+        ifIncompatibleImagesFound,
       });
+      pdf = result.pdf;
+      const { incompatibleImages } = result;
+      for (const incompatibleImage of incompatibleImages) {
+        Logger.logWarn(
+          `Image color space is incompatible with Device CMYK: ref "${incompatibleImage.key}" (${incompatibleImage.colorSpace}, ${incompatibleImage.width}x${incompatibleImage.height}) on page ${incompatibleImage.pageIndex + 1}`,
+        );
+      }
+      if (
+        ifIncompatibleImagesFound === 'error' &&
+        incompatibleImages.length > 0
+      ) {
+        failures.push(
+          `${incompatibleImages.length} image(s) incompatible with Device CMYK color`,
+        );
+      }
       signal?.throwIfAborted();
+    }
+
+    if (failures.length > 0) {
+      throw new Error(failures.join('; '));
     }
 
     if (preflight) {

--- a/src/vite-adapter.ts
+++ b/src/vite-adapter.ts
@@ -31,7 +31,7 @@ export async function createVitePlugin(
   const vivliostyleConfig =
     (await loadVivliostyleConfig(parsedInlineConfig)) ??
     setupConfigFromFlags(parsedInlineConfig);
-  warnDeprecatedConfig(vivliostyleConfig);
+  warnDeprecatedConfig(vivliostyleConfig, parsedInlineConfig);
   const { tasks, inlineOptions } = mergeInlineConfig(
     vivliostyleConfig,
     parsedInlineConfig,

--- a/tests/cmyk.test.ts
+++ b/tests/cmyk.test.ts
@@ -91,7 +91,7 @@ describe('convertCmykColors', () => {
     const destPdf = await convertCmykColors({
       pdf: srcPdf,
       colorMap,
-      warnUnmapped: false,
+      unmappedColors: null,
     });
 
     // Verify destination PDF contains CMYK operators
@@ -117,11 +117,31 @@ describe('convertCmykColors', () => {
     const destPdf = await convertCmykColors({
       pdf: srcPdf,
       colorMap,
-      warnUnmapped: false,
+      unmappedColors: null,
     });
 
     expect(destPdf).toBeInstanceOf(Uint8Array);
     expect(destPdf.length).toBeGreaterThan(0);
+  });
+
+  it('collects unmapped colors', async () => {
+    const srcPdf = fs.readFileSync(path.join(fixturesDir, 'text.pdf'));
+    const unmappedColors = new Set<string>();
+
+    await convertCmykColors({
+      pdf: srcPdf,
+      colorMap: {},
+      unmappedColors,
+    });
+
+    expect(unmappedColors.size).toBeGreaterThan(0);
+    for (const color of unmappedColors) {
+      expect(JSON.parse(color)).toMatchObject({
+        r: expect.any(Number),
+        g: expect.any(Number),
+        b: expect.any(Number),
+      });
+    }
   });
 
   it('preserves unmapped RGB colors', async () => {
@@ -131,7 +151,7 @@ describe('convertCmykColors', () => {
       pdf: srcPdf,
       // no colors will be converted
       colorMap: {},
-      warnUnmapped: false,
+      unmappedColors: null,
     });
 
     // Verify destination PDF still contains RGB operators

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -4,8 +4,15 @@ import { ValiError } from 'valibot';
 import { expect, it, onTestFinished, vi } from 'vitest';
 
 import { warnDeprecatedConfig } from '../src/config/load.js';
-import { UseTemporaryServerRoot } from '../src/config/resolve.js';
-import { VivliostyleConfigSchema } from '../src/config/schema.js';
+import { mergeInlineConfig } from '../src/config/merge.js';
+import {
+  resolveTaskConfig,
+  UseTemporaryServerRoot,
+} from '../src/config/resolve.js';
+import {
+  VivliostyleConfigSchema,
+  VivliostyleInlineConfig,
+} from '../src/config/schema.js';
 import { Logger } from '../src/logger.js';
 import { getTaskConfig, maskConfig, resolveFixture } from './command-util.js';
 
@@ -592,7 +599,8 @@ it('supports pdfPostprocess configuration', async () => {
   expect(config.outputs[0]).toMatchObject({
     format: 'pdf',
     cmyk: {
-      warnUnmapped: true,
+      ifUnmappedColorsFound: 'warn',
+      ifIncompatibleImagesFound: 'warn',
       overrideMap: [],
       reserveMap: [],
       mapOutput: undefined,
@@ -630,6 +638,212 @@ it('preserves sticky matching across independent source paths', async () => {
       replacement.endsWith('img_cmyk.tiff'),
     ),
   ).toBe(true);
+});
+
+it('resolves CMYK issue policies and the deprecated warnUnmapped option', async () => {
+  const defaulted = await getTaskConfig(['build'], resolveFixture('config'), {
+    entry: 'manuscript.md',
+    output: 'output.pdf',
+    pdfPostprocess: { cmyk: {} },
+  });
+  expect(defaulted.outputs[0]).toMatchObject({
+    cmyk: {
+      ifUnmappedColorsFound: 'warn',
+      ifIncompatibleImagesFound: 'warn',
+    },
+  });
+
+  const explicit = await getTaskConfig(['build'], resolveFixture('config'), {
+    entry: 'manuscript.md',
+    output: 'output.pdf',
+    pdfPostprocess: {
+      cmyk: {
+        ifUnmappedColorsFound: 'error',
+        ifIncompatibleImagesFound: 'ignore',
+      },
+    },
+  });
+  expect(explicit.outputs[0]).toMatchObject({
+    cmyk: {
+      ifUnmappedColorsFound: 'error',
+      ifIncompatibleImagesFound: 'ignore',
+    },
+  });
+
+  const legacy = await getTaskConfig(['build'], resolveFixture('config'), {
+    entry: 'manuscript.md',
+    output: 'output.pdf',
+    pdfPostprocess: { cmyk: { warnUnmapped: false } },
+  });
+  expect(legacy.outputs[0]).toMatchObject({
+    cmyk: { ifUnmappedColorsFound: 'ignore' },
+  });
+
+  const preferred = await getTaskConfig(['build'], resolveFixture('config'), {
+    entry: 'manuscript.md',
+    output: 'output.pdf',
+    pdfPostprocess: {
+      cmyk: { warnUnmapped: false, ifUnmappedColorsFound: 'error' },
+    },
+  });
+  expect(preferred.outputs[0]).toMatchObject({
+    cmyk: { ifUnmappedColorsFound: 'error' },
+  });
+});
+
+it('resolves a top-level CMYK config object', () => {
+  const mergedConfig = mergeInlineConfig(
+    v.parse(VivliostyleConfigSchema, {
+      entry: 'manuscript.md',
+      output: 'output.pdf',
+    }),
+    v.parse(VivliostyleInlineConfig, {
+      cwd: resolveFixture('config'),
+      cmyk: {
+        ifUnmappedColorsFound: 'error',
+        ifIncompatibleImagesFound: 'ignore',
+      },
+    }),
+  );
+
+  const config = resolveTaskConfig(
+    mergedConfig.tasks[0],
+    mergedConfig.inlineOptions,
+  );
+
+  expect(config.outputs[0]).toMatchObject({
+    cmyk: {
+      ifUnmappedColorsFound: 'error',
+      ifIncompatibleImagesFound: 'ignore',
+    },
+  });
+});
+
+it('preserves boolean CMYK config when the top-level API specifies false', () => {
+  const mergedConfig = mergeInlineConfig(
+    v.parse(VivliostyleConfigSchema, {
+      entry: 'manuscript.md',
+      output: 'output.pdf',
+      pdfPostprocess: { cmyk: true },
+    }),
+    v.parse(VivliostyleInlineConfig, {
+      cwd: resolveFixture('config'),
+      cmyk: false,
+    }),
+  );
+
+  const config = resolveTaskConfig(
+    mergedConfig.tasks[0],
+    mergedConfig.inlineOptions,
+  );
+
+  expect(config.outputs[0]).toMatchObject({
+    cmyk: {
+      ifUnmappedColorsFound: 'warn',
+      ifIncompatibleImagesFound: 'warn',
+    },
+  });
+});
+
+it('gives a config-file CMYK object priority over the top-level API', () => {
+  const mergedConfig = mergeInlineConfig(
+    v.parse(VivliostyleConfigSchema, {
+      entry: 'manuscript.md',
+      output: 'output.pdf',
+      pdfPostprocess: {
+        cmyk: {
+          ifUnmappedColorsFound: 'ignore',
+          ifIncompatibleImagesFound: 'warn',
+        },
+      },
+    }),
+    v.parse(VivliostyleInlineConfig, {
+      cwd: resolveFixture('config'),
+      cmyk: {
+        ifUnmappedColorsFound: 'error',
+        ifIncompatibleImagesFound: 'ignore',
+      },
+    }),
+  );
+
+  const config = resolveTaskConfig(
+    mergedConfig.tasks[0],
+    mergedConfig.inlineOptions,
+  );
+
+  expect(config.outputs[0]).toMatchObject({
+    cmyk: {
+      ifUnmappedColorsFound: 'ignore',
+      ifIncompatibleImagesFound: 'warn',
+    },
+  });
+});
+
+it('warns when build-level cmyk config uses warnUnmapped', () => {
+  const warn = vi.spyOn(Logger, 'logWarn').mockImplementation(() => {});
+  onTestFinished(() => warn.mockRestore());
+  const config = v.parse(VivliostyleConfigSchema, {
+    entry: 'manuscript.md',
+    pdfPostprocess: { cmyk: { warnUnmapped: true } },
+  });
+
+  warnDeprecatedConfig(config);
+
+  expect(warn).toHaveBeenCalledWith(
+    expect.stringContaining('ifUnmappedColorsFound'),
+  );
+});
+
+it('warns when output-level cmyk config uses warnUnmapped', () => {
+  const warn = vi.spyOn(Logger, 'logWarn').mockImplementation(() => {});
+  onTestFinished(() => warn.mockRestore());
+  const config = v.parse(VivliostyleConfigSchema, {
+    entry: 'manuscript.md',
+    output: {
+      path: 'output.pdf',
+      pdfPostprocess: { cmyk: { warnUnmapped: false } },
+    },
+  });
+
+  warnDeprecatedConfig(config);
+
+  expect(warn).toHaveBeenCalledWith(
+    expect.stringContaining('ifUnmappedColorsFound'),
+  );
+});
+
+it('warns when top-level cmyk config uses warnUnmapped', () => {
+  const warn = vi.spyOn(Logger, 'logWarn').mockImplementation(() => {});
+  onTestFinished(() => warn.mockRestore());
+  const config = v.parse(VivliostyleConfigSchema, {
+    entry: 'manuscript.md',
+  });
+  const inlineConfig = v.parse(VivliostyleInlineConfig, {
+    cmyk: { warnUnmapped: false },
+  });
+
+  warnDeprecatedConfig(config, inlineConfig);
+
+  expect(warn).toHaveBeenCalledWith(
+    expect.stringContaining('ifUnmappedColorsFound'),
+  );
+});
+
+it('does not warn for current top-level preflight options', () => {
+  const warn = vi.spyOn(Logger, 'logWarn').mockImplementation(() => {});
+  onTestFinished(() => warn.mockRestore());
+  const config = v.parse(VivliostyleConfigSchema, {
+    entry: 'manuscript.md',
+    output: 'output.pdf',
+  });
+  const inlineConfig = v.parse(VivliostyleInlineConfig, {
+    preflight: 'press-ready',
+    preflightOption: ['gray-scale'],
+  });
+
+  warnDeprecatedConfig(config, inlineConfig);
+
+  expect(warn).not.toHaveBeenCalled();
 });
 
 it('pdfPostprocess takes precedence over legacy pressReady option', async () => {
@@ -674,7 +888,8 @@ it('output-level pdfPostprocess overrides build-level', async () => {
   expect(config.outputs[0]).toMatchObject({
     format: 'pdf',
     cmyk: {
-      warnUnmapped: true,
+      ifUnmappedColorsFound: 'warn',
+      ifIncompatibleImagesFound: 'warn',
       overrideMap: [],
       reserveMap: [],
       mapOutput: undefined,

--- a/tests/image.test.ts
+++ b/tests/image.test.ts
@@ -57,59 +57,192 @@ async function getImageColorSpace(
   return colorSpace;
 }
 
+function findFirstImageXObject(xobjects: import('mupdf').PDFObject): {
+  key: string | number;
+  value: import('mupdf').PDFObject;
+} {
+  let found:
+    | { key: string | number; value: import('mupdf').PDFObject }
+    | undefined;
+  xobjects.forEach((value, key) => {
+    if (
+      found === undefined &&
+      value.resolve().get('Subtype')?.toString() === '/Image'
+    ) {
+      found = { key, value };
+    }
+  });
+  if (!found) {
+    throw new Error('No image XObject found');
+  }
+  return found;
+}
+
+async function convertFirstImageToIndexed(
+  pdf: Uint8Array,
+): Promise<Uint8Array> {
+  const mupdf = await import('mupdf');
+  const doc = mupdf.PDFDocument.openDocument(
+    pdf,
+    'application/pdf',
+  ) as import('mupdf').PDFDocument;
+  const page = doc.loadPage(0);
+  const xobjects = page.getObject().resolve().get('Resources').get('XObject');
+  const { value } = findFirstImageXObject(xobjects);
+  const resolved = value.resolve();
+  const width = resolved.get('Width').asNumber();
+  const height = resolved.get('Height').asNumber();
+  const palette = doc.addRawStream(
+    new Uint8Array([255, 0, 0, 0, 0, 255]),
+    doc.newDictionary(),
+  );
+  const colorSpace = doc.newArray();
+  for (const entry of [
+    doc.newName('Indexed'),
+    doc.newName('DeviceRGB'),
+    doc.newInteger(1),
+    palette,
+  ]) {
+    colorSpace.push(entry);
+  }
+  resolved.put('ColorSpace', colorSpace);
+  resolved.put('BitsPerComponent', doc.newInteger(8));
+  resolved.delete('Filter');
+  resolved.delete('DecodeParms');
+  value.writeRawStream(
+    new Uint8Array(width * height).map((_, index) => index % 2),
+  );
+  const output = doc.saveToBuffer('compress');
+  const result = new Uint8Array(output.asUint8Array());
+  output.destroy();
+  page.destroy();
+  doc.destroy();
+  return result;
+}
+
 describe('replaceImages', () => {
   it.each([
-    ['Gray', 'ck_gray.pgm', '/DeviceGray', 'DeviceGray'],
-    ['RGB', 'ck_rgb.png', '/DeviceRGB', 'DeviceRGB'],
-    ['CMYK', 'ck_cmyk.tiff', '/DeviceCMYK', 'DeviceCMYK'],
+    ['Gray', 'ck_gray.pgm', '/DeviceGray', 'DeviceGray', 0],
+    ['RGB', 'ck_rgb.png', '/DeviceRGB', 'DeviceRGB', 1],
+    ['CMYK', 'ck_cmyk.tiff', '/DeviceCMYK', 'DeviceCMYK', 0],
   ])(
     'embeds a Device%s replacement using the direct device color space',
-    async (_, replacement, objectColorSpace, imageColorSpace) => {
+    async (
+      _,
+      replacement,
+      objectColorSpace,
+      imageColorSpace,
+      incompatibleCount,
+    ) => {
       const srcPdf = fs.readFileSync(path.join(fixturesDir, 'image.pdf'));
-      const destPdf = await replaceImages({
-        pdf: srcPdf,
-        replaceImageConfig: [
+      const { pdf: destPdf, incompatibleImages } = await replaceImages(srcPdf, {
+        replacements: [
           {
             source: path.join(fixturesDir, 'ck_rgb.png'),
             replacement: path.join(fixturesDir, replacement),
           },
         ],
+        ifIncompatibleImagesFound: 'warn',
       });
 
       expect(await getImageColorSpace(destPdf)).toEqual({
         object: objectColorSpace,
         image: imageColorSpace,
       });
+      expect(incompatibleImages).toHaveLength(incompatibleCount);
     },
   );
 
   it('preserves an ICCBased replacement color space', async () => {
     const srcPdf = fs.readFileSync(path.join(fixturesDir, 'image.pdf'));
-    const destPdf = await replaceImages({
-      pdf: srcPdf,
-      replaceImageConfig: [
+    const { pdf: destPdf, incompatibleImages } = await replaceImages(srcPdf, {
+      replacements: [
         {
           source: path.join(fixturesDir, 'ck_rgb.png'),
           replacement: path.join(fixturesDir, '..', 'cover', 'arch.jpg'),
         },
       ],
+      ifIncompatibleImagesFound: 'warn',
     });
 
     expect(await getImageColorSpace(destPdf)).toEqual({
       object: '/ICCBased',
       image: 'ICCBased(RGB,sRGB IEC61966-2.1)',
     });
+    expect(incompatibleImages).toEqual([
+      expect.objectContaining({
+        colorSpace: expect.stringMatching(/^ICCBased/v),
+      }),
+    ]);
   });
 
-  it('returns original PDF when replaceImageConfig is empty', async () => {
+  it('returns the original PDF without scanning when replacements are empty and the policy is ignore', async () => {
     const srcPdf = fs.readFileSync(path.join(fixturesDir, 'image.pdf'));
 
-    const destPdf = await replaceImages({
-      pdf: srcPdf,
-      replaceImageConfig: [],
+    const result = await replaceImages(srcPdf, {
+      replacements: [],
+      ifIncompatibleImagesFound: 'ignore',
     });
 
-    // Should return the same PDF
-    expect(destPdf).toEqual(srcPdf);
+    expect(result).toEqual({ pdf: srcPdf, incompatibleImages: [] });
+  });
+
+  it('reports incompatible images when replacements are empty', async () => {
+    const pdf = fs.readFileSync(path.join(fixturesDir, 'image.pdf'));
+
+    const result = await replaceImages(pdf, {
+      replacements: [],
+      ifIncompatibleImagesFound: 'warn',
+    });
+
+    expect(result.pdf).toEqual(pdf);
+    expect(result.incompatibleImages).toEqual([
+      {
+        key: expect.anything(),
+        colorSpace: expect.any(String),
+        width: expect.any(Number),
+        height: expect.any(Number),
+        pageIndex: 0,
+      },
+    ]);
+  });
+
+  it('reports indexed RGB images', async () => {
+    const pdf = fs.readFileSync(path.join(fixturesDir, 'image.pdf'));
+    const indexedPdf = await convertFirstImageToIndexed(pdf);
+
+    const result = await replaceImages(indexedPdf, {
+      replacements: [],
+      ifIncompatibleImagesFound: 'warn',
+    });
+
+    expect(result.incompatibleImages).toHaveLength(1);
+  });
+
+  it('reports unmatched images encountered by the replacement scan', async () => {
+    const pdf = fs.readFileSync(path.join(fixturesDir, 'image.pdf'));
+
+    const result = await replaceImages(pdf, {
+      replacements: [
+        {
+          source: path.join(fixturesDir, '..', 'cover', 'arch.jpg'),
+          replacement: path.join(fixturesDir, 'ck_cmyk.tiff'),
+        },
+      ],
+      ifIncompatibleImagesFound: 'error',
+    });
+
+    expect(result.incompatibleImages).toHaveLength(1);
+  });
+
+  it('accepts PDFs without images', async () => {
+    const pdf = fs.readFileSync(path.join(fixturesDir, 'text.pdf'));
+
+    const result = await replaceImages(pdf, {
+      replacements: [],
+      ifIncompatibleImagesFound: 'warn',
+    });
+
+    expect(result.incompatibleImages).toEqual([]);
   });
 });

--- a/tests/pdf-postprocess.test.ts
+++ b/tests/pdf-postprocess.test.ts
@@ -1,0 +1,143 @@
+import { randomUUID } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { expect, it, vi } from 'vitest';
+
+import type { CmykConfig } from '../src/config/resolve.js';
+import { Logger } from '../src/logger.js';
+import { PostProcess } from '../src/output/pdf-postprocess.js';
+
+const fixturesDir = path.join(import.meta.dirname, 'fixtures', 'cmyk');
+const temporaryDir = path.join(import.meta.dirname, '..', '.tmp');
+
+function cmykConfig(overrides: Partial<CmykConfig> = {}): CmykConfig {
+  return {
+    ifUnmappedColorsFound: 'warn',
+    ifIncompatibleImagesFound: 'warn',
+    overrideMap: [],
+    reserveMap: [],
+    mapOutput: undefined,
+    ...overrides,
+  };
+}
+
+async function runSave(
+  pdf: Uint8Array,
+  cmyk: CmykConfig | false,
+): Promise<{ error: Error | null; written: boolean; warnings: string[] }> {
+  fs.mkdirSync(temporaryDir, { recursive: true });
+  const output = path.join(temporaryDir, `cmyk-check-${randomUUID()}.pdf`);
+  const warning = vi.spyOn(Logger, 'logWarn').mockImplementation(() => {});
+  let error: Error | null = null;
+
+  try {
+    const postProcess = await PostProcess.load(pdf);
+    await postProcess.save(output, {
+      preflight: undefined,
+      preflightOption: [],
+      image: '',
+      cmyk,
+      cmykMap: {},
+      replaceImage: [],
+    });
+  } catch (cause) {
+    error = cause instanceof Error ? cause : new Error(String(cause));
+  }
+
+  const warnings = warning.mock.calls.flat().map(String);
+  warning.mockRestore();
+  const written = fs.existsSync(output);
+  fs.rmSync(output, { force: true });
+  return { error, written, warnings };
+}
+
+it('warns about unmapped colors and incompatible images by default', async () => {
+  const pdf = fs.readFileSync(path.join(fixturesDir, 'image.pdf'));
+
+  const result = await runSave(pdf, cmykConfig());
+
+  expect(result.error).toBeNull();
+  expect(result.written).toBe(true);
+  expect(result.warnings).toContainEqual(
+    expect.stringContaining('RGB color not mapped to CMYK'),
+  );
+  expect(result.warnings).toContainEqual(
+    expect.stringContaining('incompatible with Device CMYK'),
+  );
+});
+
+it('fails before writing when an incompatible image is found', async () => {
+  const pdf = fs.readFileSync(path.join(fixturesDir, 'image.pdf'));
+
+  const result = await runSave(
+    pdf,
+    cmykConfig({ ifIncompatibleImagesFound: 'error' }),
+  );
+
+  expect(result.error?.message).toContain(
+    'image(s) incompatible with Device CMYK color',
+  );
+  expect(result.written).toBe(false);
+});
+
+it('fails before writing when an unmapped color is found', async () => {
+  const pdf = fs.readFileSync(path.join(fixturesDir, 'text.pdf'));
+
+  const result = await runSave(
+    pdf,
+    cmykConfig({
+      ifUnmappedColorsFound: 'error',
+      ifIncompatibleImagesFound: 'ignore',
+    }),
+  );
+
+  expect(result.error?.message).toContain('RGB color(s) not mapped to CMYK');
+  expect(result.written).toBe(false);
+  expect(result.warnings).toContainEqual(
+    expect.stringContaining('RGB color not mapped to CMYK'),
+  );
+});
+
+it('combines color and image failures', async () => {
+  const pdf = fs.readFileSync(path.join(fixturesDir, 'image.pdf'));
+
+  const result = await runSave(
+    pdf,
+    cmykConfig({
+      ifUnmappedColorsFound: 'error',
+      ifIncompatibleImagesFound: 'error',
+    }),
+  );
+
+  expect(result.error?.message).toMatch(
+    /RGB color\(s\) not mapped to CMYK; .*image\(s\) incompatible with Device CMYK/v,
+  );
+  expect(result.written).toBe(false);
+});
+
+it('skips both checks when configured to ignore them', async () => {
+  const pdf = fs.readFileSync(path.join(fixturesDir, 'image.pdf'));
+
+  const result = await runSave(
+    pdf,
+    cmykConfig({
+      ifUnmappedColorsFound: 'ignore',
+      ifIncompatibleImagesFound: 'ignore',
+    }),
+  );
+
+  expect(result.error).toBeNull();
+  expect(result.written).toBe(true);
+  expect(result.warnings).toEqual([]);
+});
+
+it('skips image compatibility checks when CMYK processing is disabled', async () => {
+  const pdf = fs.readFileSync(path.join(fixturesDir, 'image.pdf'));
+
+  const result = await runSave(pdf, false);
+
+  expect(result.error).toBeNull();
+  expect(result.written).toBe(true);
+  expect(result.warnings).toEqual([]);
+});


### PR DESCRIPTION
#766 のうち、未マップのRGB色とDeviceCMYK互換でない画像の扱いを指定する`ifUnmappedColorsFound`と`ifIncompatibleImagesFound`を追加するPRです。どちらも`"warn"`、`"error"`、`"ignore"`を受け取り、既定値は`"warn"`です。`"error"`では検出結果をまとめ、PDFを書き出す前にビルドを失敗させます。

`ifUnmappedColorsFound`は既存の`warnUnmapped`を置き換えます。`warnUnmapped`は非推奨とし、`true`を`"warn"`、`false`を`"ignore"`として引き続き解決します。両方が指定された場合は`ifUnmappedColorsFound`を使用します。

`ifIncompatibleImagesFound`は`ifUnmappedColorsFound`の画像版で、（マスク画像を除き）画像の色空間が`DeviceCMYK`または`DeviceGray`でなければ、指定されたポリシーに従って報告します。 #893 を経て要件を改め、名称も変更しました。

Assisted-by: Codex:gpt-5

<details>
<summary>How the AI was used</summary>

- The human author defined the two policies and their compatibility semantics, required image validation to share the `replaceImage` traversal, and retained the existing precedence of config-file CMYK objects.
- Codex implemented the schema, config resolution, image validation within the replacement traversal, aggregated failures, tests, generated documentation, changeset, and CMYK example updates. Codex also drafted this pull request description and ran the type-checker, linter, formatter, builds, test suite, and example build.
- The human author reviewed the implementation and corrected the configuration and image-traversal semantics. Two independent Codex reviewers audited the complete tracked diff without receiving the change history.

</details>