### PR TITLE
refactor: process PDF traversal with filter hooks

### DIFF
--- a/.changeset/fair-forms-visit.md
+++ b/.changeset/fair-forms-visit.md
@@ -1,0 +1,5 @@
+---
+"@vivliostyle/cli": patch
+---
+
+Refactor PDF post-processing to run CMYK color conversion and image processing as hooks during a shared traversal.

--- a/.changeset/fair-forms-visit.md
+++ b/.changeset/fair-forms-visit.md
@@ -2,4 +2,4 @@
 "@vivliostyle/cli": patch
 ---
 
-Refactor PDF post-processing to run CMYK color conversion and image processing as hooks during a shared traversal.
+Fix `pdfPostprocess.replaceImage` skipping images nested in Form XObjects.

--- a/src/output/cmyk.ts
+++ b/src/output/cmyk.ts
@@ -1,198 +1,134 @@
-import type * as mupdfType from 'mupdf';
+import type { CmykConfig } from '../config/resolve.js';
+import type { CMYKValue } from '../global-viewer.js';
+import { Logger } from '../logger.js';
+import { tokenize, type OperatorToken } from './pdf-stream.js';
+import type { PdfEditHook } from './pdf-visitor.js';
 
-import type { CmykMap } from '../global-viewer.js';
-import { importNodeModule } from '../node-modules.js';
-import { convertStreamColors } from './pdf-stream.js';
+/**
+ * `SRGBValue.MAX`
+ * @see https://github.com/vivliostyle/vivliostyle.js/blob/master/packages/core/src/vivliostyle/cmyk-store.ts
+ */
+const SRGB_MAX = 10000;
+/**
+ * `CMYKValue.MAX`
+ * @see https://github.com/vivliostyle/vivliostyle.js/blob/master/packages/core/src/vivliostyle/cmyk-store.ts
+ */
+const CMYK_MAX = 10000;
 
