### PR TITLE
fix: Remove orphaned image objects after replacement

### DIFF
--- a/.changeset/clean-images-prune.md
+++ b/.changeset/clean-images-prune.md
@@ -2,4 +2,5 @@
 '@vivliostyle/cli': patch
 ---
 
-Remove replaced image objects and their unused dependencies when no references to them remain.
+Fix `pdfPostprocess.replaceImage` leaving original images and their dependencies inside the output PDF after replacement, even when no references to them remain.
+

--- a/.changeset/clean-images-prune.md
+++ b/.changeset/clean-images-prune.md
@@ -1,0 +1,5 @@
+---
+'@vivliostyle/cli': patch
+---
+
+Remove replaced image objects and their unused dependencies when no references to them remain.

--- a/src/output/image.ts
+++ b/src/output/image.ts
@@ -94,8 +94,15 @@ function collectDeviceCmykIncompatibleImage(
 function addImagePreservingColorSpace(
   doc: mupdfType.PDFDocument,
   image: mupdfType.Image,
-): mupdfType.PDFObject {
+): { ref: mupdfType.PDFObject; objectNumbers: Set<number> } {
+  const xrefLengthBefore = doc.countObjects();
   const ref = doc.addImage(image);
+  const objectNumbers = collectReachableObjectNumbers([ref]);
+  for (const objectNumber of objectNumbers) {
+    if (objectNumber < xrefLengthBefore) {
+      objectNumbers.delete(objectNumber);
+    }
+  }
   const colorSpaceName = image.getColorSpace()?.getName();
 
   if (
@@ -108,7 +115,89 @@ function addImagePreservingColorSpace(
     ref.resolve().put('ColorSpace', colorSpaceName);
   }
 
-  return ref;
+  return { ref, objectNumbers };
+}
+
+function collectReachableObjectNumbers(
+  roots: Iterable<mupdfType.PDFObject>,
+): Set<number> {
+  const reachable = new Set<number>();
+  const pending = [...roots];
+
+  while (pending.length > 0) {
+    const object = pending.pop();
+    if (!object) {
+      break;
+    }
+    if (object.isIndirect()) {
+      const objectNumber = object.asIndirect();
+      if (reachable.has(objectNumber)) {
+        continue;
+      }
+      reachable.add(objectNumber);
+      pending.push(object.resolve());
+      continue;
+    }
+    if (object.isArray() || object.isDictionary()) {
+      object.forEach((value) => {
+        pending.push(value);
+      });
+    }
+  }
+
+  return reachable;
+}
+
+function removeUnreferencedCandidates(
+  doc: mupdfType.PDFDocument,
+  candidates: Set<number>,
+): void {
+  if (candidates.size === 0) {
+    return;
+  }
+
+  const roots: mupdfType.PDFObject[] = [doc.getTrailer()];
+  const xrefLength = doc.countObjects();
+  for (let objectNumber = 1; objectNumber < xrefLength; objectNumber++) {
+    if (candidates.has(objectNumber)) {
+      continue;
+    }
+    const ref = doc.newIndirect(objectNumber);
+    if (!ref.resolve().isNull()) {
+      roots.push(ref);
+    }
+  }
+  const referenced = collectReachableObjectNumbers(roots);
+
+  for (const objectNumber of candidates) {
+    if (!referenced.has(objectNumber)) {
+      doc.deleteObject(objectNumber);
+    }
+  }
+}
+
+function addReplacementImage(
+  doc: mupdfType.PDFDocument,
+  source: mupdfType.PDFObject,
+  image: mupdfType.Image,
+  cleanupCandidates: Set<number>,
+): mupdfType.PDFObject {
+  const sourceObjectNumbers = collectReachableObjectNumbers([source]);
+  const replacement = addImagePreservingColorSpace(doc, image);
+  const replacementObjectNumbers = collectReachableObjectNumbers([
+    replacement.ref,
+  ]);
+
+  for (const objectNumber of sourceObjectNumbers) {
+    cleanupCandidates.add(objectNumber);
+  }
+  for (const objectNumber of replacement.objectNumbers) {
+    if (!replacementObjectNumbers.has(objectNumber)) {
+      cleanupCandidates.add(objectNumber);
+    }
+  }
+
+  return replacement.ref;
 }
 
 function replaceImagesInDocument(
@@ -118,6 +207,7 @@ function replaceImagesInDocument(
 ): ReplaceStats {
   let replaced = 0;
   let total = 0;
+  const cleanupCandidates = new Set<number>();
 
   const pageCount = doc.countPages();
 
@@ -157,7 +247,12 @@ function replaceImagesInDocument(
       // Find matching source image
       for (const pair of imagePairs) {
         if (imagesEqual(pdfImage, pair.srcImage)) {
-          replacementRef = addImagePreservingColorSpace(doc, pair.destImage);
+          replacementRef = addReplacementImage(
+            doc,
+            value,
+            pair.destImage,
+            cleanupCandidates,
+          );
           xobjects.put(key, replacementRef);
           replaced++;
           Logger.debug(
@@ -191,6 +286,7 @@ function replaceImagesInDocument(
     pageObj.put('Resources', res);
   }
 
+  removeUnreferencedCandidates(doc, cleanupCandidates);
   return { replaced, total };
 }
 

--- a/tests/image.test.ts
+++ b/tests/image.test.ts
@@ -57,6 +57,291 @@ async function getImageColorSpace(
   return colorSpace;
 }
 
+async function getXrefImageColorSpaces(pdf: Uint8Array): Promise<string[]> {
+  const mupdf = await import('mupdf');
+  const doc = mupdf.PDFDocument.openDocument(
+    pdf,
+    'application/pdf',
+  ) as import('mupdf').PDFDocument;
+  const colorSpaces: string[] = [];
+
+  for (
+    let objectNumber = 1;
+    objectNumber < doc.countObjects();
+    objectNumber++
+  ) {
+    try {
+      const ref = doc.newIndirect(objectNumber);
+      if (ref.resolve().get('Subtype')?.toString() !== '/Image') {
+        continue;
+      }
+      const image = doc.loadImage(ref);
+      colorSpaces.push(image.getColorSpace()?.getName() ?? 'Unknown');
+      image.destroy();
+    } catch {
+      continue;
+    }
+  }
+
+  doc.destroy();
+  return colorSpaces;
+}
+
+async function addUnreferencedObject(
+  pdf: Uint8Array,
+  type: string,
+): Promise<Uint8Array> {
+  const mupdf = await import('mupdf');
+  const doc = mupdf.PDFDocument.openDocument(
+    pdf,
+    'application/pdf',
+  ) as import('mupdf').PDFDocument;
+  const object = doc.newDictionary();
+  object.put('Type', doc.newName(type));
+  doc.addObject(object);
+  const output = doc.saveToBuffer('compress');
+  const result = new Uint8Array(output.asUint8Array());
+  output.destroy();
+  doc.destroy();
+  return result;
+}
+
+function collectReachableObjectNumbers(
+  root: import('mupdf').PDFObject,
+): Set<number> {
+  const reachable = new Set<number>();
+  const pending = [root];
+
+  while (pending.length > 0) {
+    const object = pending.pop();
+    if (!object) {
+      break;
+    }
+    if (object.isIndirect()) {
+      const objectNumber = object.asIndirect();
+      if (reachable.has(objectNumber)) {
+        continue;
+      }
+      reachable.add(objectNumber);
+      pending.push(object.resolve());
+      continue;
+    }
+    if (object.isArray() || object.isDictionary()) {
+      object.forEach((value) => {
+        pending.push(value);
+      });
+    }
+  }
+
+  return reachable;
+}
+
+async function countUnreachableObjects(pdf: Uint8Array): Promise<number> {
+  const mupdf = await import('mupdf');
+  const doc = mupdf.PDFDocument.openDocument(
+    pdf,
+    'application/pdf',
+  ) as import('mupdf').PDFDocument;
+  const reachable = collectReachableObjectNumbers(doc.getTrailer());
+  let count = 0;
+
+  for (
+    let objectNumber = 1;
+    objectNumber < doc.countObjects();
+    objectNumber++
+  ) {
+    try {
+      if (
+        !reachable.has(objectNumber) &&
+        !doc.newIndirect(objectNumber).resolve().isNull()
+      ) {
+        count++;
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  doc.destroy();
+  return count;
+}
+
+async function retainFirstPageImageFromCatalog(
+  pdf: Uint8Array,
+): Promise<Uint8Array> {
+  const mupdf = await import('mupdf');
+  const doc = mupdf.PDFDocument.openDocument(
+    pdf,
+    'application/pdf',
+  ) as import('mupdf').PDFDocument;
+  const page = doc.loadPage(0);
+  const xobjects = page.getObject().resolve().get('Resources').get('XObject');
+  const { value } = findFirstImageXObject(xobjects);
+  doc.getTrailer().get('Root').resolve().put('RetainedImage', value);
+  const output = doc.saveToBuffer('compress');
+  const result = new Uint8Array(output.asUint8Array());
+  output.destroy();
+  page.destroy();
+  doc.destroy();
+  return result;
+}
+
+async function retainFirstPageImageFromOrphan(
+  pdf: Uint8Array,
+): Promise<Uint8Array> {
+  const mupdf = await import('mupdf');
+  const doc = mupdf.PDFDocument.openDocument(
+    pdf,
+    'application/pdf',
+  ) as import('mupdf').PDFDocument;
+  const page = doc.loadPage(0);
+  const xobjects = page.getObject().resolve().get('Resources').get('XObject');
+  const { value } = findFirstImageXObject(xobjects);
+  const orphan = doc.newDictionary();
+  orphan.put('Type', doc.newName('ImageRetainingOrphan'));
+  orphan.put('Image', value);
+  doc.addObject(orphan);
+  const output = doc.saveToBuffer('compress');
+  const result = new Uint8Array(output.asUint8Array());
+  output.destroy();
+  page.destroy();
+  doc.destroy();
+  return result;
+}
+
+async function getRetainedImageColorSpace(pdf: Uint8Array): Promise<string> {
+  const mupdf = await import('mupdf');
+  const doc = mupdf.PDFDocument.openDocument(
+    pdf,
+    'application/pdf',
+  ) as import('mupdf').PDFDocument;
+
+  for (
+    let objectNumber = 1;
+    objectNumber < doc.countObjects();
+    objectNumber++
+  ) {
+    try {
+      const object = doc.newIndirect(objectNumber).resolve();
+      if (object.get('Type').toString() !== '/ImageRetainingOrphan') {
+        continue;
+      }
+      const image = doc.loadImage(object.get('Image'));
+      const colorSpace = image.getColorSpace()?.getName() ?? 'Unknown';
+      image.destroy();
+      doc.destroy();
+      return colorSpace;
+    } catch {
+      continue;
+    }
+  }
+
+  doc.destroy();
+  throw new Error('Image-retaining orphan not found');
+}
+
+async function createPdfWithSharedSoftMask(
+  pdf: Uint8Array,
+): Promise<Uint8Array> {
+  const mupdf = await import('mupdf');
+  const doc = mupdf.PDFDocument.openDocument(
+    pdf,
+    'application/pdf',
+  ) as import('mupdf').PDFDocument;
+  const page = doc.loadPage(0);
+  const pageObject = page.getObject().resolve();
+  const resources = pageObject.get('Resources');
+  const xobjects = resources.get('XObject');
+  const maskImage = new mupdf.Image(
+    fs.readFileSync(path.join(fixturesDir, 'ck_gray.pgm')),
+  );
+  const maskRef = doc.addImage(maskImage);
+  maskRef.resolve().put('ColorSpace', 'DeviceGray');
+  const carrierImage = new mupdf.Image(
+    fs.readFileSync(path.join(fixturesDir, 'ck_rgb.png')),
+  );
+  const carrierRef = doc.addImage(carrierImage);
+  carrierRef.resolve().put('SMask', maskRef);
+  xobjects.put('X4', maskRef);
+  xobjects.put('Carrier', carrierRef);
+  resources.put('XObject', xobjects);
+  pageObject.put('Resources', resources);
+  const output = doc.saveToBuffer('compress');
+  const result = new Uint8Array(output.asUint8Array());
+  output.destroy();
+  carrierImage.destroy();
+  maskImage.destroy();
+  page.destroy();
+  doc.destroy();
+  return result;
+}
+
+async function getSoftMaskColorSpace(pdf: Uint8Array): Promise<string> {
+  const mupdf = await import('mupdf');
+  const doc = mupdf.PDFDocument.openDocument(
+    pdf,
+    'application/pdf',
+  ) as import('mupdf').PDFDocument;
+
+  for (
+    let objectNumber = 1;
+    objectNumber < doc.countObjects();
+    objectNumber++
+  ) {
+    try {
+      const object = doc.newIndirect(objectNumber).resolve();
+      if (object.get('Subtype').toString() !== '/Image') {
+        continue;
+      }
+      const softMask = object.get('SMask');
+      if (softMask.isNull()) {
+        continue;
+      }
+      const image = doc.loadImage(softMask);
+      const colorSpace = image.getColorSpace()?.getName() ?? 'Unknown';
+      image.destroy();
+      doc.destroy();
+      return colorSpace;
+    } catch {
+      continue;
+    }
+  }
+
+  doc.destroy();
+  throw new Error('Soft mask not found');
+}
+
+async function referenceCatalogFromFirstPageImage(
+  pdf: Uint8Array,
+): Promise<Uint8Array> {
+  const mupdf = await import('mupdf');
+  const doc = mupdf.PDFDocument.openDocument(
+    pdf,
+    'application/pdf',
+  ) as import('mupdf').PDFDocument;
+  const page = doc.loadPage(0);
+  const xobjects = page.getObject().resolve().get('Resources').get('XObject');
+  const { value } = findFirstImageXObject(xobjects);
+  value.resolve().put('Catalog', doc.getTrailer().get('Root'));
+  const output = doc.saveToBuffer('compress');
+  const result = new Uint8Array(output.asUint8Array());
+  output.destroy();
+  page.destroy();
+  doc.destroy();
+  return result;
+}
+
+async function getPageCount(pdf: Uint8Array): Promise<number> {
+  const mupdf = await import('mupdf');
+  const doc = mupdf.PDFDocument.openDocument(
+    pdf,
+    'application/pdf',
+  ) as import('mupdf').PDFDocument;
+  const pageCount = doc.countPages();
+  doc.destroy();
+  return pageCount;
+}
+
 function findFirstImageXObject(xobjects: import('mupdf').PDFObject): {
   key: string | number;
   value: import('mupdf').PDFObject;
@@ -174,6 +459,119 @@ describe('replaceImages', () => {
         colorSpace: expect.stringMatching(/^ICCBased/v),
       }),
     ]);
+  });
+
+  it('removes replaced image objects that are no longer referenced', async () => {
+    const srcPdf = fs.readFileSync(path.join(fixturesDir, 'image.pdf'));
+    const { pdf: destPdf } = await replaceImages(srcPdf, {
+      replacements: [
+        {
+          source: path.join(fixturesDir, 'ck_rgb.png'),
+          replacement: path.join(fixturesDir, 'ck_cmyk.tiff'),
+        },
+      ],
+      ifIncompatibleImagesFound: 'warn',
+    });
+
+    expect(await getXrefImageColorSpaces(destPdf)).toEqual(['DeviceCMYK']);
+    expect(await countUnreachableObjects(destPdf)).toBe(0);
+  });
+
+  it('preserves unrelated unreferenced objects', async () => {
+    const srcPdf = fs.readFileSync(path.join(fixturesDir, 'image.pdf'));
+    const pdfWithOrphan = await addUnreferencedObject(
+      srcPdf,
+      'UnrelatedOrphan',
+    );
+    const unreachableBefore = await countUnreachableObjects(pdfWithOrphan);
+    const { pdf: destPdf } = await replaceImages(pdfWithOrphan, {
+      replacements: [
+        {
+          source: path.join(fixturesDir, 'ck_rgb.png'),
+          replacement: path.join(fixturesDir, 'ck_cmyk.tiff'),
+        },
+      ],
+      ifIncompatibleImagesFound: 'warn',
+    });
+
+    expect(unreachableBefore).toBeGreaterThan(0);
+    expect(await countUnreachableObjects(destPdf)).toBe(unreachableBefore);
+  });
+
+  it('preserves replaced image objects that remain referenced', async () => {
+    const srcPdf = fs.readFileSync(path.join(fixturesDir, 'image.pdf'));
+    const pdfWithRetainedImage = await retainFirstPageImageFromCatalog(srcPdf);
+    const sourceColorSpaces =
+      await getXrefImageColorSpaces(pdfWithRetainedImage);
+    const { pdf: destPdf } = await replaceImages(pdfWithRetainedImage, {
+      replacements: [
+        {
+          source: path.join(fixturesDir, 'ck_rgb.png'),
+          replacement: path.join(fixturesDir, 'ck_cmyk.tiff'),
+        },
+      ],
+      ifIncompatibleImagesFound: 'warn',
+    });
+
+    expect(await getXrefImageColorSpaces(destPdf)).toEqual([
+      ...sourceColorSpaces,
+      'DeviceCMYK',
+    ]);
+  });
+
+  it('preserves orphan objects that reference replaced images', async () => {
+    const srcPdf = fs.readFileSync(path.join(fixturesDir, 'image.pdf'));
+    const pdfWithOrphan = await retainFirstPageImageFromOrphan(srcPdf);
+    const retainedColorSpaceBefore =
+      await getRetainedImageColorSpace(pdfWithOrphan);
+    const { pdf: destPdf } = await replaceImages(pdfWithOrphan, {
+      replacements: [
+        {
+          source: path.join(fixturesDir, 'ck_rgb.png'),
+          replacement: path.join(fixturesDir, 'ck_cmyk.tiff'),
+        },
+      ],
+      ifIncompatibleImagesFound: 'warn',
+    });
+
+    expect(await getRetainedImageColorSpace(destPdf)).toBe(
+      retainedColorSpaceBefore,
+    );
+  });
+
+  it('preserves replaced images that remain referenced as soft masks', async () => {
+    const srcPdf = fs.readFileSync(path.join(fixturesDir, 'image.pdf'));
+    const pdfWithSharedSoftMask = await createPdfWithSharedSoftMask(srcPdf);
+    const { pdf: destPdf } = await replaceImages(pdfWithSharedSoftMask, {
+      replacements: [
+        {
+          source: path.join(fixturesDir, 'ck_gray.pgm'),
+          replacement: path.join(fixturesDir, 'ck_cmyk.tiff'),
+        },
+      ],
+      ifIncompatibleImagesFound: 'warn',
+    });
+
+    expect(await getSoftMaskColorSpace(destPdf)).toBe('DeviceGray');
+    expect(await getXrefImageColorSpaces(destPdf)).toContain('DeviceCMYK');
+  });
+
+  it('preserves objects referenced from the trailer', async () => {
+    const srcPdf = fs.readFileSync(path.join(fixturesDir, 'image.pdf'));
+    const pdfWithCatalogReference =
+      await referenceCatalogFromFirstPageImage(srcPdf);
+    const { pdf: destPdf } = await replaceImages(pdfWithCatalogReference, {
+      replacements: [
+        {
+          source: path.join(fixturesDir, 'ck_rgb.png'),
+          replacement: path.join(fixturesDir, 'ck_cmyk.tiff'),
+        },
+      ],
+      ifIncompatibleImagesFound: 'warn',
+    });
+
+    expect(await getPageCount(destPdf)).toBe(1);
+    expect(await getXrefImageColorSpaces(destPdf)).toEqual(['DeviceCMYK']);
   });
 
   it('returns the original PDF without scanning when replacements are empty and the policy is ignore', async () => {


### PR DESCRIPTION
#766 にあった問題のうちの一つです。

`replaceImage`はページのXObject参照を置換後の画像へ差し替えますが、置換元の画像オブジェクトとその依存オブジェクトはxrefに残っていました。置換したPDFについて、印刷会社のチェックでRGB画像を検出した事例がありました。チェックの内部実装は不明ですが、紙面ではなく内部構造を直接読んでこの未使用画像を検知したものと思います。

このPRでは、置換完了後に参照が残っていない置換元画像とその依存オブジェクトを削除します。

Assisted-by: Codex:gpt-5

<details>
<summary>How the AI was used</summary>

- The human author identified the issue from an external printer's inspection result, established that replaced image objects remained in the PDF, required cleanup to stay scoped to replacement-related objects, rejected global garbage collection and compression changes, and chose to propagate reference-resolution errors rather than return an incomplete result.
- Codex inspected the relevant pull requests and PDF object behavior, implemented candidate-based reference analysis and cleanup, added regression tests and a changeset, drafted this pull request description, and ran the formatter, type-checker, linter, build, and test suite.
- The human author reviewed and refined the cleanup and error-handling semantics. Two independent Codex reviewers audited the complete uncommitted diff without receiving the change history.

</details>
