### PR TITLE
fix: align CMYK fallback conversion APIs

### DIFF
--- a/.changeset/calm-colors-fallback.md
+++ b/.changeset/calm-colors-fallback.md
@@ -2,4 +2,4 @@
 "@vivliostyle/cli": minor
 ---
 
-Add `cmyk.fallback`, a function that converts RGB colors not covered by the regular color mapping, and deprecate `cmyk.overrideMap`. Return `null` to leave a color unmapped.
+Add `cmyk.fallback`, which accepts a custom function or a factory-created color conversion for RGB colors not covered by the regular color mapping, and deprecate `cmyk.overrideMap`. Return `null` from a custom function to leave a color unmapped.

--- a/.changeset/young-colors-blend.md
+++ b/.changeset/young-colors-blend.md
@@ -2,4 +2,4 @@
 "@vivliostyle/cli": minor
 ---
 
-Add `builtinCmykConversion`, `builtinGrayConversion`, and `iccConversion`, which return `cmyk.fallback` functions that convert colors using MuPDF's built-in color spaces or an ICC profile.
+Add factories for built-in or ICC-based RGB to CMYK color conversion in `cmyk.fallback`.

--- a/docs/api-javascript.md
+++ b/docs/api-javascript.md
@@ -6,16 +6,16 @@
 ### Functions
 
 - [`build`](#build)
-- [`builtinCmykConversion`](#builtincmykconversion)
-- [`builtinGrayConversion`](#builtingrayconversion)
 - [`create`](#create)
+- [`createBuiltinCmykConversion`](#createbuiltincmykconversion)
 - [`createBuiltinCmykConversionReplacement`](#createbuiltincmykconversionreplacement)
+- [`createBuiltinGrayConversion`](#createbuiltingrayconversion)
 - [`createBuiltinGrayConversionReplacement`](#createbuiltingrayconversionreplacement)
 - [`createBuiltinRgbConversionReplacement`](#createbuiltinrgbconversionreplacement)
+- [`createIccConversion`](#createiccconversion)
 - [`createIccConversionReplacement`](#createiccconversionreplacement)
 - [`createVitePlugin`](#createviteplugin)
 - [`defineConfig`](#defineconfig)
-- [`iccConversion`](#iccconversion)
 - [`preview`](#preview)
 - [`VFM`](#vfm)
 
@@ -30,6 +30,7 @@
 
 ### Type Aliases
 
+- [`CmykConversion`](#cmykconversion)
 - [`CmykConvertFunction`](#cmykconvertfunction)
 - [`ImageConversionReplacement`](#imageconversionreplacement)
 - [`Metadata`](#metadata)
@@ -79,7 +80,7 @@ build({
 
 ###### cmyk?
 
-`boolean` \| \{ `fallback?`: [`CmykConvertFunction`](#cmykconvertfunction); `ifIncompatibleImagesFound?`: `"warn"` \| `"error"` \| `"ignore"`; `ifUnmappedColorsFound?`: `"warn"` \| `"error"` \| `"ignore"`; `mapOutput?`: `string`; `overrideMap?`: \[`string` \| \{ `b`: `number`; `g`: `number`; `r`: `number`; \}, \{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \}\][]; `reserveMap?`: \[`string` \| \{ `b`: `number`; `g`: `number`; `r`: `number`; \}, \{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \}\][]; `warnUnmapped?`: `boolean`; \} = `CmykSchema`
+`boolean` \| \{ `fallback?`: [`CmykConversion`](#cmykconversion) \| [`CmykConvertFunction`](#cmykconvertfunction); `ifIncompatibleImagesFound?`: `"warn"` \| `"error"` \| `"ignore"`; `ifUnmappedColorsFound?`: `"warn"` \| `"error"` \| `"ignore"`; `mapOutput?`: `string`; `overrideMap?`: \[`string` \| \{ `b`: `number`; `g`: `number`; `r`: `number`; \}, \{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \}\][]; `reserveMap?`: \[`string` \| \{ `b`: `number`; `g`: `number`; `r`: `number`; \}, \{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \}\][]; `warnUnmapped?`: `boolean`; \} = `CmykSchema`
 
 ###### config?
 
@@ -284,32 +285,6 @@ build({
 #### Returns
 
 `Promise`\<`void`\>
-
-***
-
-### builtinCmykConversion()
-
-> **builtinCmykConversion**(): [`CmykConvertFunction`](#cmykconvertfunction)
-
-Creates a function for cmyk.fallback that converts RGB colors to CMYK using
-MuPDF's DeviceCMYK color space.
-
-#### Returns
-
-[`CmykConvertFunction`](#cmykconvertfunction)
-
-***
-
-### builtinGrayConversion()
-
-> **builtinGrayConversion**(): [`CmykConvertFunction`](#cmykconvertfunction)
-
-Creates a function for cmyk.fallback that converts RGB colors to grayscale
-and maps the result to the K channel.
-
-#### Returns
-
-[`CmykConvertFunction`](#cmykconvertfunction)
 
 ***
 
@@ -337,7 +312,7 @@ Scaffold a new Vivliostyle project.
 
 ###### cmyk?
 
-`boolean` \| \{ `fallback?`: [`CmykConvertFunction`](#cmykconvertfunction); `ifIncompatibleImagesFound?`: `"warn"` \| `"error"` \| `"ignore"`; `ifUnmappedColorsFound?`: `"warn"` \| `"error"` \| `"ignore"`; `mapOutput?`: `string`; `overrideMap?`: \[`string` \| \{ `b`: `number`; `g`: `number`; `r`: `number`; \}, \{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \}\][]; `reserveMap?`: \[`string` \| \{ `b`: `number`; `g`: `number`; `r`: `number`; \}, \{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \}\][]; `warnUnmapped?`: `boolean`; \} = `CmykSchema`
+`boolean` \| \{ `fallback?`: [`CmykConversion`](#cmykconversion) \| [`CmykConvertFunction`](#cmykconvertfunction); `ifIncompatibleImagesFound?`: `"warn"` \| `"error"` \| `"ignore"`; `ifUnmappedColorsFound?`: `"warn"` \| `"error"` \| `"ignore"`; `mapOutput?`: `string`; `overrideMap?`: \[`string` \| \{ `b`: `number`; `g`: `number`; `r`: `number`; \}, \{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \}\][]; `reserveMap?`: \[`string` \| \{ `b`: `number`; `g`: `number`; `r`: `number`; \}, \{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \}\][]; `warnUnmapped?`: `boolean`; \} = `CmykSchema`
 
 ###### config?
 
@@ -545,6 +520,25 @@ Scaffold a new Vivliostyle project.
 
 ***
 
+### createBuiltinCmykConversion()
+
+> **createBuiltinCmykConversion**(`options?`): [`CmykConversion`](#cmykconversion)
+
+Creates a conversion for cmyk.fallback that converts RGB colors to CMYK using
+MuPDF's DeviceCMYK color space.
+
+#### Parameters
+
+##### options?
+
+[`ColorConversionOptions`](#colorconversionoptions) = `{}`
+
+#### Returns
+
+[`CmykConversion`](#cmykconversion)
+
+***
+
 ### createBuiltinCmykConversionReplacement()
 
 > **createBuiltinCmykConversionReplacement**(`options?`): [`ImageConversionReplacement`](#imageconversionreplacement)
@@ -560,6 +554,25 @@ Creates a replacement that converts images to DeviceCMYK.
 #### Returns
 
 [`ImageConversionReplacement`](#imageconversionreplacement)
+
+***
+
+### createBuiltinGrayConversion()
+
+> **createBuiltinGrayConversion**(`options?`): [`CmykConversion`](#cmykconversion)
+
+Creates a conversion for cmyk.fallback that converts RGB colors to grayscale
+and maps the result to the K channel.
+
+#### Parameters
+
+##### options?
+
+[`ColorConversionOptions`](#colorconversionoptions) = `{}`
+
+#### Returns
+
+[`CmykConversion`](#cmykconversion)
 
 ***
 
@@ -596,6 +609,26 @@ Creates a replacement that converts images to DeviceRGB.
 #### Returns
 
 [`ImageConversionReplacement`](#imageconversionreplacement)
+
+***
+
+### createIccConversion()
+
+> **createIccConversion**(`options`): [`CmykConversion`](#cmykconversion)
+
+Creates a conversion for cmyk.fallback that converts RGB colors through an ICC
+profile. CMYK profiles return all four channels; grayscale profiles map to
+the K channel.
+
+#### Parameters
+
+##### options
+
+[`IccConversionOptions`](#iccconversionoptions)
+
+#### Returns
+
+[`CmykConversion`](#cmykconversion)
 
 ***
 
@@ -640,7 +673,7 @@ profile and returns an image in the corresponding Device color space.
 
 ###### cmyk?
 
-`boolean` \| \{ `fallback?`: [`CmykConvertFunction`](#cmykconvertfunction); `ifIncompatibleImagesFound?`: `"warn"` \| `"error"` \| `"ignore"`; `ifUnmappedColorsFound?`: `"warn"` \| `"error"` \| `"ignore"`; `mapOutput?`: `string`; `overrideMap?`: \[`string` \| \{ `b`: `number`; `g`: `number`; `r`: `number`; \}, \{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \}\][]; `reserveMap?`: \[`string` \| \{ `b`: `number`; `g`: `number`; `r`: `number`; \}, \{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \}\][]; `warnUnmapped?`: `boolean`; \} = `CmykSchema`
+`boolean` \| \{ `fallback?`: [`CmykConversion`](#cmykconversion) \| [`CmykConvertFunction`](#cmykconvertfunction); `ifIncompatibleImagesFound?`: `"warn"` \| `"error"` \| `"ignore"`; `ifUnmappedColorsFound?`: `"warn"` \| `"error"` \| `"ignore"`; `mapOutput?`: `string`; `overrideMap?`: \[`string` \| \{ `b`: `number`; `g`: `number`; `r`: `number`; \}, \{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \}\][]; `reserveMap?`: \[`string` \| \{ `b`: `number`; `g`: `number`; `r`: `number`; \}, \{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \}\][]; `warnUnmapped?`: `boolean`; \} = `CmykSchema`
 
 ###### config?
 
@@ -866,26 +899,6 @@ Define the configuration for Vivliostyle CLI.
 
 ***
 
-### iccConversion()
-
-> **iccConversion**(`outputProfile`): [`CmykConvertFunction`](#cmykconvertfunction)
-
-Creates a function for cmyk.fallback that converts RGB colors through an ICC
-profile. CMYK profiles return all four channels; grayscale profiles map to
-the K channel.
-
-#### Parameters
-
-##### outputProfile
-
-`Uint8Array`
-
-#### Returns
-
-[`CmykConvertFunction`](#cmykconvertfunction)
-
-***
-
 ### preview()
 
 > **preview**(`options`): `Promise`\<`ViteDevServer`\>
@@ -910,7 +923,7 @@ Open a browser for previewing the publication.
 
 ###### cmyk?
 
-`boolean` \| \{ `fallback?`: [`CmykConvertFunction`](#cmykconvertfunction); `ifIncompatibleImagesFound?`: `"warn"` \| `"error"` \| `"ignore"`; `ifUnmappedColorsFound?`: `"warn"` \| `"error"` \| `"ignore"`; `mapOutput?`: `string`; `overrideMap?`: \[`string` \| \{ `b`: `number`; `g`: `number`; `r`: `number`; \}, \{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \}\][]; `reserveMap?`: \[`string` \| \{ `b`: `number`; `g`: `number`; `r`: `number`; \}, \{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \}\][]; `warnUnmapped?`: `boolean`; \} = `CmykSchema`
+`boolean` \| \{ `fallback?`: [`CmykConversion`](#cmykconversion) \| [`CmykConvertFunction`](#cmykconvertfunction); `ifIncompatibleImagesFound?`: `"warn"` \| `"error"` \| `"ignore"`; `ifUnmappedColorsFound?`: `"warn"` \| `"error"` \| `"ignore"`; `mapOutput?`: `string`; `overrideMap?`: \[`string` \| \{ `b`: `number`; `g`: `number`; `r`: `number`; \}, \{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \}\][]; `reserveMap?`: \[`string` \| \{ `b`: `number`; `g`: `number`; `r`: `number`; \}, \{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \}\][]; `warnUnmapped?`: `boolean`; \} = `CmykSchema`
 
 ###### config?
 
@@ -1159,7 +1172,7 @@ Unified processor.
 
 ### ColorConversionOptions
 
-Options shared by image color conversion replacements.
+Options shared by color conversions and image conversion replacements.
 
 #### Extended by
 
@@ -1169,7 +1182,7 @@ Options shared by image color conversion replacements.
 
 | Property | Type | Description |
 | ------ | ------ | ------ |
-| <a id="property-inputprofile"></a> `inputProfile?` | `string` | Path to an ICC profile used to interpret an unprofiled DeviceGray, DeviceRGB, or DeviceCMYK input. It must use the same color space as the input image. Relative paths use the same entry context as `replaceImage` source and replacement paths. |
+| <a id="property-inputprofile"></a> `inputProfile?` | `string` | Path to an ICC profile used to interpret an unprofiled DeviceGray, DeviceRGB, or DeviceCMYK input. It must use the same color space as the input. For cmyk.fallback, the input is always RGB. Relative paths use the same entry context as `replaceImage` source and replacement paths. |
 
 ***
 
@@ -1185,8 +1198,8 @@ Options for conversion using a caller-provided destination ICC profile.
 
 | Property | Type | Description |
 | ------ | ------ | ------ |
-| <a id="property-inputprofile-1"></a> `inputProfile?` | `string` | Path to an ICC profile used to interpret an unprofiled DeviceGray, DeviceRGB, or DeviceCMYK input. It must use the same color space as the input image. Relative paths use the same entry context as `replaceImage` source and replacement paths. |
-| <a id="property-outputprofile"></a> `outputProfile` | `string` | Path to the destination ICC profile. Relative paths use the same entry context as `replaceImage` source and replacement paths. The converted image uses the corresponding Device color space; the profile itself is not embedded in the image. |
+| <a id="property-inputprofile-1"></a> `inputProfile?` | `string` | Path to an ICC profile used to interpret an unprofiled DeviceGray, DeviceRGB, or DeviceCMYK input. It must use the same color space as the input. For cmyk.fallback, the input is always RGB. Relative paths use the same entry context as `replaceImage` source and replacement paths. |
+| <a id="property-outputprofile"></a> `outputProfile` | `string` | Path to the destination ICC profile. Relative paths use the same entry context as `replaceImage` source and replacement paths. The converted image uses the corresponding Device color space; the profile itself is not embedded in the image. For cmyk.fallback, the profile must use CMYK or Gray; Gray is mapped to the K channel. |
 
 ***
 
@@ -1260,7 +1273,7 @@ interface to the schema, so a drift in either direction is rejected.
 | `browser.tag?` | `string` |
 | `browser.type` | `"chrome"` \| `"chromium"` \| `"firefox"` |
 | <a id="property-cliversion"></a> `cliVersion` | `string` |
-| <a id="property-cmyk"></a> `cmyk?` | `boolean` \| \{ `fallback?`: [`CmykConvertFunction`](#cmykconvertfunction); `ifIncompatibleImagesFound?`: `"warn"` \| `"error"` \| `"ignore"`; `ifUnmappedColorsFound?`: `"warn"` \| `"error"` \| `"ignore"`; `mapOutput?`: `string`; `overrideMap?`: \[`string` \| \{ `b`: `number`; `g`: `number`; `r`: `number`; \}, \{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \}\][]; `reserveMap?`: \[`string` \| \{ `b`: `number`; `g`: `number`; `r`: `number`; \}, \{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \}\][]; `warnUnmapped?`: `boolean`; \} |
+| <a id="property-cmyk"></a> `cmyk?` | `boolean` \| \{ `fallback?`: [`CmykConversion`](#cmykconversion) \| [`CmykConvertFunction`](#cmykconvertfunction); `ifIncompatibleImagesFound?`: `"warn"` \| `"error"` \| `"ignore"`; `ifUnmappedColorsFound?`: `"warn"` \| `"error"` \| `"ignore"`; `mapOutput?`: `string`; `overrideMap?`: \[`string` \| \{ `b`: `number`; `g`: `number`; `r`: `number`; \}, \{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \}\][]; `reserveMap?`: \[`string` \| \{ `b`: `number`; `g`: `number`; `r`: `number`; \}, \{ `c`: `number`; `k`: `number`; `m`: `number`; `y`: `number`; \}\][]; `warnUnmapped?`: `boolean`; \} |
 | <a id="property-config"></a> `config?` | `string` |
 | <a id="property-configdata"></a> `configData?` | [`VivliostyleConfigSchema`](#vivliostyleconfigschema) \| `null` |
 | <a id="property-coreversion"></a> `coreVersion` | `string` |
@@ -1317,6 +1330,12 @@ interface to the schema, so a drift in either direction is rejected.
 | <a id="property-viteconfigfile"></a> `viteConfigFile?` | `string` \| `boolean` |
 
 ## Type Aliases
+
+### CmykConversion
+
+> **CmykConversion** = `Readonly`\<`v.InferInput`\<*typeof* `CmykConversionSchema`\>\>
+
+***
 
 ### CmykConvertFunction
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -465,10 +465,11 @@ type PdfPostprocessConfig = {
     Each entry is a tuple of [rgb, {c, m, y, k}] that overrides the color mapping.
     RGB can be an object {r, g, b} with integers (0-10000) or a hex color string (e.g. "#ff0000").
 
-  - `fallback`: import("@vivliostyle/cli").CmykConvertFunction  
-    Custom conversion applied to RGB colors not covered by the regular mapping.
+  - `fallback`: import("@vivliostyle/cli").CmykConvertFunction | [CmykConversion](#cmykconversion)  
+    Conversion applied to RGB colors not covered by the regular mapping.
+    Accepts a custom function or a color conversion created by a fallback factory.
     RGB and CMYK channel values are integers on a 0-10000 scale.
-    Return null to leave the color unmapped.
+    Return null from a custom function to leave the color unmapped.
     Exceptions and invalid return values fail the build.
 
   - `reserveMap`: ("{tuple(Array)}")[]  
@@ -499,7 +500,9 @@ type PdfPostprocessConfig = {
 ```ts
 type CmykConfig = {
   overrideMap?: "{tuple(Array)}"[];
-  fallback?: import("@vivliostyle/cli").CmykConvertFunction;
+  fallback?:
+    | import("@vivliostyle/cli").CmykConvertFunction
+    | CmykConversion;
   reserveMap?: "{tuple(Array)}"[];
   warnUnmapped?: boolean;
   ifUnmappedColorsFound?:
@@ -512,6 +515,28 @@ type CmykConfig = {
     | "ignore";
   mapOutput?: string;
 };
+```
+
+### CmykConversion
+
+RGB to CMYK color conversion created by a fallback factory.
+
+#### Type definition
+
+```ts
+type CmykConversion =
+  | {
+      kind: "builtin";
+      destination:
+        | "DeviceGray"
+        | "DeviceCMYK";
+      inputProfile?: string;
+    }
+  | {
+      kind: "icc";
+      inputProfile?: string;
+      outputProfile: string;
+    };
 ```
 
 ### ReplaceImageEntry

--- a/src/config/resolve.ts
+++ b/src/config/resolve.ts
@@ -45,6 +45,7 @@ import {
 import type {
   ArticleEntryConfig,
   BrowserType,
+  CmykConversion,
   CmykConvertFunction,
   ContentsEntryConfig,
   CoverEntryConfig,
@@ -278,7 +279,7 @@ export interface CmykConfig {
   ifIncompatibleImagesFound: 'warn' | 'error' | 'ignore';
   overrideMap: CmykMapEntry[];
   reserveMap: CmykMapEntry[];
-  fallback: CmykConvertFunction | undefined;
+  fallback: CmykConvertFunction | CmykConversion | undefined;
   mapOutput: string | undefined;
 }
 
@@ -701,6 +702,23 @@ export function resolveTaskConfig(
     undefined;
 
   const outputs = ((): OutputConfig[] => {
+    const resolveColorConversion = <T extends ImageConversionReplacement>(
+      conversion: T,
+    ): T => ({
+      ...conversion,
+      inputProfile:
+        conversion.inputProfile === undefined
+          ? undefined
+          : upath.resolve(entryContextDir, conversion.inputProfile.trim()),
+      ...(conversion.kind === 'icc'
+        ? {
+            outputProfile: upath.resolve(
+              entryContextDir,
+              conversion.outputProfile.trim(),
+            ),
+          }
+        : {}),
+    });
     type CmykOption = NonNullable<typeof config.pdfPostprocess>['cmyk'];
     const resolveCmykConfig = (cmykOption: CmykOption): CmykConfig | false => {
       const cmykObject =
@@ -720,7 +738,10 @@ export function resolveTaskConfig(
           // oxlint-disable-next-line typescript/no-deprecated -- preserve overrideMap behavior for existing configurations
           overrideMap: resolveMapEntries(cmykObject.overrideMap ?? []),
           reserveMap: resolveMapEntries(cmykObject.reserveMap ?? []),
-          fallback: cmykObject.fallback,
+          fallback:
+            typeof cmykObject.fallback === 'object'
+              ? resolveColorConversion(cmykObject.fallback)
+              : cmykObject.fallback,
           mapOutput: cmykObject.mapOutput
             ? upath.resolve(context, cmykObject.mapOutput)
             : undefined,
@@ -759,32 +780,7 @@ export function resolveTaskConfig(
         replacement: ImageConversionReplacement,
         index: number,
       ): ResolvedImageConversionReplacement => ({
-        imageConversion:
-          replacement.kind === 'builtin'
-            ? {
-                ...replacement,
-                inputProfile:
-                  replacement.inputProfile === undefined
-                    ? undefined
-                    : upath.resolve(
-                        entryContextDir,
-                        replacement.inputProfile.trim(),
-                      ),
-              }
-            : {
-                ...replacement,
-                inputProfile:
-                  replacement.inputProfile === undefined
-                    ? undefined
-                    : upath.resolve(
-                        entryContextDir,
-                        replacement.inputProfile.trim(),
-                      ),
-                outputProfile: upath.resolve(
-                  entryContextDir,
-                  replacement.outputProfile.trim(),
-                ),
-              },
+        imageConversion: resolveColorConversion(replacement),
         label: `[function#${index}]`,
       });
       const resolveReplacement = (

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -291,6 +291,37 @@ const CMYKValueSchema = v.pipe(
 
 const CmykMapEntrySchema = v.tuple([RGBValueSchema, CMYKValueSchema]);
 
+const BuiltinColorConversionSchema = v.object({
+  kind: v.literal('builtin'),
+  destination: v.union([
+    v.literal('DeviceGray'),
+    v.literal('DeviceRGB'),
+    v.literal('DeviceCMYK'),
+  ]),
+  inputProfile: v.optional(ValidString),
+});
+
+const IccColorConversionSchema = v.object({
+  kind: v.literal('icc'),
+  inputProfile: v.optional(ValidString),
+  outputProfile: ValidString,
+});
+
+export const CmykConversionSchema = v.pipe(
+  v.variant('kind', [
+    v.object({
+      ...BuiltinColorConversionSchema.entries,
+      destination: v.union([v.literal('DeviceGray'), v.literal('DeviceCMYK')]),
+    }),
+    IccColorConversionSchema,
+  ]),
+  v.title('CmykConversion'),
+  v.description('RGB to CMYK color conversion created by a fallback factory.'),
+);
+export type CmykConversion = Readonly<
+  v.InferInput<typeof CmykConversionSchema>
+>;
+
 export function isValidCMYKValue(
   value: unknown,
 ): value is v.InferOutput<typeof CMYKValueSchema> {
@@ -320,6 +351,19 @@ const CmykConvertFunctionSchema = v.pipe(
   `),
 );
 
+const CmykFallbackSchema: v.GenericSchema<
+  CmykConvertFunction | CmykConversion
+> = v.pipe(
+  v.union([CmykConvertFunctionSchema, CmykConversionSchema]),
+  v.description($`
+    Conversion applied to RGB colors not covered by the regular mapping.
+    Accepts a custom function or a color conversion created by a fallback factory.
+    RGB and CMYK channel values are integers on a 0-10000 scale.
+    Return null from a custom function to leave the color unmapped.
+    Exceptions and invalid return values fail the build.
+  `),
+);
+
 const CmykConfigSchema = v.pipe(
   v.partial(
     v.object({
@@ -333,7 +377,7 @@ const CmykConfigSchema = v.pipe(
           RGB can be an object {r, g, b} with integers (0-10000) or a hex color string (e.g. "#ff0000").
         `),
       ),
-      fallback: CmykConvertFunctionSchema,
+      fallback: CmykFallbackSchema,
       reserveMap: v.pipe(
         v.array(CmykMapEntrySchema),
         v.description($`
@@ -430,20 +474,12 @@ const ReplaceFunctionSchema = v.pipe(
 export const ImageConversionReplacementSchema = v.pipe(
   v.variant('kind', [
     v.object({
-      kind: v.literal('builtin'),
-      destination: v.union([
-        v.literal('DeviceGray'),
-        v.literal('DeviceRGB'),
-        v.literal('DeviceCMYK'),
-      ]),
-      inputProfile: v.optional(ValidString),
+      ...BuiltinColorConversionSchema.entries,
       source: v.exactOptional(v.never()),
       replacement: v.exactOptional(v.never()),
     }),
     v.object({
-      kind: v.literal('icc'),
-      inputProfile: v.optional(ValidString),
-      outputProfile: ValidString,
+      ...IccColorConversionSchema.entries,
       source: v.exactOptional(v.never()),
       replacement: v.exactOptional(v.never()),
     }),

--- a/src/image-replacement.ts
+++ b/src/image-replacement.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import type * as mupdfType from 'mupdf';
 
 import type {
+  CmykConversion,
   CmykConvertFunction,
   ImageConversionReplacement,
   ReplaceFunction,
@@ -10,13 +11,13 @@ import type {
 import { disposable, disposableOrNull } from './disposable.js';
 import { importNodeModule } from './node-modules.js';
 
-/** Options shared by image color conversion replacements. */
+/** Options shared by color conversions and image conversion replacements. */
 export interface ColorConversionOptions {
   /**
    * Path to an ICC profile used to interpret an unprofiled DeviceGray,
    * DeviceRGB, or DeviceCMYK input. It must use the same color space as the
-   * input image. Relative paths use the same entry context as `replaceImage`
-   * source and replacement paths.
+   * input. For cmyk.fallback, the input is always RGB. Relative paths use the
+   * same entry context as `replaceImage` source and replacement paths.
    */
   inputProfile?: string;
 }
@@ -27,7 +28,8 @@ export interface IccConversionOptions extends ColorConversionOptions {
    * Path to the destination ICC profile. Relative paths use the same entry
    * context as `replaceImage` source and replacement paths. The converted
    * image uses the corresponding Device color space; the profile itself is
-   * not embedded in the image.
+   * not embedded in the image. For cmyk.fallback, the profile must use CMYK
+   * or Gray; Gray is mapped to the K channel.
    */
   outputProfile: string;
 }
@@ -129,8 +131,9 @@ function convertImage(
     return convertPixmap(source, destination, outputColorSpace, mupdf);
   }
 
+  using inputProfileBuffer = disposable(new mupdf.Buffer(inputProfile));
   using inputColorSpace = disposable(
-    new mupdf.ColorSpace(inputProfile, 'input-profile'),
+    new mupdf.ColorSpace(inputProfileBuffer, 'input-profile'),
   );
   if (inputColorSpace.getType() !== deviceColorSpaceType) {
     throw new TypeError(
@@ -251,9 +254,10 @@ function createIccConversionReplaceFunction(
   };
 }
 
-function createColorConversion(
-  replaceFunction: ReplaceFunction,
+export function createCmykConversionFunction(
+  conversion: CmykConversion,
 ): CmykConvertFunction {
+  const { replaceFunction } = createImageConversionReplaceFunction(conversion);
   let mupdfPromise: Promise<typeof import('mupdf')> | undefined;
   return async (rgb) => {
     const mupdf = await (mupdfPromise ??= importNodeModule('mupdf'));
@@ -305,34 +309,46 @@ function createColorConversion(
 }
 
 /**
- * Creates a function for cmyk.fallback that converts RGB colors to CMYK using
+ * Creates a conversion for cmyk.fallback that converts RGB colors to CMYK using
  * MuPDF's DeviceCMYK color space.
  */
-export function builtinCmykConversion(): CmykConvertFunction {
-  return createColorConversion(
-    createBuiltinConversionReplaceFunction('DeviceCMYK', {}),
-  );
+export function createBuiltinCmykConversion(
+  options: ColorConversionOptions = {},
+): CmykConversion {
+  return Object.freeze({
+    kind: 'builtin',
+    destination: 'DeviceCMYK',
+    inputProfile: options.inputProfile,
+  });
 }
 
 /**
- * Creates a function for cmyk.fallback that converts RGB colors to grayscale
+ * Creates a conversion for cmyk.fallback that converts RGB colors to grayscale
  * and maps the result to the K channel.
  */
-export function builtinGrayConversion(): CmykConvertFunction {
-  return createColorConversion(
-    createBuiltinConversionReplaceFunction('DeviceGray', {}),
-  );
+export function createBuiltinGrayConversion(
+  options: ColorConversionOptions = {},
+): CmykConversion {
+  return Object.freeze({
+    kind: 'builtin',
+    destination: 'DeviceGray',
+    inputProfile: options.inputProfile,
+  });
 }
 
 /**
- * Creates a function for cmyk.fallback that converts RGB colors through an ICC
+ * Creates a conversion for cmyk.fallback that converts RGB colors through an ICC
  * profile. CMYK profiles return all four channels; grayscale profiles map to
  * the K channel.
  */
-export function iccConversion(outputProfile: Uint8Array): CmykConvertFunction {
-  return createColorConversion(
-    createIccConversionReplaceFunction({ outputProfile }),
-  );
+export function createIccConversion(
+  options: IccConversionOptions,
+): CmykConversion {
+  return Object.freeze({
+    kind: 'icc',
+    inputProfile: options.inputProfile,
+    outputProfile: options.outputProfile,
+  });
 }
 
 export function createImageConversionReplaceFunction(

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ export {
 export type { CMYKValue } from './global-viewer.js';
 export { defineConfig } from './config/define.js';
 export type {
+  CmykConversion,
   CmykConvertFunction,
   ImageConversionReplacement,
   ReplaceFunction,
@@ -28,13 +29,13 @@ export type {
 } from './config/schema.js';
 export type { TemplateVariable } from './create-template.js';
 export {
-  builtinCmykConversion,
-  builtinGrayConversion,
+  createBuiltinCmykConversion,
+  createBuiltinGrayConversion,
   createBuiltinCmykConversionReplacement,
   createBuiltinGrayConversionReplacement,
   createBuiltinRgbConversionReplacement,
+  createIccConversion,
   createIccConversionReplacement,
-  iccConversion,
 } from './image-replacement.js';
 export type {
   ColorConversionOptions,

--- a/src/output/cmyk.ts
+++ b/src/output/cmyk.ts
@@ -4,6 +4,7 @@ import {
   isValidCMYKValue,
 } from '../config/schema.js';
 import type { CMYKValue } from '../global-viewer.js';
+import { createCmykConversionFunction } from '../image-replacement.js';
 import { Logger } from '../logger.js';
 import { tokenize, type OperatorToken } from './pdf-stream.js';
 import type { PdfEditHook } from './pdf-visitor.js';
@@ -128,11 +129,16 @@ async function convertColors(
 
 export function createCmykColorHook(
   colorMap: ReadonlyMap<string, CMYKValue>,
-  fallback: CmykConvertFunction | undefined,
+  fallback: CmykConfig['fallback'],
   ifUnmappedColorsFound: CmykConfig['ifUnmappedColorsFound'],
   failures: string[],
 ): PdfEditHook {
-  const convert = createColorConverter(colorMap, fallback);
+  const convert = createColorConverter(
+    colorMap,
+    typeof fallback === 'object'
+      ? createCmykConversionFunction(fallback)
+      : fallback,
+  );
   const unmappedColors =
     ifUnmappedColorsFound === 'ignore' ? null : new Set<string>();
   return {

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -1,6 +1,6 @@
 import './mocks/fs.js';
 import './mocks/tmp.js';
-import { expect, it, vi } from 'vitest';
+import { expect, expectTypeOf, it, vi } from 'vitest';
 
 const mockedBuild = vi.hoisted(() =>
   vi.fn<typeof import('../src/core/build.js').build>(),
@@ -17,15 +17,15 @@ vi.mock('../src/core/create', () => ({ create: mockedCreate }));
 vi.mock('../src/core/preview', () => ({ preview: mockedPreview }));
 
 import {
-  builtinCmykConversion,
-  builtinGrayConversion,
   build,
   create,
+  createBuiltinCmykConversion,
   createBuiltinCmykConversionReplacement,
+  createBuiltinGrayConversion,
   createBuiltinGrayConversionReplacement,
   createBuiltinRgbConversionReplacement,
+  createIccConversion,
   createIccConversionReplacement,
-  iccConversion,
   preview,
 } from '../src/index.js';
 
@@ -41,9 +41,32 @@ it('provides build function', async () => {
 });
 
 it('provides CMYK fallback conversion factories', () => {
-  expect(builtinCmykConversion()).toBeTypeOf('function');
-  expect(builtinGrayConversion()).toBeTypeOf('function');
-  expect(iccConversion(new Uint8Array())).toBeTypeOf('function');
+  expect(createBuiltinCmykConversion()).toEqual(
+    createBuiltinCmykConversionReplacement(),
+  );
+  expect(createBuiltinGrayConversion()).toEqual(
+    createBuiltinGrayConversionReplacement(),
+  );
+  const options = { inputProfile: 'input.icc' };
+  expect(createBuiltinCmykConversion(options)).toEqual(
+    createBuiltinCmykConversionReplacement(options),
+  );
+  expect(createBuiltinGrayConversion(options)).toEqual(
+    createBuiltinGrayConversionReplacement(options),
+  );
+  const iccOptions = { ...options, outputProfile: 'output.icc' };
+  expect(createIccConversion(iccOptions)).toEqual(
+    createIccConversionReplacement(iccOptions),
+  );
+  expectTypeOf(createBuiltinCmykConversion).parameters.toEqualTypeOf<
+    Parameters<typeof createBuiltinCmykConversionReplacement>
+  >();
+  expectTypeOf(createBuiltinGrayConversion).parameters.toEqualTypeOf<
+    Parameters<typeof createBuiltinGrayConversionReplacement>
+  >();
+  expectTypeOf(createIccConversion).parameters.toEqualTypeOf<
+    Parameters<typeof createIccConversionReplacement>
+  >();
 });
 
 it('provides create function', async () => {

--- a/tests/cmyk-conversion.test.ts
+++ b/tests/cmyk-conversion.test.ts
@@ -1,16 +1,62 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-import { describe, expect, it, vi } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
+import { disposable } from '../src/disposable.js';
 import {
-  builtinCmykConversion,
-  builtinGrayConversion,
-  iccConversion,
+  type ColorConversionOptions,
+  createBuiltinCmykConversion,
+  createBuiltinGrayConversion,
+  createIccConversion,
+  createCmykConversionFunction,
 } from '../src/image-replacement.js';
 import type { CMYKValue } from '../src/index.js';
 
 const fixturesDir = path.join(import.meta.dirname, 'fixtures', 'cmyk');
+let temporaryDir: string;
+let inputProfile: string;
+
+beforeAll(async () => {
+  const temporaryRoot = path.join(import.meta.dirname, '..', '.tmp');
+  fs.mkdirSync(temporaryRoot, { recursive: true });
+  temporaryDir = fs.mkdtempSync(path.join(temporaryRoot, 'cmyk-conversion-'));
+  inputProfile = path.join(temporaryDir, 'swapped-primaries.icc');
+  const mupdf = await import('mupdf');
+  using doc = disposable(
+    mupdf.PDFDocument.openDocument(
+      fs.readFileSync(path.join(fixturesDir, 'image.pdf')),
+      'application/pdf',
+    ) as import('mupdf').PDFDocument,
+  );
+  using page = disposable(doc.loadPage(0));
+  using profile = disposable(
+    page
+      .getObject()
+      .get('Resources')
+      .get('XObject')
+      .get('X4')
+      .get('ColorSpace')
+      .get(1)
+      .readStream(),
+  );
+  const bytes = Buffer.from(profile.asUint8Array());
+  const redTag = bytes.indexOf('rXYZ');
+  const blueTag = bytes.indexOf('bXYZ');
+  const redOffset = bytes.readUInt32BE(redTag + 4);
+  const blueOffset = bytes.readUInt32BE(blueTag + 4);
+  const tagLength = bytes.readUInt32BE(redTag + 8);
+  const redPrimary = Buffer.from(
+    bytes.subarray(redOffset, redOffset + tagLength),
+  );
+  bytes.copy(bytes, redOffset, blueOffset, blueOffset + tagLength);
+  redPrimary.copy(bytes, blueOffset);
+  fs.writeFileSync(inputProfile, bytes);
+});
+
+afterAll(() => {
+  fs.rmSync(temporaryDir, { recursive: true, force: true });
+});
 
 function expectCmykValue(value: CMYKValue | null): CMYKValue {
   if (value === null) {
@@ -19,9 +65,9 @@ function expectCmykValue(value: CMYKValue | null): CMYKValue {
   return value;
 }
 
-describe('builtinCmykConversion', () => {
+describe('createBuiltinCmykConversion', () => {
   it('converts black to mostly K', async () => {
-    const convert = builtinCmykConversion();
+    const convert = createCmykConversionFunction(createBuiltinCmykConversion());
 
     const result = expectCmykValue(await convert({ r: 0, g: 0, b: 0 }));
 
@@ -29,7 +75,7 @@ describe('builtinCmykConversion', () => {
   });
 
   it('converts white to near-zero CMYK', async () => {
-    const convert = builtinCmykConversion();
+    const convert = createCmykConversionFunction(createBuiltinCmykConversion());
 
     const result = expectCmykValue(
       await convert({ r: 10000, g: 10000, b: 10000 }),
@@ -42,9 +88,9 @@ describe('builtinCmykConversion', () => {
   });
 });
 
-describe('builtinGrayConversion', () => {
+describe('createBuiltinGrayConversion', () => {
   it('converts black to high K', async () => {
-    const convert = builtinGrayConversion();
+    const convert = createCmykConversionFunction(createBuiltinGrayConversion());
 
     const result = expectCmykValue(await convert({ r: 0, g: 0, b: 0 }));
 
@@ -53,7 +99,7 @@ describe('builtinGrayConversion', () => {
   });
 
   it('converts white to near-zero K', async () => {
-    const convert = builtinGrayConversion();
+    const convert = createCmykConversionFunction(createBuiltinGrayConversion());
 
     const result = expectCmykValue(
       await convert({ r: 10000, g: 10000, b: 10000 }),
@@ -64,10 +110,13 @@ describe('builtinGrayConversion', () => {
   });
 });
 
-describe('iccConversion', () => {
+describe('createIccConversion', () => {
   it('converts colors through a CMYK profile', async () => {
-    const profile = fs.readFileSync(path.join(fixturesDir, 'ps_cmyk.icc'));
-    const convert = iccConversion(profile);
+    const convert = createCmykConversionFunction(
+      createIccConversion({
+        outputProfile: path.join(fixturesDir, 'ps_cmyk.icc'),
+      }),
+    );
 
     const black = expectCmykValue(await convert({ r: 0, g: 0, b: 0 }));
     const white = expectCmykValue(
@@ -82,8 +131,11 @@ describe('iccConversion', () => {
   });
 
   it('maps grayscale profiles to the K channel', async () => {
-    const profile = fs.readFileSync(path.join(fixturesDir, 'ps_gray.icc'));
-    const convert = iccConversion(profile);
+    const convert = createCmykConversionFunction(
+      createIccConversion({
+        outputProfile: path.join(fixturesDir, 'ps_gray.icc'),
+      }),
+    );
 
     const black = expectCmykValue(await convert({ r: 0, g: 0, b: 0 }));
 
@@ -94,13 +146,104 @@ describe('iccConversion', () => {
   it('destroys the native profile buffer after conversion', async () => {
     const mupdf = await import('mupdf');
     const destroy = vi.spyOn(mupdf.Buffer.prototype, 'destroy');
-    const profile = fs.readFileSync(path.join(fixturesDir, 'ps_cmyk.icc'));
-    const convert = iccConversion(profile);
+    const convert = createCmykConversionFunction(
+      createIccConversion({
+        outputProfile: path.join(fixturesDir, 'ps_cmyk.icc'),
+      }),
+    );
 
     try {
       await convert({ r: 1000, g: 2000, b: 3000 });
-
       expect(destroy).toHaveBeenCalledTimes(1);
+    } finally {
+      destroy.mockRestore();
+    }
+  });
+
+  it('rejects an RGB output profile', async () => {
+    const convert = createCmykConversionFunction(
+      createIccConversion({
+        outputProfile: inputProfile,
+      }),
+    );
+
+    await expect(convert({ r: 1000, g: 2000, b: 3000 })).rejects.toThrow(
+      'Cannot derive CMYK values from a [ColorSpace DeviceRGB] image',
+    );
+  });
+
+  it('rejects invalid ICC profile data', async () => {
+    const outputProfile = path.join(temporaryDir, 'invalid.icc');
+    fs.writeFileSync(outputProfile, 'invalid ICC profile');
+    const convert = createCmykConversionFunction(
+      createIccConversion({
+        outputProfile,
+      }),
+    );
+
+    await expect(convert({ r: 1000, g: 2000, b: 3000 })).rejects.toThrow(
+      'cmsOpenProfileFromMem failed',
+    );
+  });
+});
+
+describe.each([
+  {
+    name: 'DeviceCMYK',
+    create: createBuiltinCmykConversion,
+    outputProfiles: [],
+  },
+  {
+    name: 'DeviceGray',
+    create: createBuiltinGrayConversion,
+    outputProfiles: [],
+  },
+  {
+    name: 'ICC',
+    outputProfiles: [path.join(fixturesDir, 'ps_cmyk.icc')],
+    create: (options: ColorConversionOptions) =>
+      createIccConversion({
+        ...options,
+        outputProfile: path.join(fixturesDir, 'ps_cmyk.icc'),
+      }),
+  },
+])('$name input profiles', ({ create, outputProfiles }) => {
+  it('interprets RGB using the input profile and reads each profile once', async () => {
+    const rgb = { r: 8000, g: 4000, b: 2000 };
+    const unprofiled = await createCmykConversionFunction(create({}))(rgb);
+    const readFile = vi.spyOn(fs, 'readFileSync');
+    const conversion = create({ inputProfile });
+    const profilePaths = [inputProfile, ...outputProfiles];
+
+    try {
+      expect(readFile).not.toHaveBeenCalled();
+      const convert = createCmykConversionFunction(conversion);
+      const profiled = expectCmykValue(await convert(rgb));
+      expect(profiled).not.toEqual(unprofiled);
+      expect(await convert(rgb)).toEqual(profiled);
+      expect(
+        readFile.mock.calls.filter(([filename]) =>
+          profilePaths.includes(String(filename)),
+        ),
+      ).toEqual(profilePaths.map((filename) => [filename]));
+    } finally {
+      readFile.mockRestore();
+    }
+  });
+
+  it('rejects a non-RGB input profile and disposes native buffers', async () => {
+    const mupdf = await import('mupdf');
+    const conversion = create({
+      inputProfile: path.join(fixturesDir, 'ps_gray.icc'),
+    });
+    const convert = createCmykConversionFunction(conversion);
+    const destroy = vi.spyOn(mupdf.Buffer.prototype, 'destroy');
+
+    try {
+      await expect(convert({ r: 1000, g: 2000, b: 3000 })).rejects.toThrow(
+        'inputProfile uses Gray, but the input image uses DeviceRGB',
+      );
+      expect(destroy).toHaveBeenCalledTimes(outputProfiles.length + 1);
     } finally {
       destroy.mockRestore();
     }

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -20,16 +20,21 @@ import {
   UseTemporaryServerRoot,
 } from '../src/config/resolve.js';
 import type {
+  CmykConversion,
   ReplaceFunction,
   ReplaceImageConfig,
 } from '../src/config/schema.js';
 import {
+  CmykConversionSchema,
   ImageConversionReplacementSchema,
   VivliostyleConfigSchema,
   VivliostyleInlineConfig,
 } from '../src/config/schema.js';
 import {
+  createBuiltinCmykConversion,
   createBuiltinCmykConversionReplacement,
+  createBuiltinGrayConversion,
+  createIccConversion,
   createIccConversionReplacement,
 } from '../src/image-replacement.js';
 import { Logger } from '../src/logger.js';
@@ -890,6 +895,128 @@ it('resolves cmyk fallback functions without wrapping them', async () => {
   expect(config.outputs[0]).toMatchObject({
     cmyk: { fallback },
   });
+});
+
+it('resolves fallback profiles from the entry context for each output', async () => {
+  const fallback = createIccConversion({
+    inputProfile: ' profiles/input.icc ',
+    outputProfile: ' profiles/output.icc ',
+  });
+  const config = await getTaskConfig(['build'], resolveFixture('.'), {
+    entryContext: 'config',
+    entry: 'manuscript.md',
+    output: [
+      'default.pdf',
+      {
+        path: 'cmyk.pdf',
+        pdfPostprocess: {
+          cmyk: {
+            fallback: createBuiltinCmykConversion({
+              inputProfile: 'profiles/input.icc',
+            }),
+          },
+        },
+      },
+      {
+        path: 'gray.pdf',
+        pdfPostprocess: {
+          cmyk: {
+            fallback: createBuiltinGrayConversion({
+              inputProfile: resolveFixture('cmyk/absolute.icc'),
+            }),
+          },
+        },
+      },
+    ],
+    pdfPostprocess: { cmyk: { fallback } },
+  });
+
+  expect(config.outputs).toMatchObject([
+    {
+      cmyk: {
+        fallback: {
+          kind: 'icc',
+          inputProfile: resolveFixture('config/profiles/input.icc'),
+          outputProfile: resolveFixture('config/profiles/output.icc'),
+        },
+      },
+    },
+    {
+      cmyk: {
+        fallback: {
+          kind: 'builtin',
+          destination: 'DeviceCMYK',
+          inputProfile: resolveFixture('config/profiles/input.icc'),
+        },
+      },
+    },
+    {
+      cmyk: {
+        fallback: {
+          kind: 'builtin',
+          destination: 'DeviceGray',
+          inputProfile: resolveFixture('cmyk/absolute.icc'),
+        },
+      },
+    },
+  ]);
+  expect(fallback).toMatchObject({
+    inputProfile: ' profiles/input.icc ',
+    outputProfile: ' profiles/output.icc ',
+  });
+});
+
+it('resolves fallback profiles supplied through the inline API', () => {
+  const merged = mergeInlineConfig(
+    v.parse(VivliostyleConfigSchema, {
+      entryContext: 'config',
+      entry: 'manuscript.md',
+      output: 'output.pdf',
+    }),
+    v.parse(VivliostyleInlineConfig, {
+      cwd: resolveFixture('.'),
+      cmyk: {
+        fallback: createIccConversion({ outputProfile: 'output.icc' }),
+      },
+    }),
+  );
+  const config = resolveTaskConfig(merged.tasks[0], merged.inlineOptions);
+
+  expect(config.outputs[0]).toMatchObject({
+    cmyk: {
+      fallback: {
+        kind: 'icc',
+        outputProfile: resolveFixture('config/output.icc'),
+      },
+    },
+  });
+});
+
+it.each([
+  { kind: 'builtin', destination: 'DeviceRGB' },
+  { kind: 'builtin', destination: 'DeviceCMYK', inputProfile: '' },
+  {
+    kind: 'builtin',
+    destination: 'DeviceGray',
+    inputProfile: new Uint8Array(),
+  },
+  { kind: 'icc' },
+  { kind: 'icc', outputProfile: ' ' },
+  { kind: 'icc', outputProfile: new Uint8Array() },
+])('rejects an invalid fallback conversion: %j', (fallback) => {
+  expect(v.is(CmykConversionSchema, fallback)).toBe(false);
+  expect(
+    v.safeParse(VivliostyleConfigSchema, {
+      pdfPostprocess: { cmyk: { fallback } },
+    }).success,
+  ).toBe(false);
+});
+
+it('excludes DeviceRGB from the fallback conversion type', () => {
+  expectTypeOf<{
+    kind: 'builtin';
+    destination: 'DeviceRGB';
+  }>().not.toExtend<CmykConversion>();
 });
 
 it('resolves a top-level CMYK config object', () => {

--- a/tests/pdf-postprocess.test.ts
+++ b/tests/pdf-postprocess.test.ts
@@ -6,6 +6,11 @@ import { expect, it, vi } from 'vitest';
 
 import type { CmykConfig } from '../src/config/resolve.js';
 import type { CmykConvertFunction } from '../src/config/schema.js';
+import {
+  createBuiltinCmykConversion,
+  createBuiltinGrayConversion,
+  createIccConversion,
+} from '../src/image-replacement.js';
 import { Logger } from '../src/logger.js';
 import { PostProcess } from '../src/output/pdf-postprocess.js';
 
@@ -142,6 +147,45 @@ it('fails without writing when cmyk fallback throws', async () => {
   expect(result.error?.message).toContain('fallback failed');
   expect(result.written).toBe(false);
 });
+
+it.each([
+  createBuiltinCmykConversion(),
+  createBuiltinGrayConversion(),
+  createIccConversion({ outputProfile: path.join(fixturesDir, 'ps_cmyk.icc') }),
+  createIccConversion({ outputProfile: path.join(fixturesDir, 'ps_gray.icc') }),
+])('uses a factory-created cmyk fallback: %j', async (fallback) => {
+  const pdf = fs.readFileSync(path.join(fixturesDir, 'text.pdf'));
+
+  const result = await runSave(
+    pdf,
+    cmykConfig({
+      fallback,
+      ifUnmappedColorsFound: 'error',
+      ifIncompatibleImagesFound: 'ignore',
+    }),
+  );
+
+  expect(result.error).toBeNull();
+  expect(result.written).toBe(true);
+  expect(result.warnings).toEqual([]);
+});
+
+it.each([
+  createBuiltinCmykConversion({
+    inputProfile: path.join(fixturesDir, 'missing.icc'),
+  }),
+  createIccConversion({ outputProfile: path.join(fixturesDir, 'missing.icc') }),
+])(
+  'fails without writing when a fallback profile is missing: %j',
+  async (fallback) => {
+    const pdf = fs.readFileSync(path.join(fixturesDir, 'text.pdf'));
+
+    const result = await runSave(pdf, cmykConfig({ fallback }));
+
+    expect(result.error?.message).toContain('missing.icc');
+    expect(result.written).toBe(false);
+  },
+);
 
 it('combines color and image failures', async () => {
   const pdf = fs.readFileSync(path.join(fixturesDir, 'image.pdf'));


### PR DESCRIPTION
#886 で追加した`cmyk.fallback`の組み込み変換のファクトリが #766 で最終的に採用した形と揃っておらず、入力プロファイルを指定できずICC変換は出力プロファイルのバイト列を直接受け取る、以前に検討していた形のままでした。このPRでfixupさせてください。

Assisted-by: Codex:gpt-6

<details>
<summary>How the AI was used</summary>

- The human author identified the API mismatch with #766, required symmetric factory signatures and profile path semantics, and directed the changeset wording and regeneration of documentation from the build.
- Codex implemented the factories, configuration schemas, profile resolution, and fallback integration; added regression tests; updated the changesets; regenerated the documentation; and drafted this PR description. Codex ran 235 related tests, the type-checker, linter, formatter checks, and the full build.
- At the human author's request, two independent Codex reviewers audited the diff without receiving the change context, and a third reviewer checked symmetry with #766. All three reported no findings.

</details>