-interface Destroyable {
-  destroy(): void;
+function formatRgbKey(r: number, g: number, b: number): string {
+  const ri = Math.round(r * SRGB_MAX);
+  const gi = Math.round(g * SRGB_MAX);
+  const bi = Math.round(b * SRGB_MAX);
+  return JSON.stringify([ri, gi, bi]);
 }
 
-function disposable<T extends Destroyable>(obj: T): T & Disposable {
-  return Object.assign(obj, {
-    [Symbol.dispose]() {
-      obj.destroy();
+function formatUnmappedRgbKey(r: number, g: number, b: number): string {
+  const ri = Math.round(r * SRGB_MAX);
+  const gi = Math.round(g * SRGB_MAX);
+  const bi = Math.round(b * SRGB_MAX);
+  return JSON.stringify({ r: ri, g: gi, b: bi });
+}
+
+/**
+ * Convert RGB color operators to CMYK in a content stream
+ */
+function convertColors(
+  content: string,
+  colorMap: ReadonlyMap<string, CMYKValue>,
+  unmappedColors: Set<string> | null,
+): string {
+  const result: string[] = [];
+  const pendingNumbers: { value: number; raw: string }[] = [];
+
+  const flushPendingNumbers = () => {
+    for (const num of pendingNumbers) {
+      result.push(num.raw);
+    }
+    pendingNumbers.length = 0;
+  };
+
+  const convertRgbOperator = (
+    cmykOp: 'k' | 'K',
+    token: OperatorToken,
+  ): void => {
+    const b = pendingNumbers.pop();
+    const g = pendingNumbers.pop();
+    const r = pendingNumbers.pop();
+    /* v8 ignore next 3 */
+    if (!b || !g || !r) {
+      throw new Error('Expected at least three pending numbers for RGB color');
+    }
+    flushPendingNumbers();
+
+    const key = formatRgbKey(r.value, g.value, b.value);
+    const cmyk = colorMap.get(key);
+
+    if (!cmyk) {
+      result.push(r.raw, g.raw, b.raw, token.raw);
+      if (unmappedColors !== null) {
+        unmappedColors.add(formatUnmappedRgbKey(r.value, g.value, b.value));
+      }
+      return;
+    }
+    const c = (cmyk.c / CMYK_MAX).toString();
+    const m = (cmyk.m / CMYK_MAX).toString();
+    const y = (cmyk.y / CMYK_MAX).toString();
+    const k = (cmyk.k / CMYK_MAX).toString();
+    result.push(`${c} ${m} ${y} ${k} ${cmykOp}`);
+  };
+
+  for (const token of tokenize(content)) {
+    if (token.type === 'number') {
+      pendingNumbers.push({ value: token.value, raw: token.raw });
+    } else if (token.type === 'operator') {
+      const op = token.value;
+
+      // RGB color: r g b rg (non-stroking) or r g b RG (stroking)
+      const cmykOp = op === 'rg' ? 'k' : op === 'RG' ? 'K' : null;
+      if (cmykOp && pendingNumbers.length >= 3) {
+        convertRgbOperator(cmykOp, token);
+      } else {
+        flushPendingNumbers();
+        result.push(token.raw);
+      }
+    } else {
+      // Other token types - flush pending numbers and pass through
+      flushPendingNumbers();
+      result.push(token.raw);
+    }
+  }
+
+  // Flush any remaining pending numbers
+  flushPendingNumbers();
+
+  return result.join(' ');
+}
+
+export function createCmykColorHook(
+  colorMap: ReadonlyMap<string, CMYKValue>,
+  ifUnmappedColorsFound: CmykConfig['ifUnmappedColorsFound'],
+  failures: string[],
+): PdfEditHook {
+  const unmappedColors =
+    ifUnmappedColorsFound === 'ignore' ? null : new Set<string>();
+  return {
+    visit(node) {
+      if (node.kind !== 'content-stream') {
+        return;
+      }
+      const converted = convertColors(node.read(), colorMap, unmappedColors);
+      node.write(converted);
     },
-  });
-}
-
-function processStream(
-  stream: mupdfType.PDFObject,
-  colorMap: CmykMap,
-  warnUnmapped: boolean,
-  warnedColors: Set<string>,
-  mupdf: typeof import('mupdf'),
-): void {
-  const buffer = stream.readStream();
-  const content = buffer.asString();
-  const converted = convertStreamColors(
-    content,
-    colorMap,
-    warnUnmapped,
-    warnedColors,
-  );
-  stream.writeStream(new mupdf.Buffer(converted));
-}
-
-function processFormXObjects(
-  resources: mupdfType.PDFObject,
-  colorMap: CmykMap,
-  warnUnmapped: boolean,
-  warnedColors: Set<string>,
-  mupdf: typeof import('mupdf'),
-  processed: Set<number>,
-): void {
-  const xobjects = resources.get('XObject');
-  if (!xobjects || !xobjects.isDictionary()) {
-    return;
-  }
-
-  xobjects.forEach((xobj) => {
-    if (!xobj || !xobj.isStream()) {
-      return;
-    }
-
-    // Use original indirect reference for stream operations (see #735)
-    const objNum = xobj.asIndirect();
-    if (objNum && processed.has(objNum)) {
-      // Avoid circular references
-      return;
-    }
-    if (objNum) {
-      processed.add(objNum);
-    }
-
-    const subtype = xobj.get('Subtype');
-    if (!subtype || subtype.toString() !== '/Form') {
-      return;
-    }
-
-    processStream(xobj, colorMap, warnUnmapped, warnedColors, mupdf);
-    const nestedResources = xobj.get('Resources');
-    if (nestedResources && nestedResources.isDictionary()) {
-      processFormXObjects(
-        nestedResources,
-        colorMap,
-        warnUnmapped,
-        warnedColors,
-        mupdf,
-        processed,
-      );
-    }
-  });
-}
-
-function processContents(
-  contents: mupdfType.PDFObject,
-  colorMap: CmykMap,
-  warnUnmapped: boolean,
-  warnedColors: Set<string>,
-  mupdf: typeof import('mupdf'),
-): void {
-  if (contents.isArray()) {
-    // Multiple content streams
-    for (let i = 0; i < contents.length; i++) {
-      const streamObj = contents.get(i);
-      // Use original indirect reference for stream operations (see #735)
-      if (streamObj && streamObj.isStream()) {
-        processStream(streamObj, colorMap, warnUnmapped, warnedColors, mupdf);
+    complete() {
+      if (!unmappedColors) {
+        return;
       }
-    }
-  } else if (contents.isStream()) {
-    // Single content stream
-    processStream(contents, colorMap, warnUnmapped, warnedColors, mupdf);
-  }
-}
-
-export async function convertCmykColors({
-  pdf,
-  colorMap,
-  unmappedColors,
-}: {
-  pdf: Uint8Array;
-  colorMap: CmykMap;
-  unmappedColors: Set<string> | null;
-}): Promise<Uint8Array> {
-  const mupdf = await importNodeModule('mupdf');
-  const foundUnmappedColors = unmappedColors ?? new Set<string>();
-  const warnUnmapped = unmappedColors !== null;
-  const processedXObjects = new Set<number>();
-
-  using doc = disposable(
-    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- openDocument returns the Document base type; a PDF input yields a PDFDocument
-    mupdf.PDFDocument.openDocument(
-      pdf,
-      'application/pdf',
-    ) as mupdfType.PDFDocument,
-  );
-
-  const pageCount = doc.countPages();
-  for (let i = 0; i < pageCount; i++) {
-    const page = doc.loadPage(i);
-    const pageObj = page.getObject().resolve();
-
-    const contents = pageObj.get('Contents');
-    if (contents) {
-      processContents(
-        contents,
-        colorMap,
-        warnUnmapped,
-        foundUnmappedColors,
-        mupdf,
-      );
-    }
-
-    const resources = pageObj.get('Resources');
-    if (resources && resources.isDictionary()) {
-      processFormXObjects(
-        resources,
-        colorMap,
-        warnUnmapped,
-        foundUnmappedColors,
-        mupdf,
-        processedXObjects,
-      );
-    }
-
-    // Annotations may have appearance streams with colors
-    const annots = pageObj.get('Annots');
-    if (!annots?.isArray()) {
-      continue;
-    }
-    for (let j = 0; j < annots.length; j++) {
-      const annot = annots.get(j);
-      if (!annot) {
-        continue;
+      for (const color of unmappedColors) {
+        Logger.logWarn(`RGB color not mapped to CMYK: ${color}`);
       }
-      const ap = annot.resolve().get('AP');
-      if (!ap?.isDictionary()) {
-        continue;
+      if (unmappedColors.size > 0 && ifUnmappedColorsFound === 'error') {
+        failures.push(`${unmappedColors.size} RGB color(s) not mapped to CMYK`);
       }
-      // Normal appearance
-      const n = ap.get('N');
-      if (!n) {
-        continue;
-      }
-      if (n.isStream()) {
-        processStream(n, colorMap, warnUnmapped, foundUnmappedColors, mupdf);
-      } else if (n.isDictionary()) {
-        // Multiple appearance states
-        n.forEach((val) => {
-          if (val?.isStream()) {
-            processStream(
-              val,
-              colorMap,
-              warnUnmapped,
-              foundUnmappedColors,
-              mupdf,
-            );
-          }
-        });
-      }
-    }
-  }
-
-  using outputBuffer = disposable(doc.saveToBuffer('compress'));
-  // Create a copy to ensure the data remains valid after the buffer is destroyed
-  return new Uint8Array(outputBuffer.asUint8Array());
+    },
+  };
 }

--- a/src/output/image.ts
+++ b/src/output/image.ts
@@ -5,6 +5,7 @@ import type * as mupdfType from 'mupdf';
 import type { CmykConfig, ReplaceImageConfig } from '../config/resolve.js';
 import { Logger } from '../logger.js';
 import { importNodeModule } from '../node-modules.js';
+import type { PdfEditHook, PdfImageXObjectNode } from './pdf-visitor.js';
 
 interface Destroyable {
   destroy(): void;
@@ -18,23 +19,29 @@ function disposable<T extends Destroyable>(obj: T): T & Disposable {
   });
 }
 
+function disposableOrNull<T extends Destroyable>(
+  obj: T | null,
+): (T & Disposable) | null {
+  return obj && disposable(obj);
+}
+
 function imagesEqual(a: mupdfType.Image, b: mupdfType.Image): boolean {
   if (a.getWidth() !== b.getWidth() || a.getHeight() !== b.getHeight()) {
     return false;
   }
 
-  const pixmapA = a.toPixmap();
-  const pixmapB = b.toPixmap();
+  using pixmapA = disposable(a.toPixmap());
+  using pixmapB = disposable(b.toPixmap());
 
-  const typeA = pixmapA.getColorSpace();
-  const typeB = pixmapB.getColorSpace();
+  using colorSpaceA = disposableOrNull(pixmapA.getColorSpace());
+  using colorSpaceB = disposableOrNull(pixmapB.getColorSpace());
   if (
-    typeA === null ||
-    typeB === null ||
+    colorSpaceA === null ||
+    colorSpaceB === null ||
     !(
-      (typeA.isRGB() && typeB.isRGB()) ||
-      (typeA.isCMYK() && typeB.isCMYK()) ||
-      (typeA.isGray() && typeB.isGray())
+      (colorSpaceA.isRGB() && colorSpaceB.isRGB()) ||
+      (colorSpaceA.isCMYK() && colorSpaceB.isCMYK()) ||
+      (colorSpaceA.isGray() && colorSpaceB.isGray())
     )
   ) {
     return false;
@@ -49,18 +56,74 @@ function imagesEqual(a: mupdfType.Image, b: mupdfType.Image): boolean {
 }
 
 interface ImagePair {
-  srcImage: mupdfType.Image;
-  destImage: mupdfType.Image;
+  srcImage: mupdfType.Image & Disposable;
+  destImage: mupdfType.Image & Disposable;
   sourcePath: string;
   replacementPath: string;
 }
 
-interface ReplaceStats {
-  replaced: number;
-  total: number;
+function disposeImagePairs(imagePairs: readonly ImagePair[]): void {
+  for (const pair of imagePairs) {
+    pair.srcImage[Symbol.dispose]();
+    pair.destImage[Symbol.dispose]();
+  }
 }
 
-export interface DeviceCmykIncompatibleImage {
+async function createImagePairs(
+  replacements: ReplaceImageConfig,
+): Promise<ImagePair[]> {
+  if (replacements.length === 0) {
+    return [];
+  }
+  const mupdf = await importNodeModule('mupdf');
+  const imagePairs: ImagePair[] = [];
+  try {
+    for (const { source, replacement } of replacements) {
+      let srcImage: mupdfType.Image & Disposable;
+      let destImage: mupdfType.Image & Disposable;
+
+      try {
+        const srcBuffer = fs.readFileSync(source);
+        srcImage = disposable(new mupdf.Image(srcBuffer));
+        Logger.debug(
+          `Loaded source image: ${source} (${srcImage.getWidth()}x${srcImage.getHeight()})`,
+        );
+      } catch (error) {
+        Logger.logWarn(
+          `Failed to load source image: ${source}: ${String(error)}`,
+        );
+        continue;
+      }
+
+      try {
+        const destBuffer = fs.readFileSync(replacement);
+        destImage = disposable(new mupdf.Image(destBuffer));
+        Logger.debug(
+          `Loaded replacement image: ${replacement} (${destImage.getWidth()}x${destImage.getHeight()})`,
+        );
+      } catch (error) {
+        srcImage[Symbol.dispose]();
+        Logger.logWarn(
+          `Failed to load replacement image: ${replacement}: ${String(error)}`,
+        );
+        continue;
+      }
+
+      imagePairs.push({
+        srcImage,
+        destImage,
+        sourcePath: source,
+        replacementPath: replacement,
+      });
+    }
+  } catch (error) {
+    disposeImagePairs(imagePairs);
+    throw error;
+  }
+  return imagePairs;
+}
+
+interface DeviceCmykIncompatibleImage {
   key: string | number;
   colorSpace: string;
   width: number;
@@ -72,23 +135,23 @@ function collectDeviceCmykIncompatibleImage(
   image: mupdfType.Image,
   key: string | number,
   pageIndex: number,
-  found: DeviceCmykIncompatibleImage[],
-): void {
-  const colorSpace = image.getColorSpace()?.getName() ?? 'None';
+): DeviceCmykIncompatibleImage | null {
+  using imageColorSpace = disposableOrNull(image.getColorSpace());
+  const colorSpace = imageColorSpace?.getName() ?? 'None';
   if (
     image.getImageMask() ||
     colorSpace === 'DeviceCMYK' ||
     colorSpace === 'DeviceGray'
   ) {
-    return;
+    return null;
   }
-  found.push({
+  return {
     key,
     colorSpace,
     width: image.getWidth(),
     height: image.getHeight(),
     pageIndex,
-  });
+  };
 }
 
 function addImagePreservingColorSpace(
@@ -103,7 +166,8 @@ function addImagePreservingColorSpace(
       objectNumbers.delete(objectNumber);
     }
   }
-  const colorSpaceName = image.getColorSpace()?.getName();
+  using imageColorSpace = disposableOrNull(image.getColorSpace());
+  const colorSpaceName = imageColorSpace?.getName();
 
   if (
     colorSpaceName === 'DeviceGray' ||
@@ -180,8 +244,8 @@ function addReplacementImage(
   doc: mupdfType.PDFDocument,
   source: mupdfType.PDFObject,
   image: mupdfType.Image,
-  cleanupCandidates: Set<number>,
-): mupdfType.PDFObject {
+): { ref: mupdfType.PDFObject; cleanupCandidates: ReadonlySet<number> } {
+  const cleanupCandidates = new Set<number>();
   const sourceObjectNumbers = collectReachableObjectNumbers([source]);
   const replacement = addImagePreservingColorSpace(doc, image);
   const replacementObjectNumbers = collectReachableObjectNumbers([
@@ -197,186 +261,130 @@ function addReplacementImage(
     }
   }
 
-  return replacement.ref;
+  return { ref: replacement.ref, cleanupCandidates };
 }
 
-function replaceImagesInDocument(
-  doc: mupdfType.PDFDocument,
-  imagePairs: ImagePair[],
+type ReplaceImageResult =
+  | { readonly kind: 'unchanged' }
+  | {
+      readonly kind: 'replaced';
+      readonly cleanupCandidates: ReadonlySet<number>;
+    };
+
+function replaceImage(
+  node: PdfImageXObjectNode,
+  imagePairs: readonly ImagePair[],
   incompatibleImages: DeviceCmykIncompatibleImage[] | null,
-): ReplaceStats {
+): ReplaceImageResult {
+  using pdfImage = disposable(node.document.loadImage(node.object));
+  let replacementRef: mupdfType.PDFObject | null = null;
+  let cleanupCandidates: ReadonlySet<number> | null = null;
+
+  if (node.resourceVisit === 'initial') {
+    const pair = imagePairs.find((candidate) =>
+      imagesEqual(pdfImage, candidate.srcImage),
+    );
+    if (pair) {
+      const replacement = addReplacementImage(
+        node.document,
+        node.object,
+        pair.destImage,
+      );
+      replacementRef = replacement.ref;
+      cleanupCandidates = replacement.cleanupCandidates;
+      node.replaceWith(replacementRef);
+      Logger.debug(
+        `  Page ${node.pageIndex + 1}, ref "${node.key}": ${pair.sourcePath} -> ${pair.replacementPath}`,
+      );
+    }
+  }
+
+  if (incompatibleImages !== null) {
+    let incompatibleImage: DeviceCmykIncompatibleImage | null = null;
+    if (replacementRef === null) {
+      incompatibleImage = collectDeviceCmykIncompatibleImage(
+        pdfImage,
+        node.key,
+        node.pageIndex,
+      );
+    } else {
+      using replacementImage = disposable(
+        node.document.loadImage(replacementRef),
+      );
+      incompatibleImage = collectDeviceCmykIncompatibleImage(
+        replacementImage,
+        node.key,
+        node.pageIndex,
+      );
+    }
+    if (incompatibleImage) {
+      incompatibleImages.push(incompatibleImage);
+    }
+  }
+
+  return cleanupCandidates
+    ? { kind: 'replaced', cleanupCandidates }
+    : { kind: 'unchanged' };
+}
+
+export async function createReplaceImageHook(
+  replacements: ReplaceImageConfig,
+  ifIncompatibleImagesFound: CmykConfig['ifIncompatibleImagesFound'],
+  failures: string[],
+): Promise<PdfEditHook & Disposable> {
+  const imagePairs = await createImagePairs(replacements);
+  if (imagePairs.length === 0 && ifIncompatibleImagesFound === 'ignore') {
+    return {
+      [Symbol.dispose]() {},
+    };
+  }
+
+  const incompatibleImages: DeviceCmykIncompatibleImage[] | null =
+    ifIncompatibleImagesFound === 'ignore' ? null : [];
   let replaced = 0;
   let total = 0;
-  const cleanupCandidates = new Set<number>();
-
-  const pageCount = doc.countPages();
-
-  for (let i = 0; i < pageCount; i++) {
-    const page = doc.loadPage(i);
-    const pageObj = page.getObject().resolve();
-
-    const res = pageObj.get('Resources');
-    if (!res || !res.isDictionary()) {
-      continue;
-    }
-
-    const xobjects = res.get('XObject');
-    if (!xobjects || !xobjects.isDictionary()) {
-      continue;
-    }
-
-    // Collect keys first to avoid modification during iteration
-    const entries: { key: string | number; value: mupdfType.PDFObject }[] = [];
-    xobjects.forEach((value, key) => {
-      entries.push({ key, value });
-    });
-
-    for (const { key, value } of entries) {
-      const resolved = value.resolve();
-      const subtype = resolved.get('Subtype');
-
-      if (!subtype || subtype.toString() !== '/Image') {
-        continue;
-      }
-      total++;
-
-      // Extract image from PDF
-      using pdfImage = disposable(doc.loadImage(value));
-      let replacementRef: mupdfType.PDFObject | undefined;
-
-      // Find matching source image
-      for (const pair of imagePairs) {
-        if (imagesEqual(pdfImage, pair.srcImage)) {
-          replacementRef = addReplacementImage(
-            doc,
-            value,
-            pair.destImage,
-            cleanupCandidates,
-          );
-          xobjects.put(key, replacementRef);
-          replaced++;
-          Logger.debug(
-            `  Page ${i + 1}, ref "${key}": ${pair.sourcePath} -> ${pair.replacementPath}`,
-          );
-          break;
-        }
-      }
-
-      if (incompatibleImages) {
-        if (replacementRef) {
-          using replacementImage = disposable(doc.loadImage(replacementRef));
-          collectDeviceCmykIncompatibleImage(
-            replacementImage,
-            key,
-            i,
-            incompatibleImages,
-          );
-        } else {
-          collectDeviceCmykIncompatibleImage(
-            pdfImage,
-            key,
-            i,
-            incompatibleImages,
-          );
-        }
-      }
-    }
-
-    res.put('XObject', xobjects);
-    pageObj.put('Resources', res);
-  }
-
-  removeUnreferencedCandidates(doc, cleanupCandidates);
-  return { replaced, total };
-}
-
-export async function replaceImages(
-  pdf: Uint8Array,
-  {
-    replacements,
-    ifIncompatibleImagesFound,
-  }: {
-    replacements: ReplaceImageConfig;
-    ifIncompatibleImagesFound: CmykConfig['ifIncompatibleImagesFound'];
-  },
-): Promise<{
-  pdf: Uint8Array;
-  incompatibleImages: DeviceCmykIncompatibleImage[];
-}> {
-  if (replacements.length === 0 && ifIncompatibleImagesFound === 'ignore') {
-    return { pdf, incompatibleImages: [] };
-  }
-
-  const mupdf = await importNodeModule('mupdf');
-
-  // Load image pairs
-  const imagePairs: ImagePair[] = [];
-  for (const { source, replacement } of replacements) {
-    let srcImage: mupdfType.Image;
-    let destImage: mupdfType.Image;
-
-    try {
-      const srcBuffer = fs.readFileSync(source);
-      srcImage = new mupdf.Image(srcBuffer);
-      Logger.debug(
-        `Loaded source image: ${source} (${srcImage.getWidth()}x${srcImage.getHeight()})`,
-      );
-    } catch (error) {
-      Logger.logWarn(
-        `Failed to load source image: ${source}: ${String(error)}`,
-      );
-      continue;
-    }
-
-    try {
-      const destBuffer = fs.readFileSync(replacement);
-      destImage = new mupdf.Image(destBuffer);
-      Logger.debug(
-        `Loaded replacement image: ${replacement} (${destImage.getWidth()}x${destImage.getHeight()})`,
-      );
-    } catch (error) {
-      Logger.logWarn(
-        `Failed to load replacement image: ${replacement}: ${String(error)}`,
-      );
-      continue;
-    }
-
-    imagePairs.push({
-      srcImage,
-      destImage,
-      sourcePath: source,
-      replacementPath: replacement,
-    });
-  }
-
-  if (imagePairs.length === 0 && ifIncompatibleImagesFound === 'ignore') {
-    return { pdf, incompatibleImages: [] };
-  }
-
-  using doc = disposable(
-    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- openDocument returns the Document base type; a PDF input yields a PDFDocument
-    mupdf.PDFDocument.openDocument(
-      pdf,
-      'application/pdf',
-    ) as mupdfType.PDFDocument,
-  );
-
-  const incompatibleImages: DeviceCmykIncompatibleImage[] = [];
-  const stats = replaceImagesInDocument(
-    doc,
-    imagePairs,
-    ifIncompatibleImagesFound === 'ignore' ? null : incompatibleImages,
-  );
-  Logger.debug(`Replaced ${stats.replaced} of ${stats.total} images`);
-
-  if (imagePairs.length === 0) {
-    return { pdf, incompatibleImages };
-  }
-
-  using outputBuffer = disposable(doc.saveToBuffer('compress'));
-  // Create a copy to ensure the data remains valid after the buffer is destroyed
+  const cleanupCandidateBatches: ReadonlySet<number>[] = [];
   return {
-    pdf: new Uint8Array(outputBuffer.asUint8Array()),
-    incompatibleImages,
+    visit(node) {
+      if (node.kind !== 'image-xobject') {
+        return;
+      }
+      const result = replaceImage(node, imagePairs, incompatibleImages);
+      total++;
+      if (result.kind === 'replaced') {
+        replaced++;
+        cleanupCandidateBatches.push(result.cleanupCandidates);
+      }
+    },
+    complete(document) {
+      const cleanupCandidates = new Set<number>();
+      for (const batch of cleanupCandidateBatches) {
+        for (const objectNumber of batch) {
+          cleanupCandidates.add(objectNumber);
+        }
+      }
+      removeUnreferencedCandidates(document, cleanupCandidates);
+
+      Logger.debug(`Replaced ${replaced} of ${total} images`);
+      if (!incompatibleImages) {
+        return;
+      }
+      for (const incompatibleImage of incompatibleImages) {
+        Logger.logWarn(
+          `Image color space is incompatible with Device CMYK: ref "${incompatibleImage.key}" (${incompatibleImage.colorSpace}, ${incompatibleImage.width}x${incompatibleImage.height}) on page ${incompatibleImage.pageIndex + 1}`,
+        );
+      }
+      if (
+        incompatibleImages.length > 0 &&
+        ifIncompatibleImagesFound === 'error'
+      ) {
+        failures.push(
+          `${incompatibleImages.length} image(s) incompatible with Device CMYK color`,
+        );
+      }
+    },
+    [Symbol.dispose]() {
+      disposeImagePairs(imagePairs);
+    },
   };
 }

--- a/src/output/pdf-postprocess.ts
+++ b/src/output/pdf-postprocess.ts
@@ -12,7 +12,7 @@ import {
   runContainer,
   toContainerPath,
 } from '../container.js';
-import type { CmykMap, Meta, TOCItem } from '../global-viewer.js';
+import type { CMYKValue, CmykMap, Meta, TOCItem } from '../global-viewer.js';
 import { Logger } from '../logger.js';
 import { importNodeModule } from '../node-modules.js';
 import {
@@ -20,8 +20,9 @@ import {
   executeWithCleanupOnInterrupt,
   isInContainer,
 } from '../util.js';
-import { convertCmykColors } from './cmyk.js';
-import { replaceImages } from './image.js';
+import { createCmykColorHook } from './cmyk.js';
+import { createReplaceImageHook } from './image.js';
+import { editPdf } from './pdf-visitor.js';
 
 export type SaveOption = Pick<
   PdfOutput,
@@ -115,79 +116,62 @@ export class PostProcess {
       preflight,
       preflightOption,
       image,
-      cmyk,
+      cmyk: cmykConfig,
       cmykMap,
-      replaceImage,
+      replaceImage: replaceImageConfig,
       signal,
     }: SaveOption,
   ): Promise<void> {
     let pdf = await this.document.save();
     signal?.throwIfAborted();
 
-    const failures: string[] = [];
-    if (cmyk) {
-      const mergedMap: CmykMap = { ...cmykMap };
-      for (const [rgb, cmykValue] of cmyk.overrideMap) {
-        const key = JSON.stringify([rgb.r, rgb.g, rgb.b]);
-        mergedMap[key] = cmykValue;
-      }
+    const mergedMap = new Map<string, CMYKValue>([
+      ...Object.entries(cmykMap),
+      ...(cmykConfig ? cmykConfig.overrideMap : []).map(
+        ([{ r, g, b }, cmyk]) => [JSON.stringify([r, g, b]), cmyk] as const,
+      ),
+    ]);
+    if (cmykConfig && cmykConfig.mapOutput) {
+      const mapOutputDir = upath.dirname(cmykConfig.mapOutput);
+      await fs.promises.mkdir(mapOutputDir, { recursive: true });
+      await fs.promises.writeFile(
+        cmykConfig.mapOutput,
+        JSON.stringify(Object.fromEntries(mergedMap), null, 2),
+      );
+      Logger.logInfo(`CMYK color map saved to ${cmykConfig.mapOutput}`);
+    }
 
+    const replacesColors = cmykConfig && mergedMap.size > 0;
+    const replacesImages = replaceImageConfig.length > 0;
+    if (replacesColors && replacesImages) {
+      Logger.logInfo('Converting CMYK colors and replacing images');
+    } else if (replacesColors) {
       Logger.logInfo('Converting CMYK colors');
-      const unmappedColors =
-        cmyk.ifUnmappedColorsFound === 'ignore' ? null : new Set<string>();
-      pdf = await convertCmykColors({
-        pdf,
-        colorMap: mergedMap,
-        unmappedColors,
-      });
-      if (
-        cmyk.ifUnmappedColorsFound === 'error' &&
-        unmappedColors &&
-        unmappedColors.size > 0
-      ) {
-        failures.push(`${unmappedColors.size} RGB color(s) not mapped to CMYK`);
-      }
-      signal?.throwIfAborted();
-
-      if (cmyk.mapOutput) {
-        const mapOutputDir = upath.dirname(cmyk.mapOutput);
-        fs.mkdirSync(mapOutputDir, { recursive: true });
-        await fs.promises.writeFile(
-          cmyk.mapOutput,
-          JSON.stringify(mergedMap, null, 2),
-        );
-        Logger.logInfo(`CMYK color map saved to ${cmyk.mapOutput}`);
-      }
+    } else if (replacesImages) {
+      Logger.logInfo('Replacing images');
     }
 
-    const ifIncompatibleImagesFound = cmyk
-      ? cmyk.ifIncompatibleImagesFound
-      : 'ignore';
-    if (replaceImage.length > 0 || ifIncompatibleImagesFound !== 'ignore') {
-      if (replaceImage.length > 0) {
-        Logger.logInfo('Replacing images');
-      }
-      const result = await replaceImages(pdf, {
-        replacements: replaceImage,
-        ifIncompatibleImagesFound,
+    const failures: string[] = [];
+
+    const cmykColorHook = cmykConfig
+      ? createCmykColorHook(
+          mergedMap,
+          cmykConfig ? cmykConfig.ifUnmappedColorsFound : 'ignore',
+          failures,
+        )
+      : {};
+
+    pdf = await (async () => {
+      using replaceImageHook = await createReplaceImageHook(
+        replaceImageConfig,
+        cmykConfig ? cmykConfig.ifIncompatibleImagesFound : 'ignore',
+        failures,
+      );
+      return await editPdf(pdf, [cmykColorHook, replaceImageHook], {
+        signal,
       });
-      pdf = result.pdf;
-      const { incompatibleImages } = result;
-      for (const incompatibleImage of incompatibleImages) {
-        Logger.logWarn(
-          `Image color space is incompatible with Device CMYK: ref "${incompatibleImage.key}" (${incompatibleImage.colorSpace}, ${incompatibleImage.width}x${incompatibleImage.height}) on page ${incompatibleImage.pageIndex + 1}`,
-        );
-      }
-      if (
-        ifIncompatibleImagesFound === 'error' &&
-        incompatibleImages.length > 0
-      ) {
-        failures.push(
-          `${incompatibleImages.length} image(s) incompatible with Device CMYK color`,
-        );
-      }
-      signal?.throwIfAborted();
-    }
+    })();
+    signal?.throwIfAborted();
 
     if (failures.length > 0) {
       throw new Error(failures.join('; '));

--- a/src/output/pdf-stream.ts
+++ b/src/output/pdf-stream.ts
@@ -1,35 +1,21 @@
-import type { CmykMap } from '../global-viewer.js';
-import { Logger } from '../logger.js';
-
-/**
- * `SRGBValue.MAX`
- * @see https://github.com/vivliostyle/vivliostyle.js/blob/master/packages/core/src/vivliostyle/cmyk-store.ts
- */
-const SRGB_MAX = 10000;
-/**
- * `CMYKValue.MAX`
- * @see https://github.com/vivliostyle/vivliostyle.js/blob/master/packages/core/src/vivliostyle/cmyk-store.ts
- */
-const CMYK_MAX = 10000;
-
-interface NumberToken {
+export interface NumberToken {
   type: 'number';
   value: number;
   raw: string;
 }
 
-interface OperatorToken {
+export interface OperatorToken {
   type: 'operator';
   value: string;
   raw: string;
 }
 
-interface OtherToken {
+export interface OtherToken {
   type: 'other';
   raw: string;
 }
 
-type Token = NumberToken | OperatorToken | OtherToken;
+export type Token = NumberToken | OperatorToken | OtherToken;
 
 function scanStringLiteral(
   content: string,
@@ -59,7 +45,7 @@ function scanStringLiteral(
 /**
  * Tokenize PDF content stream
  */
-function* tokenize(content: string): Generator<Token> {
+export function* tokenize(content: string): Generator<Token> {
   let i = 0;
   const len = content.length;
 
@@ -173,107 +159,4 @@ function* tokenize(content: string): Generator<Token> {
       yield { type: 'operator', value: token, raw: token };
     }
   }
-}
-
-function formatRgbKey(r: number, g: number, b: number): string {
-  const ri = Math.round(r * SRGB_MAX);
-  const gi = Math.round(g * SRGB_MAX);
-  const bi = Math.round(b * SRGB_MAX);
-  return JSON.stringify([ri, gi, bi]);
-}
-
-function formatRgbKeyForWarning(r: number, g: number, b: number): string {
-  const ri = Math.round(r * SRGB_MAX);
-  const gi = Math.round(g * SRGB_MAX);
-  const bi = Math.round(b * SRGB_MAX);
-  return JSON.stringify({ r: ri, g: gi, b: bi });
-}
-
-function warnUnmappedColor(
-  r: number,
-  g: number,
-  b: number,
-  warnedColors: Set<string>,
-): void {
-  const warnKey = formatRgbKeyForWarning(r, g, b);
-  if (!warnedColors.has(warnKey)) {
-    warnedColors.add(warnKey);
-    Logger.logWarn(`RGB color not mapped to CMYK: ${warnKey}`);
-  }
-}
-
-/**
- * Convert RGB color operators to CMYK in a content stream
- */
-export function convertStreamColors(
-  content: string,
-  colorMap: CmykMap,
-  warnUnmapped: boolean,
-  warnedColors: Set<string>,
-): string {
-  const result: string[] = [];
-  const pendingNumbers: { value: number; raw: string }[] = [];
-
-  const flushPendingNumbers = () => {
-    for (const num of pendingNumbers) {
-      result.push(num.raw);
-    }
-    pendingNumbers.length = 0;
-  };
-
-  const convertRgbOperator = (
-    cmykOp: 'k' | 'K',
-    token: OperatorToken,
-  ): void => {
-    const b = pendingNumbers.pop();
-    const g = pendingNumbers.pop();
-    const r = pendingNumbers.pop();
-    /* v8 ignore next 3 */
-    if (!b || !g || !r) {
-      throw new Error('Expected at least three pending numbers for RGB color');
-    }
-    flushPendingNumbers();
-
-    const key = formatRgbKey(r.value, g.value, b.value);
-    const cmyk = colorMap[key];
-
-    if (cmyk) {
-      const c = (cmyk.c / CMYK_MAX).toString();
-      const m = (cmyk.m / CMYK_MAX).toString();
-      const y = (cmyk.y / CMYK_MAX).toString();
-      const k = (cmyk.k / CMYK_MAX).toString();
-      result.push(`${c} ${m} ${y} ${k} ${cmykOp}`);
-      return;
-    }
-    result.push(r.raw, g.raw, b.raw, token.raw);
-    if (warnUnmapped) {
-      warnUnmappedColor(r.value, g.value, b.value, warnedColors);
-    }
-  };
-
-  for (const token of tokenize(content)) {
-    if (token.type === 'number') {
-      pendingNumbers.push({ value: token.value, raw: token.raw });
-    } else if (token.type === 'operator') {
-      const op = token.value;
-
-      // RGB color: r g b rg (non-stroking) or r g b RG (stroking)
-      const cmykOp = op === 'rg' ? 'k' : op === 'RG' ? 'K' : null;
-      if (cmykOp && pendingNumbers.length >= 3) {
-        convertRgbOperator(cmykOp, token);
-      } else {
-        flushPendingNumbers();
-        result.push(token.raw);
-      }
-    } else {
-      // Other token types - flush pending numbers and pass through
-      flushPendingNumbers();
-      result.push(token.raw);
-    }
-  }
-
-  // Flush any remaining pending numbers
-  flushPendingNumbers();
-
-  return result.join(' ');
 }

--- a/src/output/pdf-visitor.ts
+++ b/src/output/pdf-visitor.ts
@@ -1,0 +1,439 @@
+import type * as mupdfType from 'mupdf';
+
+import { importNodeModule } from '../node-modules.js';
+
+interface Destroyable {
+  destroy(): void;
+}
+
+function disposable<T extends Destroyable>(obj: T): T & Disposable {
+  return Object.assign(obj, {
+    [Symbol.dispose]() {
+      obj.destroy();
+    },
+  });
+}
+
+export type PdfNodeOrigin = 'page' | 'annotation-appearance';
+
+interface PdfNodeBase {
+  document: mupdfType.PDFDocument;
+  pageIndex: number;
+  origin: PdfNodeOrigin;
+  formDepth: number;
+  objectNumber: number | undefined;
+}
+
+export interface PdfContentStreamNode extends PdfNodeBase {
+  kind: 'content-stream';
+  role: 'page-content' | 'form' | 'appearance';
+  object: mupdfType.PDFObject;
+  read(): string;
+  write(content: string): void;
+}
+
+export interface PdfFormXObjectNode extends PdfNodeBase {
+  kind: 'form-xobject';
+  key: string | number;
+  object: mupdfType.PDFObject;
+}
+
+export interface PdfImageXObjectNode extends PdfNodeBase {
+  kind: 'image-xobject';
+  resourceVisit: 'initial' | 'subsequent-page';
+  key: string | number;
+  object: mupdfType.PDFObject;
+  resolved: mupdfType.PDFObject;
+  replaceWith(replacement: mupdfType.PDFObject): void;
+}
+
+export type PdfVisitNode =
+  | PdfContentStreamNode
+  | PdfFormXObjectNode
+  | PdfImageXObjectNode;
+
+export interface PdfEditHook {
+  visit?(node: PdfVisitNode): void | Promise<void>;
+  complete?(document: mupdfType.PDFDocument): void | Promise<void>;
+}
+
+interface PdfVisitContext {
+  readonly document: mupdfType.PDFDocument;
+  readonly mupdf: typeof import('mupdf');
+  readonly signal?: AbortSignal;
+  readonly processedForms: Set<number>;
+  readonly processedXObjectDictionaries: Set<number>;
+  readonly visitedFormsOnPage: Set<number>;
+  readonly visitedXObjectDictionariesOnPage: Set<number>;
+}
+
+async function visitNode(
+  context: PdfVisitContext,
+  hooks: readonly PdfEditHook[],
+  node: PdfVisitNode,
+): Promise<void> {
+  for (const hook of hooks) {
+    if (!hook.visit) {
+      continue;
+    }
+    context.signal?.throwIfAborted();
+    await hook.visit(node);
+  }
+}
+
+function visitContentStream(
+  context: PdfVisitContext,
+  hooks: readonly PdfEditHook[],
+  object: mupdfType.PDFObject,
+  pageIndex: number,
+  origin: PdfNodeOrigin,
+  formDepth: number,
+  role: PdfContentStreamNode['role'],
+): Promise<void> {
+  return visitNode(context, hooks, {
+    kind: 'content-stream',
+    document: context.document,
+    pageIndex,
+    origin,
+    formDepth,
+    role,
+    object,
+    objectNumber: object.asIndirect() || undefined,
+    read: () => {
+      using buffer = disposable(object.readStream());
+      return buffer.asString();
+    },
+    write: (content) => {
+      using buffer = disposable(new context.mupdf.Buffer(content));
+      object.writeStream(buffer);
+    },
+  });
+}
+
+async function visitContents(
+  context: PdfVisitContext,
+  hooks: readonly PdfEditHook[],
+  contents: mupdfType.PDFObject,
+  pageIndex: number,
+): Promise<void> {
+  if (contents.isArray()) {
+    // Multiple content streams
+    for (let i = 0; i < contents.length; i++) {
+      const streamObj = contents.get(i);
+      // Use original indirect reference for stream operations (see #735)
+      if (streamObj && streamObj.isStream()) {
+        await visitContentStream(
+          context,
+          hooks,
+          streamObj,
+          pageIndex,
+          'page',
+          0,
+          'page-content',
+        );
+      }
+    }
+  } else if (contents.isStream()) {
+    // Single content stream
+    await visitContentStream(
+      context,
+      hooks,
+      contents,
+      pageIndex,
+      'page',
+      0,
+      'page-content',
+    );
+  }
+}
+
+function createImageXObjectNode(
+  context: PdfVisitContext,
+  xobjects: mupdfType.PDFObject,
+  key: string | number,
+  object: mupdfType.PDFObject,
+  pageIndex: number,
+  formDepth: number,
+  resourceVisit: PdfImageXObjectNode['resourceVisit'],
+): PdfImageXObjectNode {
+  const node: PdfImageXObjectNode = {
+    kind: 'image-xobject',
+    resourceVisit,
+    document: context.document,
+    pageIndex,
+    origin: 'page',
+    formDepth,
+    key,
+    objectNumber: object.asIndirect() || undefined,
+    object,
+    resolved: object.resolve(),
+    replaceWith: (replacement) => {
+      xobjects.put(key, replacement);
+      node.objectNumber = replacement.asIndirect() || undefined;
+      node.object = replacement;
+      node.resolved = replacement.resolve();
+    },
+  };
+  return node;
+}
+
+async function visitResources(
+  context: PdfVisitContext,
+  hooks: readonly PdfEditHook[],
+  resources: mupdfType.PDFObject,
+  pageIndex: number,
+  formDepth: number,
+  ownerObjectNumber: number | undefined,
+): Promise<void> {
+  const xobjects = resources.get('XObject');
+  if (!xobjects || !xobjects.isDictionary()) {
+    return;
+  }
+  const xobjectsObjectNumber = xobjects.asIndirect() || undefined;
+  const resourcesObjectNumber = resources.asIndirect() || undefined;
+  const dictionaryObjectNumber =
+    xobjectsObjectNumber ?? resourcesObjectNumber ?? ownerObjectNumber;
+  if (
+    dictionaryObjectNumber &&
+    context.visitedXObjectDictionariesOnPage.has(dictionaryObjectNumber)
+  ) {
+    return;
+  }
+  const resourceVisit =
+    dictionaryObjectNumber &&
+    context.processedXObjectDictionaries.has(dictionaryObjectNumber)
+      ? 'subsequent-page'
+      : 'initial';
+  if (dictionaryObjectNumber) {
+    context.processedXObjectDictionaries.add(dictionaryObjectNumber);
+    context.visitedXObjectDictionariesOnPage.add(dictionaryObjectNumber);
+  }
+
+  // Collect keys first to avoid modification during iteration
+  const entries: { key: string | number; value: mupdfType.PDFObject }[] = [];
+  xobjects.forEach((value, key) => {
+    entries.push({ key, value });
+  });
+
+  for (const { key, value } of entries) {
+    const subtype = value.get('Subtype')?.toString();
+    if (subtype === '/Form' && value.isStream()) {
+      // Use original indirect reference for stream operations (see #735)
+      const objectNumber = value.asIndirect() || undefined;
+      if (objectNumber && context.visitedFormsOnPage.has(objectNumber)) {
+        // Avoid circular references
+        continue;
+      }
+      const processForm =
+        !objectNumber || !context.processedForms.has(objectNumber);
+      if (objectNumber) {
+        context.processedForms.add(objectNumber);
+        context.visitedFormsOnPage.add(objectNumber);
+      }
+
+      if (processForm) {
+        await visitNode(context, hooks, {
+          kind: 'form-xobject',
+          document: context.document,
+          pageIndex,
+          origin: 'page',
+          formDepth: formDepth + 1,
+          objectNumber,
+          key,
+          object: value,
+        });
+        await visitContentStream(
+          context,
+          hooks,
+          value,
+          pageIndex,
+          'page',
+          formDepth + 1,
+          'form',
+        );
+      }
+
+      const nestedResources = value.get('Resources');
+      if (nestedResources && nestedResources.isDictionary()) {
+        await visitResources(
+          context,
+          hooks,
+          nestedResources,
+          pageIndex,
+          formDepth + 1,
+          objectNumber,
+        );
+      }
+      continue;
+    }
+
+    if (subtype !== '/Image') {
+      continue;
+    }
+
+    await visitNode(
+      context,
+      hooks,
+      createImageXObjectNode(
+        context,
+        xobjects,
+        key,
+        value,
+        pageIndex,
+        formDepth,
+        resourceVisit,
+      ),
+    );
+  }
+}
+
+async function visitAnnotationAppearances(
+  context: PdfVisitContext,
+  hooks: readonly PdfEditHook[],
+  pageObject: mupdfType.PDFObject,
+  pageIndex: number,
+): Promise<void> {
+  // Annotations may have appearance streams with colors
+  const annots = pageObject.get('Annots');
+  if (!annots?.isArray()) {
+    return;
+  }
+
+  for (let i = 0; i < annots.length; i++) {
+    const annot = annots.get(i);
+    if (!annot) {
+      continue;
+    }
+    const ap = annot.resolve().get('AP');
+    if (!ap?.isDictionary()) {
+      continue;
+    }
+    // Normal appearance
+    const normalAppearance = ap.get('N');
+    if (!normalAppearance) {
+      continue;
+    }
+    if (normalAppearance.isStream()) {
+      await visitContentStream(
+        context,
+        hooks,
+        normalAppearance,
+        pageIndex,
+        'annotation-appearance',
+        0,
+        'appearance',
+      );
+    } else if (normalAppearance.isDictionary()) {
+      // Multiple appearance states
+      const appearances: mupdfType.PDFObject[] = [];
+      normalAppearance.forEach((value) => {
+        if (value?.isStream()) {
+          appearances.push(value);
+        }
+      });
+      for (const appearance of appearances) {
+        await visitContentStream(
+          context,
+          hooks,
+          appearance,
+          pageIndex,
+          'annotation-appearance',
+          0,
+          'appearance',
+        );
+      }
+    }
+  }
+}
+
+async function visitDocument(
+  context: PdfVisitContext,
+  hooks: readonly PdfEditHook[],
+): Promise<void> {
+  const pageCount = context.document.countPages();
+  for (let pageIndex = 0; pageIndex < pageCount; pageIndex++) {
+    context.signal?.throwIfAborted();
+    context.visitedFormsOnPage.clear();
+    context.visitedXObjectDictionariesOnPage.clear();
+    using page = disposable(context.document.loadPage(pageIndex));
+    const pageReference = page.getObject();
+    const pageObject = pageReference.resolve();
+    const contents = pageObject.get('Contents');
+    if (contents) {
+      await visitContents(context, hooks, contents, pageIndex);
+    }
+    const resources = pageObject.get('Resources');
+    if (resources && resources.isDictionary()) {
+      await visitResources(
+        context,
+        hooks,
+        resources,
+        pageIndex,
+        0,
+        pageReference.asIndirect() || undefined,
+      );
+    }
+    // As of Chrome 151, no PDF generation path creates appearance resources, so they are intentionally not visited.
+    // https://source.chromium.org/chromium/chromium/src/+/refs/tags/151.0.7922.173:third_party/skia/src/pdf/SkPDFDocument.cpp;l=337
+    await visitAnnotationAppearances(context, hooks, pageObject, pageIndex);
+  }
+  await visitDocumentCompletion(context, hooks);
+}
+
+async function visitDocumentCompletion(
+  context: PdfVisitContext,
+  hooks: readonly PdfEditHook[],
+): Promise<void> {
+  for (const hook of hooks) {
+    if (!hook.complete) {
+      continue;
+    }
+    context.signal?.throwIfAborted();
+    await hook.complete(context.document);
+  }
+}
+
+export async function editPdf(
+  pdf: Uint8Array,
+  hooks: readonly PdfEditHook[],
+  { signal }: { signal?: AbortSignal } = {},
+): Promise<Uint8Array> {
+  signal?.throwIfAborted();
+  if (
+    hooks.every(
+      (hook) => hook.visit === undefined && hook.complete === undefined,
+    )
+  ) {
+    return pdf;
+  }
+
+  const mupdf = await importNodeModule('mupdf');
+  using document = disposable(
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- openDocument returns the Document base type; a PDF input yields a PDFDocument
+    mupdf.PDFDocument.openDocument(
+      pdf,
+      'application/pdf',
+    ) as mupdfType.PDFDocument,
+  );
+  await visitDocument(
+    {
+      document,
+      mupdf,
+      signal,
+      processedForms: new Set(),
+      processedXObjectDictionaries: new Set(),
+      visitedFormsOnPage: new Set(),
+      visitedXObjectDictionariesOnPage: new Set(),
+    },
+    hooks,
+  );
+  signal?.throwIfAborted();
+
+  if (!document.hasUnsavedChanges()) {
+    return pdf;
+  }
+
+  using outputBuffer = disposable(document.saveToBuffer('compress'));
+  // Create a copy to ensure the data remains valid after the buffer is destroyed
+  return new Uint8Array(outputBuffer.asUint8Array());
+}

--- a/tests/cmyk-stream.test.ts
+++ b/tests/cmyk-stream.test.ts
@@ -1,7 +1,41 @@
-import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
-import type { CmykMap } from '../src/global-viewer.js';
-import { convertStreamColors } from '../src/output/pdf-stream.js';
+import type { CMYKValue } from '../src/global-viewer.js';
+import { createCmykColorHook } from '../src/output/cmyk.js';
+import type { PdfContentStreamNode } from '../src/output/pdf-visitor.js';
+
+function convertColors(
+  content: string,
+  colorMap: ReadonlyMap<string, CMYKValue>,
+): string {
+  let converted: string | undefined;
+  const hook = createCmykColorHook(colorMap, 'ignore', []);
+  void hook.visit?.({
+    kind: 'content-stream',
+    read: () => content,
+    write: (value) => {
+      converted = value;
+    },
+  } as PdfContentStreamNode);
+  if (converted === undefined) {
+    throw new Error('CMYK color hook did not write the content stream');
+  }
+  return converted;
+}
+
+function reportUnmappedColors(...contents: string[]): string[] {
+  const failures: string[] = [];
+  const hook = createCmykColorHook(new Map(), 'error', failures);
+  for (const content of contents) {
+    void hook.visit?.({
+      kind: 'content-stream',
+      read: () => content,
+      write() {},
+    } as unknown as PdfContentStreamNode);
+  }
+  void hook.complete?.(null as never);
+  return failures;
+}
 
 /**
  * Helper to create a color map from RGB (0-10000 scale) to CMYK values
@@ -13,28 +47,23 @@ function createColorMap(
     number,
     { c: number; m: number; y: number; k: number },
   ][],
-): CmykMap {
-  const map: CmykMap = {};
+): Map<string, CMYKValue> {
+  const map = new Map<string, CMYKValue>();
   for (const [r, g, b, cmyk] of entries) {
     const key = JSON.stringify([r, g, b]);
-    map[key] = cmyk;
+    map.set(key, cmyk);
   }
   return map;
 }
 
-describe('convertStreamColors', () => {
+describe('convertColors', () => {
   describe('RGB to CMYK conversion', () => {
     describe('rg operator (non-stroking)', () => {
       it('converts mapped RGB color to CMYK', () => {
         const colorMap = createColorMap([
           [0, 0, 0, { c: 0, m: 0, y: 0, k: 10000 }],
         ]);
-        const result = convertStreamColors(
-          '0 0 0 rg',
-          colorMap,
-          false,
-          new Set(),
-        );
+        const result = convertColors('0 0 0 rg', colorMap);
         expect(result).toBe('0 0 0 1 k');
       });
 
@@ -42,22 +71,12 @@ describe('convertStreamColors', () => {
         const colorMap = createColorMap([
           [5000, 5000, 5000, { c: 0, m: 0, y: 0, k: 5000 }],
         ]);
-        const result = convertStreamColors(
-          '0.5 0.5 0.5 rg',
-          colorMap,
-          false,
-          new Set(),
-        );
+        const result = convertColors('0.5 0.5 0.5 rg', colorMap);
         expect(result).toBe('0 0 0 0.5 k');
       });
 
       it('preserves unmapped RGB colors', () => {
-        const result = convertStreamColors(
-          '0.1 0.2 0.3 rg',
-          {},
-          false,
-          new Set(),
-        );
+        const result = convertColors('0.1 0.2 0.3 rg', new Map());
         expect(result).toBe('0.1 0.2 0.3 rg');
       });
 
@@ -65,17 +84,12 @@ describe('convertStreamColors', () => {
         const colorMap = createColorMap([
           [5000, 3000, 2000, { c: 1234, m: 5678, y: 9012, k: 3456 }],
         ]);
-        const result = convertStreamColors(
-          '0.5 0.3 0.2 rg',
-          colorMap,
-          false,
-          new Set(),
-        );
+        const result = convertColors('0.5 0.3 0.2 rg', colorMap);
         expect(result).toBe('0.1234 0.5678 0.9012 0.3456 k');
       });
 
       it('handles insufficient arguments gracefully', () => {
-        const result = convertStreamColors('0.5 0.5 rg', {}, false, new Set());
+        const result = convertColors('0.5 0.5 rg', new Map());
         expect(result).toBe('0.5 0.5 rg');
       });
     });
@@ -85,27 +99,17 @@ describe('convertStreamColors', () => {
         const colorMap = createColorMap([
           [10000, 0, 0, { c: 0, m: 10000, y: 10000, k: 0 }],
         ]);
-        const result = convertStreamColors(
-          '1 0 0 RG',
-          colorMap,
-          false,
-          new Set(),
-        );
+        const result = convertColors('1 0 0 RG', colorMap);
         expect(result).toBe('0 1 1 0 K');
       });
 
       it('preserves unmapped RGB stroking colors', () => {
-        const result = convertStreamColors(
-          '0.9 0.8 0.7 RG',
-          {},
-          false,
-          new Set(),
-        );
+        const result = convertColors('0.9 0.8 0.7 RG', new Map());
         expect(result).toBe('0.9 0.8 0.7 RG');
       });
 
       it('handles insufficient arguments gracefully', () => {
-        const result = convertStreamColors('0.5 RG', {}, false, new Set());
+        const result = convertColors('0.5 RG', new Map());
         expect(result).toBe('0.5 RG');
       });
     });
@@ -115,12 +119,7 @@ describe('convertStreamColors', () => {
         const colorMap = createColorMap([
           [0, 0, 0, { c: 0, m: 0, y: 0, k: 10000 }],
         ]);
-        const result = convertStreamColors(
-          '0 0 0 rg 0 0 0 RG',
-          colorMap,
-          false,
-          new Set(),
-        );
+        const result = convertColors('0 0 0 rg 0 0 0 RG', colorMap);
         expect(result).toBe('0 0 0 1 k 0 0 0 1 K');
       });
 
@@ -129,12 +128,7 @@ describe('convertStreamColors', () => {
           [0, 0, 0, { c: 0, m: 0, y: 0, k: 10000 }],
           [10000, 10000, 10000, { c: 0, m: 0, y: 0, k: 0 }],
         ]);
-        const result = convertStreamColors(
-          '0 0 0 rg 1 1 1 rg',
-          colorMap,
-          false,
-          new Set(),
-        );
+        const result = convertColors('0 0 0 rg 1 1 1 rg', colorMap);
         expect(result).toBe('0 0 0 1 k 0 0 0 0 k');
       });
     });
@@ -143,235 +137,160 @@ describe('convertStreamColors', () => {
   describe('content preservation', () => {
     describe('existing CMYK and gray colors', () => {
       it('preserves k operator', () => {
-        const result = convertStreamColors('0 0 0 1 k', {}, false, new Set());
+        const result = convertColors('0 0 0 1 k', new Map());
         expect(result).toBe('0 0 0 1 k');
       });
 
       it('preserves K operator', () => {
-        const result = convertStreamColors('1 0 0 0 K', {}, false, new Set());
+        const result = convertColors('1 0 0 0 K', new Map());
         expect(result).toBe('1 0 0 0 K');
       });
 
       it('preserves g operator', () => {
-        const result = convertStreamColors('0.5 g', {}, false, new Set());
+        const result = convertColors('0.5 g', new Map());
         expect(result).toBe('0.5 g');
       });
 
       it('preserves G operator', () => {
-        const result = convertStreamColors('0.5 G', {}, false, new Set());
+        const result = convertColors('0.5 G', new Map());
         expect(result).toBe('0.5 G');
       });
     });
 
     describe('PDF operators', () => {
       it('preserves text operators', () => {
-        const result = convertStreamColors(
-          'BT /F1 12 Tf ET',
-          {},
-          false,
-          new Set(),
-        );
+        const result = convertColors('BT /F1 12 Tf ET', new Map());
         expect(result).toBe('BT /F1 12 Tf ET');
       });
 
       it('preserves path operators', () => {
-        const result = convertStreamColors(
-          '100 200 m 300 400 l S',
-          {},
-          false,
-          new Set(),
-        );
+        const result = convertColors('100 200 m 300 400 l S', new Map());
         expect(result).toBe('100 200 m 300 400 l S');
       });
 
       it('preserves graphics state operators', () => {
-        const result = convertStreamColors(
-          'q 1 0 0 1 50 50 cm Q',
-          {},
-          false,
-          new Set(),
-        );
+        const result = convertColors('q 1 0 0 1 50 50 cm Q', new Map());
         expect(result).toBe('q 1 0 0 1 50 50 cm Q');
       });
     });
 
     describe('PDF syntax elements', () => {
       it('preserves string literals', () => {
-        const result = convertStreamColors(
-          '(Hello World) Tj',
-          {},
-          false,
-          new Set(),
-        );
+        const result = convertColors('(Hello World) Tj', new Map());
         expect(result).toBe('(Hello World) Tj');
       });
 
       it('preserves nested parentheses in strings', () => {
-        const result = convertStreamColors(
-          '(test (nested) string) Tj',
-          {},
-          false,
-          new Set(),
-        );
+        const result = convertColors('(test (nested) string) Tj', new Map());
         expect(result).toBe('(test (nested) string) Tj');
       });
 
       it('preserves escaped characters in strings', () => {
-        const result = convertStreamColors(
-          '(line1\\nline2) Tj',
-          {},
-          false,
-          new Set(),
-        );
+        const result = convertColors('(line1\\nline2) Tj', new Map());
         expect(result).toBe('(line1\\nline2) Tj');
       });
 
       it('preserves escaped parentheses in strings', () => {
-        const result = convertStreamColors(
-          '(test\\(escaped\\)parens) Tj',
-          {},
-          false,
-          new Set(),
-        );
+        const result = convertColors('(test\\(escaped\\)parens) Tj', new Map());
         expect(result).toBe('(test\\(escaped\\)parens) Tj');
       });
 
       it('preserves empty strings', () => {
-        const result = convertStreamColors('() Tj', {}, false, new Set());
+        const result = convertColors('() Tj', new Map());
         expect(result).toBe('() Tj');
       });
 
       it('preserves hex strings', () => {
-        const result = convertStreamColors(
-          '<48454C4C4F> Tj',
-          {},
-          false,
-          new Set(),
-        );
+        const result = convertColors('<48454C4C4F> Tj', new Map());
         expect(result).toBe('<48454C4C4F> Tj');
       });
 
       it('preserves hex strings with spaces', () => {
-        const result = convertStreamColors(
-          '<48 65 6C 6C 6F> Tj',
-          {},
-          false,
-          new Set(),
-        );
+        const result = convertColors('<48 65 6C 6C 6F> Tj', new Map());
         expect(result).toBe('<48 65 6C 6C 6F> Tj');
       });
 
       it('preserves empty hex strings', () => {
-        const result = convertStreamColors('<> Tj', {}, false, new Set());
+        const result = convertColors('<> Tj', new Map());
         expect(result).toBe('<> Tj');
       });
 
       it('preserves names', () => {
-        const result = convertStreamColors(
-          '/DeviceCMYK cs',
-          {},
-          false,
-          new Set(),
-        );
+        const result = convertColors('/DeviceCMYK cs', new Map());
         expect(result).toBe('/DeviceCMYK cs');
       });
 
       it('preserves names with special characters', () => {
-        const result = convertStreamColors(
-          '/sRGB-IEC61966-2.1 cs',
-          {},
-          false,
-          new Set(),
-        );
+        const result = convertColors('/sRGB-IEC61966-2.1 cs', new Map());
         expect(result).toBe('/sRGB-IEC61966-2.1 cs');
       });
 
       it('preserves inline dictionaries', () => {
-        const result = convertStreamColors(
-          '/Span << /MCID 0 >> BDC',
-          {},
-          false,
-          new Set(),
-        );
+        const result = convertColors('/Span << /MCID 0 >> BDC', new Map());
         expect(result).toBe('/Span << /MCID 0 >> BDC');
       });
 
       it('distinguishes hex strings from dictionary markers', () => {
-        const result = convertStreamColors(
-          '<< /Key <ABCD> >>',
-          {},
-          false,
-          new Set(),
-        );
+        const result = convertColors('<< /Key <ABCD> >>', new Map());
         expect(result).toBe('<< /Key <ABCD> >>');
       });
 
       it('preserves arrays', () => {
-        const result = convertStreamColors('[1 2 3] TJ', {}, false, new Set());
+        const result = convertColors('[1 2 3] TJ', new Map());
         expect(result).toBe('[ 1 2 3 ] TJ');
       });
 
       it('preserves comments', () => {
-        const result = convertStreamColors(
-          '% comment\n0.5 g',
-          {},
-          false,
-          new Set(),
-        );
+        const result = convertColors('% comment\n0.5 g', new Map());
         expect(result).toBe('% comment 0.5 g');
       });
     });
 
     describe('number formats', () => {
       it('handles integers', () => {
-        const result = convertStreamColors('42 g', {}, false, new Set());
+        const result = convertColors('42 g', new Map());
         expect(result).toBe('42 g');
       });
 
       it('handles floating point numbers', () => {
-        const result = convertStreamColors('3.14159 g', {}, false, new Set());
+        const result = convertColors('3.14159 g', new Map());
         expect(result).toBe('3.14159 g');
       });
 
       it('handles negative numbers', () => {
-        const result = convertStreamColors('-123 0 m', {}, false, new Set());
+        const result = convertColors('-123 0 m', new Map());
         expect(result).toBe('-123 0 m');
       });
 
       it('handles positive numbers with explicit sign', () => {
-        const result = convertStreamColors('+456 0 m', {}, false, new Set());
+        const result = convertColors('+456 0 m', new Map());
         expect(result).toBe('+456 0 m');
       });
 
       it('handles numbers starting with decimal point', () => {
-        const result = convertStreamColors('.5 g', {}, false, new Set());
+        const result = convertColors('.5 g', new Map());
         expect(result).toBe('.5 g');
       });
 
       it('handles numbers ending with decimal point', () => {
-        const result = convertStreamColors('5. g', {}, false, new Set());
+        const result = convertColors('5. g', new Map());
         expect(result).toBe('5. g');
       });
     });
 
     describe('whitespace handling', () => {
       it('handles various whitespace characters', () => {
-        const result = convertStreamColors(
-          '1\t2\n3\r4 re',
-          {},
-          false,
-          new Set(),
-        );
+        const result = convertColors('1\t2\n3\r4 re', new Map());
         expect(result).toBe('1 2 3 4 re');
       });
 
       it('handles empty input', () => {
-        const result = convertStreamColors('', {}, false, new Set());
+        const result = convertColors('', new Map());
         expect(result).toBe('');
       });
 
       it('handles whitespace-only input', () => {
-        const result = convertStreamColors('   \t\n   ', {}, false, new Set());
+        const result = convertColors('   \t\n   ', new Map());
         expect(result).toBe('');
       });
     });
@@ -383,7 +302,7 @@ describe('convertStreamColors', () => {
         [0, 0, 0, { c: 0, m: 0, y: 0, k: 10000 }],
       ]);
       const input = 'BT 0 0 0 rg /F1 12 Tf (Hello) Tj ET';
-      const result = convertStreamColors(input, colorMap, false, new Set());
+      const result = convertColors(input, colorMap);
       expect(result).toBe('BT 0 0 0 1 k /F1 12 Tf (Hello) Tj ET');
     });
 
@@ -392,7 +311,7 @@ describe('convertStreamColors', () => {
         [10000, 0, 0, { c: 0, m: 10000, y: 10000, k: 0 }],
       ]);
       const input = 'q 1 0 0 RG 100 100 200 200 re S Q';
-      const result = convertStreamColors(input, colorMap, false, new Set());
+      const result = convertColors(input, colorMap);
       expect(result).toBe('q 0 1 1 0 K 100 100 200 200 re S Q');
     });
 
@@ -403,7 +322,7 @@ describe('convertStreamColors', () => {
       ]);
       const input =
         '0 0 0 rg 50 50 m 100 100 l S 1 0 0 rg 150 150 m 200 200 l S';
-      const result = convertStreamColors(input, colorMap, false, new Set());
+      const result = convertColors(input, colorMap);
       expect(result).toBe(
         '0 0 0 1 k 50 50 m 100 100 l S 0 1 1 0 k 150 150 m 200 200 l S',
       );
@@ -415,7 +334,7 @@ describe('convertStreamColors', () => {
       ]);
       const input =
         '/NonStruct << /MCID 0 >> BDC BT 0 0 0 rg /F4 127 Tf ET EMC';
-      const result = convertStreamColors(input, colorMap, false, new Set());
+      const result = convertColors(input, colorMap);
       expect(result).toBe(
         '/NonStruct << /MCID 0 >> BDC BT 0 0 0 1 k /F4 127 Tf ET EMC',
       );
@@ -423,7 +342,7 @@ describe('convertStreamColors', () => {
 
     it('handles crop marks with CMYK colors (no conversion needed)', () => {
       const input = 'q 1 0 0 1 K 0 49.133858 m 37.795277 49.133858 l S Q';
-      const result = convertStreamColors(input, {}, false, new Set());
+      const result = convertColors(input, new Map());
       expect(result).toBe(
         'q 1 0 0 1 K 0 49.133858 m 37.795277 49.133858 l S Q',
       );
@@ -434,66 +353,40 @@ describe('convertStreamColors', () => {
         [0, 0, 0, { c: 0, m: 0, y: 0, k: 10000 }],
       ]);
       const input = '/G3 gs 0 0 0 rg';
-      const result = convertStreamColors(input, colorMap, false, new Set());
+      const result = convertColors(input, colorMap);
       expect(result).toBe('/G3 gs 0 0 0 1 k');
     });
   });
 
-  describe('warning for unmapped colors', () => {
-    let logWarnMock: ReturnType<typeof vi.fn>;
-    let originalLogWarn: typeof import('../src/logger.js').Logger.logWarn;
-
-    beforeEach(async () => {
-      const Logger = (await import('../src/logger.js')).Logger;
-      originalLogWarn = Logger.logWarn;
-      logWarnMock = vi.fn<(...messages: any[]) => void>();
-      Logger.logWarn = logWarnMock as typeof Logger.logWarn;
+  describe('unmapped color reporting', () => {
+    it('reports unmapped colors', () => {
+      expect(reportUnmappedColors('0.1 0.2 0.3 rg')).toEqual([
+        '1 RGB color(s) not mapped to CMYK',
+      ]);
     });
 
-    afterEach(async () => {
-      const Logger = (await import('../src/logger.js')).Logger;
-      Logger.logWarn = originalLogWarn;
+    it('reports duplicate colors once', () => {
+      expect(reportUnmappedColors('0.1 0.2 0.3 rg 0.1 0.2 0.3 rg')).toEqual([
+        '1 RGB color(s) not mapped to CMYK',
+      ]);
     });
 
-    it('warns for unmapped rg colors when warnUnmapped is true', () => {
-      convertStreamColors('0.1 0.2 0.3 rg', {}, true, new Set());
-      expect(logWarnMock).toHaveBeenCalledWith(
-        'RGB color not mapped to CMYK: {"r":1000,"g":2000,"b":3000}',
-      );
+    it('reports different colors separately', () => {
+      expect(reportUnmappedColors('0.1 0.2 0.3 rg 0.4 0.5 0.6 rg')).toEqual([
+        '2 RGB color(s) not mapped to CMYK',
+      ]);
     });
 
-    it('warns for unmapped RG colors when warnUnmapped is true', () => {
-      convertStreamColors('0.1 0.2 0.3 RG', {}, true, new Set());
-      expect(logWarnMock).toHaveBeenCalledWith(
-        'RGB color not mapped to CMYK: {"r":1000,"g":2000,"b":3000}',
-      );
+    it('reports colors once across multiple visits', () => {
+      expect(reportUnmappedColors('0.1 0.2 0.3 rg', '0.1 0.2 0.3 rg')).toEqual([
+        '1 RGB color(s) not mapped to CMYK',
+      ]);
     });
 
-    it('does not warn when warnUnmapped is false', () => {
-      convertStreamColors('0.1 0.2 0.3 rg', {}, false, new Set());
-      expect(logWarnMock).not.toHaveBeenCalled();
-    });
-
-    it('warns only once for duplicate colors in same stream', () => {
-      convertStreamColors('0.1 0.2 0.3 rg 0.1 0.2 0.3 rg', {}, true, new Set());
-      expect(logWarnMock).toHaveBeenCalledTimes(1);
-    });
-
-    it('warns separately for different colors', () => {
-      convertStreamColors('0.1 0.2 0.3 rg 0.4 0.5 0.6 rg', {}, true, new Set());
-      expect(logWarnMock).toHaveBeenCalledTimes(2);
-    });
-
-    it('tracks warned colors across multiple calls', () => {
-      const warnedColors = new Set<string>();
-      convertStreamColors('0.1 0.2 0.3 rg', {}, true, warnedColors);
-      convertStreamColors('0.1 0.2 0.3 rg', {}, true, warnedColors);
-      expect(logWarnMock).toHaveBeenCalledTimes(1);
-    });
-
-    it('shares warned colors between rg and RG operators', () => {
-      convertStreamColors('0.1 0.2 0.3 rg 0.1 0.2 0.3 RG', {}, true, new Set());
-      expect(logWarnMock).toHaveBeenCalledTimes(1);
+    it('reports a shared color once for rg and RG operators', () => {
+      expect(reportUnmappedColors('0.1 0.2 0.3 rg 0.1 0.2 0.3 RG')).toEqual([
+        '1 RGB color(s) not mapped to CMYK',
+      ]);
     });
   });
 
@@ -501,7 +394,7 @@ describe('convertStreamColors', () => {
     it('skips binary data between ID and EI', () => {
       // Binary data could contain byte sequences that look like "0.5 0.5 0.5 rg"
       const input = 'BI /W 10 /H 10 ID binary0.5 0.5 0.5 rgdata EI';
-      const result = convertStreamColors(input, {}, false, new Set());
+      const result = convertColors(input, new Map());
       // The binary data should pass through unchanged
       expect(result).toContain('ID');
       expect(result).toContain('EI');
@@ -514,36 +407,26 @@ describe('convertStreamColors', () => {
         [5000, 5000, 5000, { c: 0, m: 0, y: 0, k: 5000 }],
       ]);
       const input = 'BI /W 1 /H 1 ID x EI 0.5 0.5 0.5 rg';
-      const result = convertStreamColors(input, colorMap, false, new Set());
+      const result = convertColors(input, colorMap);
       expect(result).toContain('0 0 0 0.5 k');
     });
 
     it('handles inline image with EI-like bytes in data', () => {
       // "EI" without proper whitespace context should not end the image
       const input = 'BI /W 1 /H 1 ID xEIy EI';
-      const result = convertStreamColors(input, {}, false, new Set());
+      const result = convertColors(input, new Map());
       expect(result).toContain('EI');
     });
   });
 
   describe('edge cases', () => {
     it('handles negative color values (out of range)', () => {
-      const result = convertStreamColors(
-        '-0.1 0.2 0.3 rg',
-        {},
-        false,
-        new Set(),
-      );
+      const result = convertColors('-0.1 0.2 0.3 rg', new Map());
       expect(result).toBe('-0.1 0.2 0.3 rg');
     });
 
     it('handles color values > 1 (out of range)', () => {
-      const result = convertStreamColors(
-        '1.5 0.5 0.5 rg',
-        {},
-        false,
-        new Set(),
-      );
+      const result = convertColors('1.5 0.5 0.5 rg', new Map());
       expect(result).toBe('1.5 0.5 0.5 rg');
     });
 
@@ -552,12 +435,7 @@ describe('convertStreamColors', () => {
       const colorMap = createColorMap([
         [1235, 6789, 10000, { c: 1000, m: 2000, y: 3000, k: 4000 }],
       ]);
-      const result = convertStreamColors(
-        '0.12345 0.6789 0.99999 rg',
-        colorMap,
-        false,
-        new Set(),
-      );
+      const result = convertColors('0.12345 0.6789 0.99999 rg', colorMap);
       expect(result).toBe('0.1 0.2 0.3 0.4 k');
     });
   });

--- a/tests/cmyk.test.ts
+++ b/tests/cmyk.test.ts
@@ -3,10 +3,32 @@ import path from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
+import type { CmykConfig } from '../src/config/resolve.js';
 import type { CmykMap } from '../src/global-viewer.js';
-import { convertCmykColors } from '../src/output/cmyk.js';
+import { createCmykColorHook } from '../src/output/cmyk.js';
+import { editPdf } from '../src/output/pdf-visitor.js';
 
 const fixturesDir = path.join(import.meta.dirname, 'fixtures', 'cmyk');
+const signal = AbortSignal.any([]);
+
+function convertCmykColors({
+  pdf,
+  colorMap,
+  ifUnmappedColorsFound,
+  failures,
+}: {
+  pdf: Uint8Array;
+  colorMap: CmykMap;
+  ifUnmappedColorsFound: CmykConfig['ifUnmappedColorsFound'];
+  failures: string[];
+}): Promise<Uint8Array> {
+  const hook = createCmykColorHook(
+    new Map(Object.entries(colorMap)),
+    ifUnmappedColorsFound,
+    failures,
+  );
+  return editPdf(pdf, [hook], { signal });
+}
 
 /**
  * Helper to extract text content from a PDF content stream
@@ -42,6 +64,84 @@ async function extractPdfContentStream(pdf: Uint8Array): Promise<string[]> {
 
   doc.destroy();
   return contents;
+}
+
+async function addAnnotationAppearance(pdf: Uint8Array): Promise<Uint8Array> {
+  const mupdf = await import('mupdf');
+  const doc = mupdf.PDFDocument.openDocument(
+    pdf,
+    'application/pdf',
+  ) as import('mupdf').PDFDocument;
+  const page = doc.loadPage(0);
+  const pageObject = page.getObject().resolve();
+  const appearanceDictionary = doc.newDictionary();
+  appearanceDictionary.put('Type', doc.newName('XObject'));
+  appearanceDictionary.put('Subtype', doc.newName('Form'));
+  const bbox = doc.newArray();
+  for (const value of [0, 0, 1, 1]) {
+    bbox.push(doc.newInteger(value));
+  }
+  appearanceDictionary.put('BBox', bbox);
+  const appearance = doc.addStream('1 0 0 rg', appearanceDictionary);
+  const appearanceStates = doc.newDictionary();
+  appearanceStates.put('N', appearance);
+  const annotation = doc.newDictionary();
+  annotation.put('AP', appearanceStates);
+  const annotations = doc.newArray();
+  annotations.push(doc.addObject(annotation));
+  pageObject.put('Annots', annotations);
+  const output = doc.saveToBuffer('compress');
+  const result = new Uint8Array(output.asUint8Array());
+  output.destroy();
+  page.destroy();
+  doc.destroy();
+  return result;
+}
+
+async function replacePageContentsWithRepeatedColorStreams(
+  pdf: Uint8Array,
+  streamCount: number,
+): Promise<Uint8Array> {
+  const mupdf = await import('mupdf');
+  const doc = mupdf.PDFDocument.openDocument(
+    pdf,
+    'application/pdf',
+  ) as import('mupdf').PDFDocument;
+  const page = doc.loadPage(0);
+  const contents = doc.newArray();
+  for (let index = 0; index < streamCount; index++) {
+    contents.push(doc.addStream('0.1 0.2 0.3 rg', doc.newDictionary()));
+  }
+  page.getObject().resolve().put('Contents', contents);
+  const output = doc.saveToBuffer('compress');
+  const result = new Uint8Array(output.asUint8Array());
+  output.destroy();
+  page.destroy();
+  doc.destroy();
+  return result;
+}
+
+async function getAnnotationAppearance(pdf: Uint8Array): Promise<string> {
+  const mupdf = await import('mupdf');
+  const doc = mupdf.PDFDocument.openDocument(
+    pdf,
+    'application/pdf',
+  ) as import('mupdf').PDFDocument;
+  const page = doc.loadPage(0);
+  const appearance = page
+    .getObject()
+    .resolve()
+    .get('Annots')
+    .get(0)
+    .resolve()
+    .get('AP')
+    .get('N');
+  const content = appearance.readStream();
+  const result = content.asString();
+  content.destroy();
+  page.destroy();
+  doc.destroy();
+  return result;
 }
 
 /**
@@ -91,7 +191,8 @@ describe('convertCmykColors', () => {
     const destPdf = await convertCmykColors({
       pdf: srcPdf,
       colorMap,
-      unmappedColors: null,
+      ifUnmappedColorsFound: 'ignore',
+      failures: [],
     });
 
     // Verify destination PDF contains CMYK operators
@@ -117,31 +218,57 @@ describe('convertCmykColors', () => {
     const destPdf = await convertCmykColors({
       pdf: srcPdf,
       colorMap,
-      unmappedColors: null,
+      ifUnmappedColorsFound: 'ignore',
+      failures: [],
     });
 
     expect(destPdf).toBeInstanceOf(Uint8Array);
     expect(destPdf.length).toBeGreaterThan(0);
   });
 
-  it('collects unmapped colors', async () => {
+  it('converts colors in annotation appearance streams', async () => {
     const srcPdf = fs.readFileSync(path.join(fixturesDir, 'text.pdf'));
-    const unmappedColors = new Set<string>();
+    const annotatedPdf = await addAnnotationAppearance(srcPdf);
+
+    const destPdf = await convertCmykColors({
+      pdf: annotatedPdf,
+      colorMap: {
+        '[10000,0,0]': { c: 0, m: 10000, y: 10000, k: 0 },
+      },
+      ifUnmappedColorsFound: 'ignore',
+      failures: [],
+    });
+
+    expect(await getAnnotationAppearance(destPdf)).toBe('0 1 1 0 k');
+  });
+
+  it('reports unmapped colors', async () => {
+    const srcPdf = fs.readFileSync(path.join(fixturesDir, 'text.pdf'));
+    const failures: string[] = [];
 
     await convertCmykColors({
       pdf: srcPdf,
       colorMap: {},
-      unmappedColors,
+      ifUnmappedColorsFound: 'error',
+      failures,
     });
 
-    expect(unmappedColors.size).toBeGreaterThan(0);
-    for (const color of unmappedColors) {
-      expect(JSON.parse(color)).toMatchObject({
-        r: expect.any(Number),
-        g: expect.any(Number),
-        b: expect.any(Number),
-      });
-    }
+    expect(failures).toEqual([
+      expect.stringMatching(/^\d+ RGB color\(s\) not mapped to CMYK$/v),
+    ]);
+  });
+
+  it('stores repeated unmapped colors once across content streams', async () => {
+    const srcPdf = fs.readFileSync(path.join(fixturesDir, 'text.pdf'));
+    const repeatedColorPdf = await replacePageContentsWithRepeatedColorStreams(
+      srcPdf,
+      64,
+    );
+    const failures: string[] = [];
+    const hook = createCmykColorHook(new Map(), 'error', failures);
+    await editPdf(repeatedColorPdf, [hook], { signal });
+
+    expect(failures).toEqual(['1 RGB color(s) not mapped to CMYK']);
   });
 
   it('preserves unmapped RGB colors', async () => {
@@ -151,7 +278,8 @@ describe('convertCmykColors', () => {
       pdf: srcPdf,
       // no colors will be converted
       colorMap: {},
-      unmappedColors: null,
+      ifUnmappedColorsFound: 'ignore',
+      failures: [],
     });
 
     // Verify destination PDF still contains RGB operators

--- a/tests/image.test.ts
+++ b/tests/image.test.ts
@@ -1,11 +1,46 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
-import { replaceImages } from '../src/output/image.js';
+import type { CmykConfig } from '../src/config/resolve.js';
+import { Logger } from '../src/logger.js';
+import { createCmykColorHook } from '../src/output/cmyk.js';
+import { createReplaceImageHook } from '../src/output/image.js';
+import { editPdf } from '../src/output/pdf-visitor.js';
 
 const fixturesDir = path.join(import.meta.dirname, 'fixtures', 'cmyk');
+const signal = AbortSignal.any([]);
+
+async function replaceImages(
+  pdf: Uint8Array,
+  options: {
+    replacements: Parameters<typeof createReplaceImageHook>[0];
+    ifIncompatibleImagesFound: CmykConfig['ifIncompatibleImagesFound'];
+  },
+) {
+  const warnings: string[] = [];
+  const warning = vi.spyOn(Logger, 'logWarn').mockImplementation((message) => {
+    if (
+      typeof message === 'string' &&
+      message.startsWith('Image color space is incompatible')
+    ) {
+      warnings.push(message);
+    }
+  });
+  const failures: string[] = [];
+  try {
+    using replaceImageHook = await createReplaceImageHook(
+      options.replacements,
+      options.ifIncompatibleImagesFound,
+      failures,
+    );
+    const result = await editPdf(pdf, [replaceImageHook], { signal });
+    return { pdf: result, warnings, failures };
+  } finally {
+    warning.mockRestore();
+  }
+}
 
 /**
  * Helper to extract image color space from PDF
@@ -50,6 +85,7 @@ async function getImageColorSpace(
           : objectColorSpace.toString(),
         image: imageColorSpace?.getName() ?? 'Unknown',
       };
+      imageColorSpace?.destroy();
     }
   });
 
@@ -76,7 +112,9 @@ async function getXrefImageColorSpaces(pdf: Uint8Array): Promise<string[]> {
         continue;
       }
       const image = doc.loadImage(ref);
-      colorSpaces.push(image.getColorSpace()?.getName() ?? 'Unknown');
+      const imageColorSpace = image.getColorSpace();
+      colorSpaces.push(imageColorSpace?.getName() ?? 'Unknown');
+      imageColorSpace?.destroy();
       image.destroy();
     } catch {
       continue;
@@ -227,7 +265,9 @@ async function getRetainedImageColorSpace(pdf: Uint8Array): Promise<string> {
         continue;
       }
       const image = doc.loadImage(object.get('Image'));
-      const colorSpace = image.getColorSpace()?.getName() ?? 'Unknown';
+      const imageColorSpace = image.getColorSpace();
+      const colorSpace = imageColorSpace?.getName() ?? 'Unknown';
+      imageColorSpace?.destroy();
       image.destroy();
       doc.destroy();
       return colorSpace;
@@ -298,7 +338,9 @@ async function getSoftMaskColorSpace(pdf: Uint8Array): Promise<string> {
         continue;
       }
       const image = doc.loadImage(softMask);
-      const colorSpace = image.getColorSpace()?.getName() ?? 'Unknown';
+      const imageColorSpace = image.getColorSpace();
+      const colorSpace = imageColorSpace?.getName() ?? 'Unknown';
+      imageColorSpace?.destroy();
       image.destroy();
       doc.destroy();
       return colorSpace;
@@ -405,6 +447,192 @@ async function convertFirstImageToIndexed(
   return result;
 }
 
+function createFormXObject(
+  doc: import('mupdf').PDFDocument,
+  xobjects: import('mupdf').PDFObject,
+  content: string,
+): import('mupdf').PDFObject {
+  const resources = doc.newDictionary();
+  resources.put('XObject', xobjects);
+  return createFormXObjectWithResources(doc, resources, content);
+}
+
+function createFormXObjectWithResources(
+  doc: import('mupdf').PDFDocument,
+  resources: import('mupdf').PDFObject,
+  content: string,
+): import('mupdf').PDFObject {
+  const dictionary = doc.newDictionary();
+  dictionary.put('Type', doc.newName('XObject'));
+  dictionary.put('Subtype', doc.newName('Form'));
+  const bbox = doc.newArray();
+  for (const value of [0, 0, 1, 1]) {
+    bbox.push(doc.newInteger(value));
+  }
+  dictionary.put('BBox', bbox);
+  dictionary.put('Resources', resources);
+  return doc.addStream(content, dictionary);
+}
+
+async function nestFirstImageInForms(
+  pdf: Uint8Array,
+  circular = false,
+): Promise<Uint8Array> {
+  const mupdf = await import('mupdf');
+  const doc = mupdf.PDFDocument.openDocument(
+    pdf,
+    'application/pdf',
+  ) as import('mupdf').PDFDocument;
+  const page = doc.loadPage(0);
+  const xobjects = page.getObject().resolve().get('Resources').get('XObject');
+  const { key, value: image } = findFirstImageXObject(xobjects);
+
+  const innerXObjects = doc.newDictionary();
+  innerXObjects.put('NestedImage', image);
+  const inner = createFormXObject(
+    doc,
+    innerXObjects,
+    '1 0 0 rg /NestedImage Do',
+  );
+
+  const outerXObjects = doc.newDictionary();
+  outerXObjects.put('InnerForm', inner);
+  const outer = createFormXObject(doc, outerXObjects, '/InnerForm Do');
+  if (circular) {
+    innerXObjects.put('OuterForm', outer);
+  }
+  xobjects.put(key, outer);
+
+  const output = doc.saveToBuffer('compress');
+  const result = new Uint8Array(output.asUint8Array());
+  output.destroy();
+  page.destroy();
+  doc.destroy();
+  return result;
+}
+
+async function shareResourcesBetweenForms(
+  pdf: Uint8Array,
+): Promise<Uint8Array> {
+  const mupdf = await import('mupdf');
+  const doc = mupdf.PDFDocument.openDocument(
+    pdf,
+    'application/pdf',
+  ) as import('mupdf').PDFDocument;
+  const page = doc.loadPage(0);
+  const pageXObjects = page
+    .getObject()
+    .resolve()
+    .get('Resources')
+    .get('XObject');
+  const { key, value: image } = findFirstImageXObject(pageXObjects);
+  const sharedXObjects = doc.newDictionary();
+  sharedXObjects.put('SharedImage', image);
+  const sharedResources = doc.newDictionary();
+  sharedResources.put('XObject', sharedXObjects);
+  const sharedResourcesReference = doc.addObject(sharedResources);
+  const firstForm = createFormXObjectWithResources(
+    doc,
+    sharedResourcesReference,
+    '/SharedImage Do',
+  );
+  const secondForm = createFormXObjectWithResources(
+    doc,
+    sharedResourcesReference,
+    '/SharedImage Do',
+  );
+  pageXObjects.put(key, firstForm);
+  pageXObjects.put('SharedForm', secondForm);
+
+  const output = doc.saveToBuffer('compress');
+  const result = new Uint8Array(output.asUint8Array());
+  output.destroy();
+  page.destroy();
+  doc.destroy();
+  return result;
+}
+
+async function shareResourcesBetweenPages(
+  pdf: Uint8Array,
+): Promise<Uint8Array> {
+  const mupdf = await import('mupdf');
+  const doc = mupdf.PDFDocument.openDocument(
+    pdf,
+    'application/pdf',
+  ) as import('mupdf').PDFDocument;
+  const page = doc.loadPage(0);
+  const pageObject = page.getObject().resolve();
+  const resources = pageObject.get('Resources');
+  const sharedResources = resources.asIndirect()
+    ? resources
+    : doc.addObject(resources);
+  pageObject.put('Resources', sharedResources);
+  const secondPage = doc.addPage(page.getBounds(), 0, sharedResources, '');
+  doc.insertPage(-1, secondPage);
+
+  const output = doc.saveToBuffer('compress');
+  const result = new Uint8Array(output.asUint8Array());
+  output.destroy();
+  page.destroy();
+  doc.destroy();
+  return result;
+}
+
+async function inspectNestedForms(pdf: Uint8Array): Promise<{
+  colorSpaces: string[];
+  contents: string[];
+}> {
+  const mupdf = await import('mupdf');
+  const doc = mupdf.PDFDocument.openDocument(
+    pdf,
+    'application/pdf',
+  ) as import('mupdf').PDFDocument;
+  const page = doc.loadPage(0);
+  const processedForms = new Set<number>();
+  const colorSpaces: string[] = [];
+  const contents: string[] = [];
+
+  const inspectResources = (resources: import('mupdf').PDFObject): void => {
+    const xobjects = resources.get('XObject');
+    if (!xobjects?.isDictionary()) {
+      return;
+    }
+    xobjects.forEach((value) => {
+      const subtype = value.get('Subtype')?.toString();
+      if (subtype === '/Image') {
+        const image = doc.loadImage(value);
+        const imageColorSpace = image.getColorSpace();
+        colorSpaces.push(imageColorSpace?.getName() ?? 'Unknown');
+        imageColorSpace?.destroy();
+        image.destroy();
+        return;
+      }
+      if (subtype !== '/Form') {
+        return;
+      }
+      const objectNumber = value.asIndirect();
+      if (objectNumber && processedForms.has(objectNumber)) {
+        return;
+      }
+      if (objectNumber) {
+        processedForms.add(objectNumber);
+      }
+      const content = value.readStream();
+      contents.push(content.asString());
+      content.destroy();
+      const nestedResources = value.get('Resources');
+      if (nestedResources?.isDictionary()) {
+        inspectResources(nestedResources);
+      }
+    });
+  };
+
+  inspectResources(page.getObject().resolve().get('Resources'));
+  page.destroy();
+  doc.destroy();
+  return { colorSpaces, contents };
+}
+
 describe('replaceImages', () => {
   it.each([
     ['Gray', 'ck_gray.pgm', '/DeviceGray', 'DeviceGray', 0],
@@ -420,7 +648,7 @@ describe('replaceImages', () => {
       incompatibleCount,
     ) => {
       const srcPdf = fs.readFileSync(path.join(fixturesDir, 'image.pdf'));
-      const { pdf: destPdf, incompatibleImages } = await replaceImages(srcPdf, {
+      const { pdf: destPdf, warnings } = await replaceImages(srcPdf, {
         replacements: [
           {
             source: path.join(fixturesDir, 'ck_rgb.png'),
@@ -434,13 +662,13 @@ describe('replaceImages', () => {
         object: objectColorSpace,
         image: imageColorSpace,
       });
-      expect(incompatibleImages).toHaveLength(incompatibleCount);
+      expect(warnings).toHaveLength(incompatibleCount);
     },
   );
 
   it('preserves an ICCBased replacement color space', async () => {
     const srcPdf = fs.readFileSync(path.join(fixturesDir, 'image.pdf'));
-    const { pdf: destPdf, incompatibleImages } = await replaceImages(srcPdf, {
+    const { pdf: destPdf, warnings } = await replaceImages(srcPdf, {
       replacements: [
         {
           source: path.join(fixturesDir, 'ck_rgb.png'),
@@ -454,11 +682,27 @@ describe('replaceImages', () => {
       object: '/ICCBased',
       image: 'ICCBased(RGB,sRGB IEC61966-2.1)',
     });
-    expect(incompatibleImages).toEqual([
-      expect.objectContaining({
-        colorSpace: expect.stringMatching(/^ICCBased/v),
-      }),
-    ]);
+    expect(warnings).toEqual([expect.stringContaining('(ICCBased')]);
+  });
+
+  it('replaces images when the incompatible image policy is ignore', async () => {
+    const srcPdf = fs.readFileSync(path.join(fixturesDir, 'image.pdf'));
+
+    const { pdf: destPdf, warnings } = await replaceImages(srcPdf, {
+      replacements: [
+        {
+          source: path.join(fixturesDir, 'ck_rgb.png'),
+          replacement: path.join(fixturesDir, 'ck_cmyk.tiff'),
+        },
+      ],
+      ifIncompatibleImagesFound: 'ignore',
+    });
+
+    expect(await getImageColorSpace(destPdf)).toEqual({
+      object: '/DeviceCMYK',
+      image: 'DeviceCMYK',
+    });
+    expect(warnings).toEqual([]);
   });
 
   it('removes replaced image objects that are no longer referenced', async () => {
@@ -582,7 +826,29 @@ describe('replaceImages', () => {
       ifIncompatibleImagesFound: 'ignore',
     });
 
-    expect(result).toEqual({ pdf: srcPdf, incompatibleImages: [] });
+    expect(result).toEqual({ pdf: srcPdf, warnings: [], failures: [] });
+  });
+
+  it('returns an empty hook when no replacement pairs can be loaded and the policy is ignore', async () => {
+    const warning = vi.spyOn(Logger, 'logWarn').mockImplementation(() => {});
+
+    try {
+      using hook = await createReplaceImageHook(
+        [
+          {
+            source: path.join(fixturesDir, 'missing-source.png'),
+            replacement: path.join(fixturesDir, 'ck_cmyk.tiff'),
+          },
+        ],
+        'ignore',
+        [],
+      );
+
+      expect(hook.visit).toBeUndefined();
+      expect(hook.complete).toBeUndefined();
+    } finally {
+      warning.mockRestore();
+    }
   });
 
   it('reports incompatible images when replacements are empty', async () => {
@@ -594,14 +860,10 @@ describe('replaceImages', () => {
     });
 
     expect(result.pdf).toEqual(pdf);
-    expect(result.incompatibleImages).toEqual([
-      {
-        key: expect.anything(),
-        colorSpace: expect.any(String),
-        width: expect.any(Number),
-        height: expect.any(Number),
-        pageIndex: 0,
-      },
+    expect(result.warnings).toEqual([
+      expect.stringMatching(
+        /^Image color space is incompatible with Device CMYK: ref ".+" \(.+, \d+x\d+\) on page 1$/v,
+      ),
     ]);
   });
 
@@ -614,7 +876,7 @@ describe('replaceImages', () => {
       ifIncompatibleImagesFound: 'warn',
     });
 
-    expect(result.incompatibleImages).toHaveLength(1);
+    expect(result.warnings).toHaveLength(1);
   });
 
   it('reports unmatched images encountered by the replacement scan', async () => {
@@ -630,7 +892,10 @@ describe('replaceImages', () => {
       ifIncompatibleImagesFound: 'error',
     });
 
-    expect(result.incompatibleImages).toHaveLength(1);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.failures).toEqual([
+      '1 image(s) incompatible with Device CMYK color',
+    ]);
   });
 
   it('accepts PDFs without images', async () => {
@@ -641,6 +906,196 @@ describe('replaceImages', () => {
       ifIncompatibleImagesFound: 'warn',
     });
 
-    expect(result.incompatibleImages).toEqual([]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('replaces and validates images nested in Form XObjects', async () => {
+    const pdf = fs.readFileSync(path.join(fixturesDir, 'image.pdf'));
+    const nestedPdf = await nestFirstImageInForms(pdf);
+
+    const result = await replaceImages(nestedPdf, {
+      replacements: [
+        {
+          source: path.join(fixturesDir, 'ck_rgb.png'),
+          replacement: path.join(fixturesDir, 'ck_cmyk.tiff'),
+        },
+      ],
+      ifIncompatibleImagesFound: 'warn',
+    });
+
+    expect((await inspectNestedForms(result.pdf)).colorSpaces).toEqual([
+      'DeviceCMYK',
+    ]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('reports unmatched images nested in Form XObjects', async () => {
+    const pdf = fs.readFileSync(path.join(fixturesDir, 'image.pdf'));
+    const nestedPdf = await nestFirstImageInForms(pdf);
+
+    const result = await replaceImages(nestedPdf, {
+      replacements: [],
+      ifIncompatibleImagesFound: 'warn',
+    });
+
+    expect(result.pdf).toEqual(nestedPdf);
+    expect(result.warnings).toEqual([
+      expect.stringMatching(/\(.*RGB.*, \d+x\d+\) on page 1$/v),
+    ]);
+  });
+
+  it('handles circular Form XObject references', async () => {
+    const pdf = fs.readFileSync(path.join(fixturesDir, 'image.pdf'));
+    const circularPdf = await nestFirstImageInForms(pdf, true);
+
+    const result = await replaceImages(circularPdf, {
+      replacements: [
+        {
+          source: path.join(fixturesDir, 'ck_rgb.png'),
+          replacement: path.join(fixturesDir, 'ck_cmyk.tiff'),
+        },
+      ],
+      ifIncompatibleImagesFound: 'warn',
+    });
+
+    expect((await inspectNestedForms(result.pdf)).colorSpaces).toEqual([
+      'DeviceCMYK',
+    ]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('processes shared XObject dictionaries once', async () => {
+    const pdf = fs.readFileSync(path.join(fixturesDir, 'image.pdf'));
+    const sharedResourcesPdf = await shareResourcesBetweenForms(pdf);
+
+    const result = await replaceImages(sharedResourcesPdf, {
+      replacements: [
+        {
+          source: path.join(fixturesDir, 'ck_rgb.png'),
+          replacement: path.join(fixturesDir, 'ck_gray.pgm'),
+        },
+        {
+          source: path.join(fixturesDir, 'ck_gray.pgm'),
+          replacement: path.join(fixturesDir, 'ck_cmyk.tiff'),
+        },
+      ],
+      ifIncompatibleImagesFound: 'warn',
+    });
+
+    expect((await inspectNestedForms(result.pdf)).colorSpaces).toEqual([
+      'DeviceGray',
+      'DeviceGray',
+    ]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('reports shared XObject dictionaries on each page', async () => {
+    const pdf = fs.readFileSync(path.join(fixturesDir, 'image.pdf'));
+    const sharedResourcesPdf = await shareResourcesBetweenPages(pdf);
+
+    const result = await replaceImages(sharedResourcesPdf, {
+      replacements: [],
+      ifIncompatibleImagesFound: 'warn',
+    });
+
+    expect(result.warnings).toEqual([
+      expect.stringMatching(/on page 1$/v),
+      expect.stringMatching(/on page 2$/v),
+    ]);
+  });
+
+  it('reports images in shared Form resources on each page', async () => {
+    const pdf = fs.readFileSync(path.join(fixturesDir, 'image.pdf'));
+    const nestedPdf = await nestFirstImageInForms(pdf);
+    const sharedResourcesPdf = await shareResourcesBetweenPages(nestedPdf);
+
+    const result = await replaceImages(sharedResourcesPdf, {
+      replacements: [],
+      ifIncompatibleImagesFound: 'warn',
+    });
+
+    expect(result.warnings).toEqual([
+      expect.stringMatching(/on page 1$/v),
+      expect.stringMatching(/on page 2$/v),
+    ]);
+  });
+
+  it('does not replace shared XObject dictionaries again on later pages', async () => {
+    const pdf = fs.readFileSync(path.join(fixturesDir, 'image.pdf'));
+    const sharedResourcesPdf = await shareResourcesBetweenPages(pdf);
+
+    const result = await replaceImages(sharedResourcesPdf, {
+      replacements: [
+        {
+          source: path.join(fixturesDir, 'ck_rgb.png'),
+          replacement: path.join(fixturesDir, 'ck_gray.pgm'),
+        },
+        {
+          source: path.join(fixturesDir, 'ck_gray.pgm'),
+          replacement: path.join(fixturesDir, 'ck_cmyk.tiff'),
+        },
+      ],
+      ifIncompatibleImagesFound: 'warn',
+    });
+
+    expect(await getImageColorSpace(result.pdf)).toEqual({
+      object: '/DeviceGray',
+      image: 'DeviceGray',
+    });
+  });
+
+  it('does not replace images in shared Forms again on later pages', async () => {
+    const pdf = fs.readFileSync(path.join(fixturesDir, 'image.pdf'));
+    const nestedPdf = await nestFirstImageInForms(pdf);
+    const sharedResourcesPdf = await shareResourcesBetweenPages(nestedPdf);
+
+    const result = await replaceImages(sharedResourcesPdf, {
+      replacements: [
+        {
+          source: path.join(fixturesDir, 'ck_rgb.png'),
+          replacement: path.join(fixturesDir, 'ck_gray.pgm'),
+        },
+        {
+          source: path.join(fixturesDir, 'ck_gray.pgm'),
+          replacement: path.join(fixturesDir, 'ck_cmyk.tiff'),
+        },
+      ],
+      ifIncompatibleImagesFound: 'warn',
+    });
+
+    expect((await inspectNestedForms(result.pdf)).colorSpaces).toEqual([
+      'DeviceGray',
+    ]);
+  });
+});
+
+describe('PDF edit hooks', () => {
+  it('edits colors and images during the same Form traversal', async () => {
+    const pdf = fs.readFileSync(path.join(fixturesDir, 'image.pdf'));
+    const nestedPdf = await nestFirstImageInForms(pdf);
+    const cmykColorHook = createCmykColorHook(
+      new Map([['[10000,0,0]', { c: 0, m: 10000, y: 10000, k: 0 }]]),
+      'ignore',
+      [],
+    );
+    const failures: string[] = [];
+    using replaceImageHook = await createReplaceImageHook(
+      [
+        {
+          source: path.join(fixturesDir, 'ck_rgb.png'),
+          replacement: path.join(fixturesDir, 'ck_cmyk.tiff'),
+        },
+      ],
+      'error',
+      failures,
+    );
+    const result = await editPdf(nestedPdf, [cmykColorHook, replaceImageHook], {
+      signal,
+    });
+    const inspected = await inspectNestedForms(result);
+
+    expect(inspected.colorSpaces).toEqual(['DeviceCMYK']);
+    expect(inspected.contents).toContain('0 1 1 0 k /NestedImage Do');
+    expect(failures).toEqual([]);
   });
 });

--- a/tests/pdf-postprocess.test.ts
+++ b/tests/pdf-postprocess.test.ts
@@ -132,6 +132,36 @@ it('skips both checks when configured to ignore them', async () => {
   expect(result.warnings).toEqual([]);
 });
 
+it('writes the color map before reporting unmapped color errors', async () => {
+  const pdf = fs.readFileSync(path.join(fixturesDir, 'text.pdf'));
+  fs.mkdirSync(temporaryDir, { recursive: true });
+  const mapOutput = path.join(temporaryDir, `cmyk-map-${randomUUID()}.json`);
+
+  try {
+    const result = await runSave(
+      pdf,
+      cmykConfig({
+        ifUnmappedColorsFound: 'error',
+        ifIncompatibleImagesFound: 'ignore',
+        overrideMap: [
+          [
+            { r: 10000, g: 0, b: 0 },
+            { c: 0, m: 10000, y: 10000, k: 0 },
+          ],
+        ],
+        mapOutput,
+      }),
+    );
+
+    expect(result.error?.message).toContain('RGB color(s) not mapped to CMYK');
+    expect(JSON.parse(fs.readFileSync(mapOutput, 'utf8'))).toEqual({
+      '[10000,0,0]': { c: 0, m: 10000, y: 10000, k: 0 },
+    });
+  } finally {
+    fs.rmSync(mapOutput, { force: true });
+  }
+});
+
 it('skips image compatibility checks when CMYK processing is disabled', async () => {
   const pdf = fs.readFileSync(path.join(fixturesDir, 'image.pdf'));
 

--- a/tests/pdf-visitor.test.ts
+++ b/tests/pdf-visitor.test.ts
@@ -1,0 +1,182 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  editPdf,
+  type PdfEditHook,
+  type PdfImageXObjectNode,
+  type PdfVisitNode,
+} from '../src/output/pdf-visitor.js';
+
+const signal = AbortSignal.any([]);
+
+function visitImageXObject(
+  node: PdfVisitNode,
+  visit: (node: PdfImageXObjectNode) => void,
+): void {
+  if (node.kind === 'image-xobject') {
+    visit(node);
+  }
+}
+
+describe('editPdf', () => {
+  it('returns without opening the PDF when no hooks are registered', async () => {
+    const pdf = new Uint8Array([1, 2, 3]);
+
+    const result = await editPdf(pdf, []);
+
+    expect(result).toBe(pdf);
+  });
+
+  it('returns without opening the PDF when hooks have no callbacks', async () => {
+    const pdf = new Uint8Array([1, 2, 3]);
+
+    const result = await editPdf(pdf, [{}, {}]);
+
+    expect(result).toBe(pdf);
+  });
+
+  it('completes every registered hook', async () => {
+    const firstVisit = vi.fn<NonNullable<PdfEditHook['visit']>>();
+    const secondVisit = vi.fn<NonNullable<PdfEditHook['visit']>>();
+    const firstComplete = vi.fn<NonNullable<PdfEditHook['complete']>>();
+    const secondComplete = vi.fn<NonNullable<PdfEditHook['complete']>>();
+    const firstHook: PdfEditHook = {
+      visit: firstVisit,
+      complete: firstComplete,
+    };
+    const secondHook: PdfEditHook = {
+      visit: secondVisit,
+      complete: secondComplete,
+    };
+    const pdf = fs.readFileSync(
+      path.join(import.meta.dirname, 'fixtures', 'cmyk', 'text.pdf'),
+    );
+
+    await editPdf(pdf, [firstHook, secondHook], { signal });
+
+    expect(firstVisit).toHaveBeenCalled();
+    expect(secondVisit).toHaveBeenCalledTimes(firstVisit.mock.calls.length);
+    expect(firstComplete).toHaveBeenCalledOnce();
+    expect(secondComplete).toHaveBeenCalledOnce();
+  });
+
+  it('runs hooks in array order during one traversal', async () => {
+    const order: string[] = [];
+    let firstVisits = 0;
+    let secondVisits = 0;
+    const firstHook: PdfEditHook = {
+      visit: () => {
+        order.push('first');
+        firstVisits++;
+      },
+    };
+    const secondHook: PdfEditHook = {
+      visit: () => {
+        order.push('second');
+        secondVisits++;
+      },
+    };
+    const pdf = fs.readFileSync(
+      path.join(import.meta.dirname, 'fixtures', 'cmyk', 'text.pdf'),
+    );
+
+    await editPdf(pdf, [firstHook, secondHook], { signal });
+
+    expect(firstVisits).toBeGreaterThan(0);
+    expect(secondVisits).toBe(firstVisits);
+    expect(order).toEqual(
+      Array.from({ length: firstVisits }, () => ['first', 'second']).flat(),
+    );
+  });
+
+  it('passes image replacements to subsequent hooks', async () => {
+    let replacementObjectNumber: number | undefined;
+    let firstVisits = 0;
+    let secondVisits = 0;
+    const firstHook: PdfEditHook = {
+      visit: (node) =>
+        visitImageXObject(node, (imageNode) => {
+          const image = imageNode.document.loadImage(imageNode.object);
+          try {
+            const replacement = imageNode.document.addImage(image);
+            replacement
+              .resolve()
+              .put('VisitMarker', imageNode.document.newName('Replaced'));
+            replacementObjectNumber = replacement.asIndirect();
+            imageNode.replaceWith(replacement);
+            firstVisits++;
+          } finally {
+            image.destroy();
+          }
+        }),
+    };
+    const secondHook: PdfEditHook = {
+      visit: (node) =>
+        visitImageXObject(node, (imageNode) => {
+          expect(imageNode.object.asIndirect()).toBe(replacementObjectNumber);
+          expect(imageNode.objectNumber).toBe(replacementObjectNumber);
+          expect(imageNode.resolved.get('VisitMarker').toString()).toBe(
+            '/Replaced',
+          );
+          secondVisits++;
+        }),
+    };
+    const pdf = fs.readFileSync(
+      path.join(import.meta.dirname, 'fixtures', 'cmyk', 'image.pdf'),
+    );
+
+    await editPdf(pdf, [firstHook, secondHook], { signal });
+
+    expect(firstVisits).toBeGreaterThan(0);
+    expect(secondVisits).toBe(firstVisits);
+  });
+
+  it('stops visiting nodes after cancellation', async () => {
+    const controller = new AbortController();
+    const firstVisit = vi.fn<NonNullable<PdfEditHook['visit']>>(() => {
+      controller.abort();
+    });
+    const secondVisit = vi.fn<NonNullable<PdfEditHook['visit']>>();
+    const pdf = fs.readFileSync(
+      path.join(import.meta.dirname, 'fixtures', 'cmyk', 'text.pdf'),
+    );
+
+    const firstHook: PdfEditHook = {
+      visit: firstVisit,
+    };
+    const secondHook: PdfEditHook = {
+      visit: secondVisit,
+    };
+    await expect(
+      editPdf(pdf, [firstHook, secondHook], { signal: controller.signal }),
+    ).rejects.toThrow('This operation was aborted');
+    expect(firstVisit).toHaveBeenCalledOnce();
+    expect(secondVisit).not.toHaveBeenCalled();
+  });
+
+  it('stops completing hooks after cancellation', async () => {
+    const controller = new AbortController();
+    const firstComplete = vi.fn<NonNullable<PdfEditHook['complete']>>(() => {
+      controller.abort();
+    });
+    const secondComplete = vi.fn<NonNullable<PdfEditHook['complete']>>();
+    const firstHook: PdfEditHook = {
+      complete: firstComplete,
+    };
+    const secondHook: PdfEditHook = {
+      complete: secondComplete,
+    };
+    const pdf = fs.readFileSync(
+      path.join(import.meta.dirname, 'fixtures', 'cmyk', 'text.pdf'),
+    );
+
+    await expect(
+      editPdf(pdf, [firstHook, secondHook], { signal: controller.signal }),
+    ).rejects.toThrow('This operation was aborted');
+    expect(firstComplete).toHaveBeenCalledOnce();
+    expect(secondComplete).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
現在の`pdfPostprocess`では、CMYK色変換と画像置換が、それぞれ別々にMuPDFでPDFを開いてページとリソースを走査しています。独立した処理にすること自体は意図したものだったのですが、後述のように現状ですでに走査に機能差があり、長期的に良くないと考えていました。このPRでは、一度の走査に対するhookとしてCMYK色変換と画像置換を再実装します。

再実装の結果として、色変換側ではすでに対応していた入れ子のForm XObject内にある画像も置換できるようにする機能追加にもなっています。私自身はまだ使用したことがありませんが、SVGの`<image>`に`mix-blend-mode: multiply`を指定するとこの構造を作れるようです。

Assisted-by: Codex:gpt-5

<details>
<summary>How the AI was used</summary>

- The human author chose to consolidate PDF traversal behind edit hooks, defined the traversal and resource-sharing semantics, treated nested Form processing as a consequence of the refactor rather than its purpose, and directed the no-op hook, nullable collection, and MuPDF resource-lifetime behavior.
- Codex implemented the shared PDF visitor, converted CMYK and image processing into hooks, updated the integration, tests, and changeset, inspected MuPDF ownership semantics, and ran the targeted tests, type-checker, linter, and formatter.
- The human author reviewed and refined each revision. Two independent Codex reviewers audited the branch without receiving the change context or prior review history and reported no remaining findings.

</details>
