### PR TITLE
refactor: compose image replacement functions

### DIFF
--- a/src/output/image.ts
+++ b/src/output/image.ts
@@ -55,38 +55,51 @@ function imagesEqual(a: mupdfType.Image, b: mupdfType.Image): boolean {
   );
 }
 
-interface ImagePair {
-  srcImage: mupdfType.Image & Disposable;
-  destImage: mupdfType.Image & Disposable;
-  sourcePath: string;
-  replacementPath: string;
+interface ReplaceContext {
+  image: mupdfType.Image;
 }
 
-function disposeImagePairs(imagePairs: readonly ImagePair[]): void {
-  for (const pair of imagePairs) {
-    pair.srcImage[Symbol.dispose]();
-    pair.destImage[Symbol.dispose]();
+interface Replacement {
+  image: mupdfType.Image;
+  sourceLabel: string;
+  replacementLabel: string;
+}
+
+type ReplaceFn = (
+  context: ReplaceContext,
+) => Replacement | null | Promise<Replacement | null>;
+
+function disposeImages(
+  images: readonly (mupdfType.Image & Disposable)[],
+): void {
+  for (const image of images) {
+    image[Symbol.dispose]();
   }
 }
 
-async function createImagePairs(
-  replacements: ReplaceImageConfig,
-): Promise<ImagePair[]> {
+async function createReplaceFn(replacements: ReplaceImageConfig): Promise<{
+  replaceFn: ReplaceFn | null;
+  loadedImages: (mupdfType.Image & Disposable)[];
+}> {
   if (replacements.length === 0) {
-    return [];
+    return {
+      replaceFn: null,
+      loadedImages: [],
+    };
   }
   const mupdf = await importNodeModule('mupdf');
-  const imagePairs: ImagePair[] = [];
+  const replaceFns: ReplaceFn[] = [];
+  const loadedImages: (mupdfType.Image & Disposable)[] = [];
   try {
     for (const { source, replacement } of replacements) {
-      let srcImage: mupdfType.Image & Disposable;
-      let destImage: mupdfType.Image & Disposable;
+      let sourceImage: mupdfType.Image & Disposable;
+      let replacementImage: (mupdfType.Image & Disposable) | undefined;
 
       try {
         const srcBuffer = fs.readFileSync(source);
-        srcImage = disposable(new mupdf.Image(srcBuffer));
+        sourceImage = disposable(new mupdf.Image(srcBuffer));
         Logger.debug(
-          `Loaded source image: ${source} (${srcImage.getWidth()}x${srcImage.getHeight()})`,
+          `Loaded source image: ${source} (${sourceImage.getWidth()}x${sourceImage.getHeight()})`,
         );
       } catch (error) {
         Logger.logWarn(
@@ -96,31 +109,61 @@ async function createImagePairs(
       }
 
       try {
-        const destBuffer = fs.readFileSync(replacement);
-        destImage = disposable(new mupdf.Image(destBuffer));
+        const replacementBytes = fs.readFileSync(replacement);
+        replacementImage = disposable(new mupdf.Image(replacementBytes));
         Logger.debug(
-          `Loaded replacement image: ${replacement} (${destImage.getWidth()}x${destImage.getHeight()})`,
+          `Loaded replacement image: ${replacement} (${replacementImage.getWidth()}x${replacementImage.getHeight()})`,
         );
       } catch (error) {
-        srcImage[Symbol.dispose]();
+        sourceImage[Symbol.dispose]();
+        replacementImage?.[Symbol.dispose]();
         Logger.logWarn(
           `Failed to load replacement image: ${replacement}: ${String(error)}`,
         );
         continue;
       }
 
-      imagePairs.push({
-        srcImage,
-        destImage,
-        sourcePath: source,
-        replacementPath: replacement,
+      loadedImages.push(sourceImage, replacementImage);
+      replaceFns.push(({ image }) => {
+        if (!imagesEqual(image, sourceImage)) {
+          return null;
+        }
+        return {
+          image: new mupdf.Image(replacementImage.pointer),
+          sourceLabel: source,
+          replacementLabel: replacement,
+        };
       });
     }
   } catch (error) {
-    disposeImagePairs(imagePairs);
+    disposeImages(loadedImages);
     throw error;
   }
-  return imagePairs;
+  const replaceFn: ReplaceFn | null =
+    replaceFns.length === 0
+      ? null
+      : async (context) => {
+          for (const replace of replaceFns) {
+            const inputImage = new mupdf.Image(context.image.pointer);
+            let inputMoved = false;
+            try {
+              const replacement = await replace({ image: inputImage });
+              if (replacement !== null) {
+                inputMoved = replacement.image === inputImage;
+                return replacement;
+              }
+            } finally {
+              if (!inputMoved) {
+                inputImage.destroy();
+              }
+            }
+          }
+          return null;
+        };
+  return {
+    replaceFn,
+    loadedImages,
+  };
 }
 
 interface DeviceCmykIncompatibleImage {
@@ -271,30 +314,31 @@ type ReplaceImageResult =
       readonly cleanupCandidates: ReadonlySet<number>;
     };
 
-function replaceImage(
+async function replaceImage(
   node: PdfImageXObjectNode,
-  imagePairs: readonly ImagePair[],
+  replaceFn: ReplaceFn | null,
   incompatibleImages: DeviceCmykIncompatibleImage[] | null,
-): ReplaceImageResult {
+): Promise<ReplaceImageResult> {
   using pdfImage = disposable(node.document.loadImage(node.object));
   let replacementRef: mupdfType.PDFObject | null = null;
   let cleanupCandidates: ReadonlySet<number> | null = null;
 
-  if (node.resourceVisit === 'initial') {
-    const pair = imagePairs.find((candidate) =>
-      imagesEqual(pdfImage, candidate.srcImage),
-    );
-    if (pair) {
-      const replacement = addReplacementImage(
+  if (node.resourceVisit === 'initial' && replaceFn !== null) {
+    const replacement = await replaceFn({
+      image: pdfImage,
+    });
+    if (replacement !== null) {
+      using replacementImage = disposable(replacement.image);
+      const addedImage = addReplacementImage(
         node.document,
         node.object,
-        pair.destImage,
+        replacementImage,
       );
-      replacementRef = replacement.ref;
-      cleanupCandidates = replacement.cleanupCandidates;
+      replacementRef = addedImage.ref;
+      cleanupCandidates = addedImage.cleanupCandidates;
       node.replaceWith(replacementRef);
       Logger.debug(
-        `  Page ${node.pageIndex + 1}, ref "${node.key}": ${pair.sourcePath} -> ${pair.replacementPath}`,
+        `  Page ${node.pageIndex + 1}, ref "${node.key}": ${replacement.sourceLabel} -> ${replacement.replacementLabel}`,
       );
     }
   }
@@ -332,8 +376,8 @@ export async function createReplaceImageHook(
   ifIncompatibleImagesFound: CmykConfig['ifIncompatibleImagesFound'],
   failures: string[],
 ): Promise<PdfEditHook & Disposable> {
-  const imagePairs = await createImagePairs(replacements);
-  if (imagePairs.length === 0 && ifIncompatibleImagesFound === 'ignore') {
+  const { replaceFn, loadedImages } = await createReplaceFn(replacements);
+  if (replaceFn === null && ifIncompatibleImagesFound === 'ignore') {
     return {
       [Symbol.dispose]() {},
     };
@@ -345,11 +389,11 @@ export async function createReplaceImageHook(
   let total = 0;
   const cleanupCandidateBatches: ReadonlySet<number>[] = [];
   return {
-    visit(node) {
+    async visit(node) {
       if (node.kind !== 'image-xobject') {
         return;
       }
-      const result = replaceImage(node, imagePairs, incompatibleImages);
+      const result = await replaceImage(node, replaceFn, incompatibleImages);
       total++;
       if (result.kind === 'replaced') {
         replaced++;
@@ -384,7 +428,7 @@ export async function createReplaceImageHook(
       }
     },
     [Symbol.dispose]() {
-      disposeImagePairs(imagePairs);
+      disposeImages(loadedImages);
     },
   };
 }

--- a/tests/image.test.ts
+++ b/tests/image.test.ts
@@ -405,6 +405,43 @@ function findFirstImageXObject(xobjects: import('mupdf').PDFObject): {
   return found;
 }
 
+async function duplicateFirstImageObject(pdf: Uint8Array): Promise<Uint8Array> {
+  const mupdf = await import('mupdf');
+  const doc = mupdf.PDFDocument.openDocument(
+    pdf,
+    'application/pdf',
+  ) as import('mupdf').PDFDocument;
+  const page = doc.loadPage(0);
+  const xobjects = page.getObject().resolve().get('Resources').get('XObject');
+  const { value } = findFirstImageXObject(xobjects);
+  const resolved = value.resolve();
+  const dict = doc.newDictionary();
+  for (const name of [
+    'Type',
+    'Subtype',
+    'Width',
+    'Height',
+    'ColorSpace',
+    'BitsPerComponent',
+    'Filter',
+    'DecodeParms',
+  ]) {
+    const entry = resolved.get(name);
+    if (entry && !entry.isNull()) {
+      dict.put(name, entry);
+    }
+  }
+  const buffer = value.readRawStream();
+  xobjects.put('ImDup', doc.addRawStream(buffer, dict));
+  const output = doc.saveToBuffer('compress');
+  const result = new Uint8Array(output.asUint8Array());
+  output.destroy();
+  buffer.destroy();
+  page.destroy();
+  doc.destroy();
+  return result;
+}
+
 async function convertFirstImageToIndexed(
   pdf: Uint8Array,
 ): Promise<Uint8Array> {
@@ -705,6 +742,46 @@ describe('replaceImages', () => {
     expect(warnings).toEqual([]);
   });
 
+  it('uses the first matching replacement', async () => {
+    const srcPdf = fs.readFileSync(path.join(fixturesDir, 'image.pdf'));
+
+    const { pdf: destPdf } = await replaceImages(srcPdf, {
+      replacements: [
+        {
+          source: path.join(fixturesDir, 'ck_rgb.png'),
+          replacement: path.join(fixturesDir, 'ck_gray.pgm'),
+        },
+        {
+          source: path.join(fixturesDir, 'ck_rgb.png'),
+          replacement: path.join(fixturesDir, 'ck_cmyk.tiff'),
+        },
+      ],
+      ifIncompatibleImagesFound: 'ignore',
+    });
+
+    expect(await getImageColorSpace(destPdf)).toEqual({
+      object: '/DeviceGray',
+      image: 'DeviceGray',
+    });
+  });
+
+  it('reuses a loaded replacement image across matching XObjects', async () => {
+    const srcPdf = fs.readFileSync(path.join(fixturesDir, 'image.pdf'));
+    const duplicatePdf = await duplicateFirstImageObject(srcPdf);
+
+    const { pdf: destPdf } = await replaceImages(duplicatePdf, {
+      replacements: [
+        {
+          source: path.join(fixturesDir, 'ck_rgb.png'),
+          replacement: path.join(fixturesDir, 'ck_gray.pgm'),
+        },
+      ],
+      ifIncompatibleImagesFound: 'ignore',
+    });
+
+    expect(await getXrefImageColorSpaces(destPdf)).toEqual(['DeviceGray']);
+  });
+
   it('removes replaced image objects that are no longer referenced', async () => {
     const srcPdf = fs.readFileSync(path.join(fixturesDir, 'image.pdf'));
     const { pdf: destPdf } = await replaceImages(srcPdf, {
@@ -829,7 +906,7 @@ describe('replaceImages', () => {
     expect(result).toEqual({ pdf: srcPdf, warnings: [], failures: [] });
   });
 
-  it('returns an empty hook when no replacement pairs can be loaded and the policy is ignore', async () => {
+  it('returns an empty hook when no replacement functions can be prepared and the policy is ignore', async () => {
     const warning = vi.spyOn(Logger, 'logWarn').mockImplementation(() => {});
 
     try {


### PR DESCRIPTION
現在の`replaceImage`は、設定されたsource画像とreplacement画像をフック初期化時に`ImagePair[]`へ読み込み、PDF走査時にここから検索しています。この表現では、ファイル間置換の準備、ルールの選択、PDFへの適用が密に結び付いており、 #766 で提案する関数形の置換を加えるとフック内に設定形式ごとの分岐が入ります。

このPRは #766 の下地として、`replaceImage`設定を画像ペア表現を介さずに一つの関数へ合成するリファクタリングです。`ReplaceFn`は`{ image }`を受け取り、置換する場合は`{ image, sourceLabel, replacementLabel }`、置換しない場合は`null`を返します。最初の非`null`結果を採用するため、従来の先勝ちを自然に維持します。

Assisted-by: Codex:gpt-5

<details>
<summary>How the AI was used</summary>

- The human author split the function-form image replacement work into a preparatory refactor and a follow-up change, required this PR to preserve existing behavior, and designed the `ReplaceFn` result and logging boundary.
- Codex inspected the existing implementation, implemented the refactor and first-match regression test, and ran the targeted tests, type-checker, linter, and formatter.
- The human author reviewed the diff, rejected changes that removed source and replacement paths from debug output, and specified separate labels for both sides of a replacement. Two independent Codex reviewers then audited the final diff without receiving the design history and reported no concrete defects.

</details>
