### PR TITLE
fix: Update Vivliostyle.js to 2.45.1: Bug Fixes

### DIFF
--- a/.changeset/afraid-boxes-count.md
+++ b/.changeset/afraid-boxes-count.md
@@ -1,0 +1,5 @@
+---
+"@vivliostyle/cli": patch
+---
+
+Update Vivliostyle.js to 2.45.1: Bug Fixes

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@types/command-exists": "1.2.3",
     "@vivliostyle/jsdom": "25.0.1-vivliostyle-cli.2",
     "@vivliostyle/vfm": "2.7.2",
-    "@vivliostyle/viewer": "2.45.0",
+    "@vivliostyle/viewer": "2.45.1",
     "ajv": "8.18.0",
     "ajv-formats": "3.0.1",
     "archiver": "7.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,8 +42,8 @@ importers:
         specifier: 2.7.2
         version: 2.7.2(typescript@6.0.3)
       '@vivliostyle/viewer':
-        specifier: 2.45.0
-        version: 2.45.0
+        specifier: 2.45.1
+        version: 2.45.1
       ajv:
         specifier: 8.18.0
         version: 8.18.0
@@ -2888,8 +2888,8 @@ packages:
   '@vitest/utils@4.1.9':
     resolution: {integrity: sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==}
 
-  '@vivliostyle/core@2.45.0':
-    resolution: {integrity: sha512-ugKexK0/srYpY5GtiyReehpgvfko5Wy1GyMvQNwYW3ybiwL41af3JVE8PoiGvY1Y6MgKNSm8wXf2CZrb6t9mZg==}
+  '@vivliostyle/core@2.45.1':
+    resolution: {integrity: sha512-4GdAGhDUWcRKdTulUXLHMrZ7ywVXiWStsJ3qeE9FOEjKLgtA4s806S+HOUv16ciOh6RuC8bJhToNKWc9xxEGpw==}
     engines: {node: '>=20'}
 
   '@vivliostyle/jsdom@25.0.1-vivliostyle-cli.2':
@@ -2930,8 +2930,8 @@ packages:
     engines: {node: '>= 22'}
     hasBin: true
 
-  '@vivliostyle/viewer@2.45.0':
-    resolution: {integrity: sha512-KLdn2lkkMnJ3WLfE29s275nI8GAFMzk8El7ZUtM/MvlvGjWQWGQk0cAVq6rizZW+DgK91BXgEyGsUfTT1HY0hQ==}
+  '@vivliostyle/viewer@2.45.1':
+    resolution: {integrity: sha512-JjcY+eboH8jARIN7QVjFYEAT8pQBSW83gbCC1/dh2UZFqHOEKroQkArKggjtAz+HT0aJtmossMVq+EAtnjMg+g==}
     engines: {node: '>=20'}
 
   '@zachleat/heading-anchors@1.0.5':
@@ -9297,7 +9297,7 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  '@vivliostyle/core@2.45.0':
+  '@vivliostyle/core@2.45.1':
     dependencies:
       fast-diff: 1.3.0
 
@@ -9448,9 +9448,9 @@ snapshots:
       - supports-color
       - typescript
 
-  '@vivliostyle/viewer@2.45.0':
+  '@vivliostyle/viewer@2.45.1':
     dependencies:
-      '@vivliostyle/core': 2.45.0
+      '@vivliostyle/core': 2.45.1
       i18next-ko: 3.0.1
       knockout: 3.5.3
 


### PR DESCRIPTION
https://github.com/vivliostyle/vivliostyle.js/releases/tag/v2.45.1

### Bug Fixes

- Fix text overflowing outside the page area after text-spacing ([#2143](https://github.com/vivliostyle/vivliostyle.js/issues/2143)) ([6882d49](https://github.com/vivliostyle/vivliostyle.js/commit/6882d49736daff1e3415cdc30ae1bac415431198)), closes [#2142](https://github.com/vivliostyle/vivliostyle.js/issues/2142)
- Keep table caption before repeated header in the view tree ([#2138](https://github.com/vivliostyle/vivliostyle.js/issues/2138)) ([98732f8](https://github.com/vivliostyle/vivliostyle.js/commit/98732f8d3e19ef250abb488730be964c275e218b)), closes [#2137](https://github.com/vivliostyle/vivliostyle.js/issues/2137)
- Keep rules with valid but unsupported selectors like `:host` ([#2135](https://github.com/vivliostyle/vivliostyle.js/issues/2135)) ([fee26d8](https://github.com/vivliostyle/vivliostyle.js/commit/fee26d803f88aeb680bf5561cb352859ba82881f))
- stabilize cross-reference relayout after spine shrinkage ([#2132](https://github.com/vivliostyle/vivliostyle.js/issues/2132)) ([23c8db7](https://github.com/vivliostyle/vivliostyle.js/commit/23c8db7a5eae03e6480a1d4dcb203add7d2b2426))
- Avoid invoking a cleared print error callback ([#2126](https://github.com/vivliostyle/vivliostyle.js/issues/2126)) ([cff472e](https://github.com/vivliostyle/vivliostyle.js/commit/cff472eab1cc2c1a763a9f070c25555886a9f54a))