### PR TITLE
fix: Resolve CSS imports referring to the package containing the importer

### DIFF
--- a/.changeset/self-referencing-css-imports.md
+++ b/.changeset/self-referencing-css-imports.md
@@ -1,0 +1,5 @@
+---
+'@vivliostyle/cli': patch
+---
+
+Resolve CSS `@import` rules referring to the package containing the importing stylesheet by its own name, like the self-referencing of Node.js, instead of installing the package with the same name from npm.

--- a/src/output/webbook.ts
+++ b/src/output/webbook.ts
@@ -481,6 +481,7 @@ export async function copyWebPublicationAssets({
   exportAliases,
   outputs,
   copyAsset,
+  entryContextDir,
   themesDir,
   postcss,
   manifestPath,
@@ -492,6 +493,7 @@ export async function copyWebPublicationAssets({
   | 'exportAliases'
   | 'outputs'
   | 'copyAsset'
+  | 'entryContextDir'
   | 'themesDir'
   | 'entries'
   | 'postcss'
@@ -550,6 +552,7 @@ export async function copyWebPublicationAssets({
     upath.relative(input, manifestPath),
   );
   const cssResolver = new ThemeCssResolver({
+    entryContextDir,
     workspaceDir: input,
     themesDir,
   });

--- a/src/processor/css.ts
+++ b/src/processor/css.ts
@@ -20,6 +20,7 @@ import {
   isFileSync,
   isValidUri,
   pathContains,
+  pathEquals,
   readPackageJson,
   toError,
 } from '../util.js';
@@ -74,11 +75,18 @@ export function resolveLocalStyleFile(
   return file.endsWith('.css') && isFileSync(file) ? file : undefined;
 }
 
-function findThemePackageDir(
-  pkgName: string,
-  importerDir: string,
-  themesDir: string,
-): Pick<CssBareImportResolution, 'pkgDir' | 'self'> | undefined {
+function findThemePackageDir({
+  pkgName,
+  importerDir,
+  scopeDir,
+  themesDir,
+}: {
+  pkgName: string;
+  importerDir: string;
+  /** The directory the importer belongs to, which may differ from its physical location */
+  scopeDir: string;
+  themesDir: string;
+}): Pick<CssBareImportResolution, 'pkgDir' | 'self'> | undefined {
   const pkgDir =
     // Importers inside the themes directory resolve against their own tree
     // first so that nested node_modules layouts are respected
@@ -88,7 +96,7 @@ function findThemePackageDir(
   if (pkgDir) {
     return { pkgDir, self: false };
   }
-  const ownPkgDir = findOwnPackageDir(pkgName, importerDir);
+  const ownPkgDir = findOwnPackageDir(pkgName, scopeDir);
   if (ownPkgDir) {
     return { pkgDir: ownPkgDir, self: true };
   }
@@ -233,11 +241,13 @@ export class ThemeCssResolver {
       throw new Error(`Invalid import specifier: ${specifier}`);
     }
     const { pkgName, version, subpath } = parsed;
-    const found = findThemePackageDir(
+    const importerDir = upath.dirname(importer);
+    const found = findThemePackageDir({
       pkgName,
-      upath.dirname(importer),
-      this.#themesDir,
-    );
+      importerDir,
+      scopeDir: this.#sourceDirOf(importerDir),
+      themesDir: this.#themesDir,
+    });
     if (!found) {
       throw new DetailError(
         `Could not resolve the CSS import: ${specifier} (imported from ${importer})`,
@@ -256,6 +266,24 @@ export class ThemeCssResolver {
       ? resolvePackageCssSubpath(pkgDir, stripUrlQuery(subpath))
       : resolvePackageCssEntry(pkgDir);
     return { file, pkgName, pkgDir, self };
+  }
+
+  /**
+   * File themes are transformed from their workspace copies, which mirror
+   * the layout of the entry context. The package containing a copy is
+   * determined at its source location, as the workspace may be placed
+   * outside of the package (or the project).
+   */
+  #sourceDirOf(importerDir: string): string {
+    const isInside = (parent: string) =>
+      pathEquals(parent, importerDir) || pathContains(parent, importerDir);
+    if (isInside(this.#themesDir) || !isInside(this.#workspaceDir)) {
+      return importerDir;
+    }
+    return upath.join(
+      this.#entryContextDir,
+      upath.relative(this.#workspaceDir, importerDir),
+    );
   }
 
   #warnUnsatisfiedVersion(

--- a/src/processor/css.ts
+++ b/src/processor/css.ts
@@ -14,6 +14,7 @@ import type { ParsedTheme, ResolvedTaskConfig } from '../config/resolve.js';
 import { Logger } from '../logger.js';
 import {
   DetailError,
+  findOwnPackageDir,
   findPackageDir,
   getFormattedError,
   isFileSync,
@@ -27,6 +28,8 @@ export interface CssBareImportResolution {
   file: string;
   pkgName: string;
   pkgDir: string;
+  /** The importer belongs to the resolved package (Node.js-style self-referencing) */
+  self: boolean;
 }
 
 export interface BareImportSpecifier {
@@ -75,16 +78,23 @@ function findThemePackageDir(
   pkgName: string,
   importerDir: string,
   themesDir: string,
-): string | undefined {
-  return (
+): Pick<CssBareImportResolution, 'pkgDir' | 'self'> | undefined {
+  const pkgDir =
     // Importers inside the themes directory resolve against their own tree
     // first so that nested node_modules layouts are respected
     findPackageDir(pkgName, importerDir, { boundary: themesDir }) ??
     // The themes directory takes precedence over the project node_modules
-    findPackageDir(pkgName, themesDir, { boundary: themesDir }) ??
-    // Fall back to the Node.js style resolution walking up from the importer
-    findPackageDir(pkgName, importerDir)
-  );
+    findPackageDir(pkgName, themesDir, { boundary: themesDir });
+  if (pkgDir) {
+    return { pkgDir, self: false };
+  }
+  const ownPkgDir = findOwnPackageDir(pkgName, importerDir);
+  if (ownPkgDir) {
+    return { pkgDir: ownPkgDir, self: true };
+  }
+  // Fall back to the Node.js style resolution walking up from the importer
+  const projectPkgDir = findPackageDir(pkgName, importerDir);
+  return projectPkgDir ? { pkgDir: projectPkgDir, self: false } : undefined;
 }
 
 function resolveExportsSubpath(
@@ -190,15 +200,21 @@ export function resolvePackageCssSubpath(
 }
 
 export class ThemeCssResolver {
+  #entryContextDir: string;
   #workspaceDir: string;
   #themesDir: string;
   #mounts = new Map<string, string>();
   #checkedVersions = new Set<string>();
 
   constructor({
+    entryContextDir,
     workspaceDir,
     themesDir,
-  }: Pick<ResolvedTaskConfig, 'workspaceDir' | 'themesDir'>) {
+  }: Pick<
+    ResolvedTaskConfig,
+    'entryContextDir' | 'workspaceDir' | 'themesDir'
+  >) {
+    this.#entryContextDir = entryContextDir;
     this.#workspaceDir = workspaceDir;
     this.#themesDir = themesDir;
   }
@@ -217,12 +233,12 @@ export class ThemeCssResolver {
       throw new Error(`Invalid import specifier: ${specifier}`);
     }
     const { pkgName, version, subpath } = parsed;
-    const pkgDir = findThemePackageDir(
+    const found = findThemePackageDir(
       pkgName,
       upath.dirname(importer),
       this.#themesDir,
     );
-    if (!pkgDir) {
+    if (!found) {
       throw new DetailError(
         `Could not resolve the CSS import: ${specifier} (imported from ${importer})`,
         [
@@ -232,13 +248,14 @@ export class ThemeCssResolver {
         ].join('\n'),
       );
     }
+    const { pkgDir, self } = found;
     if (version) {
       this.#warnUnsatisfiedVersion(pkgName, version, pkgDir);
     }
     const file = subpath
       ? resolvePackageCssSubpath(pkgDir, stripUrlQuery(subpath))
       : resolvePackageCssEntry(pkgDir);
-    return { file, pkgName, pkgDir };
+    return { file, pkgName, pkgDir, self };
   }
 
   #warnUnsatisfiedVersion(
@@ -269,9 +286,20 @@ export class ThemeCssResolver {
    * Map a resolved file to its location on the server URL space (rooted at
    * the workspace directory).
    */
-  urlPathOf({ file, pkgName, pkgDir }: CssBareImportResolution): string {
+  urlPathOf({ file, pkgName, pkgDir, self }: CssBareImportResolution): string {
     if (pathContains(this.#themesDir, file)) {
       return `/${upath.relative(this.#workspaceDir, file)}`;
+    }
+    if (self) {
+      // A self-reference stays inside the package like a relative import:
+      // files under the entry context are served in place and copied to the
+      // workspace and the outputs along with the importing stylesheet, so
+      // mounting the package (which may be the whole project) is unnecessary
+      for (const root of [this.#workspaceDir, this.#entryContextDir]) {
+        if (pathContains(root, file)) {
+          return `/${upath.relative(root, file)}`;
+        }
+      }
     }
     // Known limitation: mounts are keyed by the package name alone, so when
     // multiple instances of the same package exist (e.g. different versions
@@ -719,6 +747,13 @@ export async function collectCssPackageImports({
         }
         return;
       }
+      const ownPackageDir = findOwnPackageDir(pkgName, upath.dirname(importer));
+      if (ownPackageDir) {
+        return resolvePackageFile(
+          ownPackageDir,
+          subpath ? stripUrlQuery(subpath) : undefined,
+        );
+      }
       const projectPackageDir = findPackageDir(
         pkgName,
         upath.dirname(importer),
@@ -806,7 +841,11 @@ export function collectThemeCssEntryFiles(themeIndexes: Set<ParsedTheme>): {
 export async function validateThemeCssDependencies(
   config: Pick<
     ResolvedTaskConfig,
-    'workspaceDir' | 'themesDir' | 'themeIndexes' | 'postcss'
+    | 'entryContextDir'
+    | 'workspaceDir'
+    | 'themesDir'
+    | 'themeIndexes'
+    | 'postcss'
   >,
 ): Promise<void> {
   const resolver = new ThemeCssResolver(config);

--- a/src/util.ts
+++ b/src/util.ts
@@ -270,6 +270,31 @@ export function findPackageDir(
   return undefined;
 }
 
+/**
+ * Locate the package containing `fromDir` when the package is named
+ * `pkgName`, following the Node.js self-referencing rule: only the nearest
+ * package.json defines the package scope, and a `node_modules` directory
+ * ends the lookup.
+ */
+export function findOwnPackageDir(
+  pkgName: string,
+  fromDir: string,
+): string | undefined {
+  let dir = fromDir;
+  while (upath.basename(dir) !== 'node_modules') {
+    const pkgJsonPath = upath.join(dir, 'package.json');
+    if (fs.existsSync(pkgJsonPath)) {
+      return readPackageJson(pkgJsonPath).name === pkgName ? dir : undefined;
+    }
+    const parent = upath.dirname(dir);
+    if (parent === dir) {
+      break;
+    }
+    dir = parent;
+  }
+  return undefined;
+}
+
 export function inflateZip(filePath: string, dest: string): Promise<void> {
   return new Promise<void>((res, rej) => {
     try {

--- a/tests/css.test.ts
+++ b/tests/css.test.ts
@@ -548,6 +548,32 @@ describe('transformCssImports', () => {
     expect(resolver.mounts.size).toBe(0);
   });
 
+  it('resolves self-references from a workspace placed outside the package', async () => {
+    writeFiles({
+      'pkg/package.json': JSON.stringify({
+        name: 'my-theme',
+        main: 'theme.css',
+      }),
+      'pkg/theme.css': '',
+      'pkg/example.css': '',
+      'ws/example.css': '',
+    });
+    const resolver = createResolver({
+      entryContextDir: abs('pkg'),
+      workspaceDir: abs('ws'),
+      themesDir: abs('ws/themes'),
+    });
+    const result = await transformCssImports({
+      code: "@import 'my-theme';",
+      importer: abs('ws/example.css'),
+      importerUrlPath: '/example.css',
+      resolver,
+    });
+    expect(result.errors).toEqual([]);
+    expect(result.code).toBe("@import 'theme.css';");
+    expect(resolver.mounts.size).toBe(0);
+  });
+
   it('mounts self-referenced packages located outside the entry context', async () => {
     writeFiles({
       'package.json': JSON.stringify({ name: 'my-theme', main: 'theme.css' }),

--- a/tests/css.test.ts
+++ b/tests/css.test.ts
@@ -57,10 +57,14 @@ function abs(rel: string): string {
   return upath.join(projectDir, rel);
 }
 
-function createResolver(): ThemeCssResolver {
+function createResolver(
+  overrides: Partial<ConstructorParameters<typeof ThemeCssResolver>[0]> = {},
+): ThemeCssResolver {
   return new ThemeCssResolver({
+    entryContextDir: projectDir,
     workspaceDir: abs('.vivliostyle'),
     themesDir: abs('.vivliostyle/themes'),
+    ...overrides,
   });
 }
 
@@ -500,6 +504,115 @@ describe('transformCssImports', () => {
     expect(resolver.mounts.get('theme-c')).toBe(abs('node_modules/theme-c'));
   });
 
+  it('resolves imports referring to the package containing the importer', async () => {
+    writeFiles({
+      'package.json': JSON.stringify({
+        name: '@scope/my-theme',
+        main: 'theme.css',
+        exports: { '.': './theme.css', './*': './css/*.css' },
+      }),
+      'theme.css': '',
+      'css/footnote.css': '',
+      'example.css': '',
+    });
+    const resolver = createResolver({ workspaceDir: projectDir });
+    const result = await transformCssImports({
+      code: "@import '@scope/my-theme';\n@import '@scope/my-theme/footnote';",
+      importer: abs('example.css'),
+      importerUrlPath: '/example.css',
+      resolver,
+    });
+    expect(result.errors).toEqual([]);
+    expect(result.code).toBe(
+      "@import 'theme.css';\n@import 'css/footnote.css';",
+    );
+    expect(resolver.mounts.size).toBe(0);
+  });
+
+  it('resolves self-references from the workspace copy of a file theme', async () => {
+    writeFiles({
+      'package.json': JSON.stringify({ name: 'my-theme', main: 'theme.css' }),
+      'theme.css': '',
+      'example.css': '',
+      '.vivliostyle/example.css': '',
+    });
+    const resolver = createResolver();
+    const result = await transformCssImports({
+      code: "@import 'my-theme';",
+      importer: abs('.vivliostyle/example.css'),
+      importerUrlPath: '/example.css',
+      resolver,
+    });
+    expect(result.errors).toEqual([]);
+    expect(result.code).toBe("@import 'theme.css';");
+    expect(resolver.mounts.size).toBe(0);
+  });
+
+  it('mounts self-referenced packages located outside the entry context', async () => {
+    writeFiles({
+      'package.json': JSON.stringify({ name: 'my-theme', main: 'theme.css' }),
+      'theme.css': '',
+      'example/style.css': '',
+    });
+    const resolver = createResolver({
+      entryContextDir: abs('example'),
+      workspaceDir: abs('example'),
+      themesDir: abs('example/themes'),
+    });
+    const result = await transformCssImports({
+      code: "@import 'my-theme';",
+      importer: abs('example/style.css'),
+      importerUrlPath: '/style.css',
+      resolver,
+    });
+    expect(result.errors).toEqual([]);
+    expect(result.code).toBe(
+      "@import 'themes/node_modules/my-theme/theme.css';",
+    );
+    expect(resolver.mounts.get('my-theme')).toBe(projectDir);
+  });
+
+  it('limits self-references to the nearest package scope', async () => {
+    writeFiles({
+      'package.json': JSON.stringify({ name: 'my-theme', main: 'theme.css' }),
+      'theme.css': '',
+      'sub/package.json': JSON.stringify({ name: 'sub' }),
+      'sub/style.css': '',
+    });
+    const result = await transformCssImports({
+      code: "@import 'my-theme';",
+      importer: abs('sub/style.css'),
+      importerUrlPath: '/sub/style.css',
+      resolver: createResolver({ workspaceDir: projectDir }),
+    });
+    expect(result.errors.map((e) => e.message)).toEqual([
+      expect.stringContaining('Could not resolve the CSS import: my-theme'),
+    ]);
+  });
+
+  it('prefers the themes directory over a self-reference', async () => {
+    writeFiles({
+      'package.json': JSON.stringify({ name: 'my-theme', main: 'theme.css' }),
+      'theme.css': '',
+      '.vivliostyle/themes/node_modules/my-theme/package.json': JSON.stringify({
+        name: 'my-theme',
+        main: 'theme.css',
+      }),
+      '.vivliostyle/themes/node_modules/my-theme/theme.css': '',
+      'example.css': '',
+    });
+    const result = await transformCssImports({
+      code: "@import 'my-theme';",
+      importer: abs('example.css'),
+      importerUrlPath: '/example.css',
+      resolver: createResolver({ workspaceDir: projectDir }),
+    });
+    expect(result.errors).toEqual([]);
+    expect(result.code).toBe(
+      "@import '.vivliostyle/themes/node_modules/my-theme/theme.css';",
+    );
+  });
+
   it('reports unresolved bare imports without changing the code', async () => {
     writeFiles({
       '.vivliostyle/style.css': '',
@@ -768,6 +881,28 @@ describe('collectCssPackageImports', () => {
     expect(discovered.size).toBe(0);
   });
 
+  it('does not install packages referring to themselves and follows their imports', async () => {
+    writeFiles({
+      'package.json': JSON.stringify({
+        name: 'my-theme',
+        version: '3.0.0',
+        exports: { '.': './theme.css', './*': './css/*.css' },
+      }),
+      'theme.css': "@import 'remote-pkg';",
+      'css/footnote.css': "@import 'other-pkg@^1.0.0';",
+      'example.css': "@import 'my-theme@^2.0.0';\n@import 'my-theme/footnote';",
+    });
+    const discovered = await collectCssPackageImports({
+      themeIndexes: new Set([fileTheme('example.css')]),
+    });
+    expect(discovered).toEqual(
+      new Map([
+        ['remote-pkg', 'remote-pkg'],
+        ['other-pkg', 'other-pkg@^1.0.0'],
+      ]),
+    );
+  });
+
   it('keeps the first specifier for conflicting versions', async () => {
     writeFiles({
       'style.css': "@import 'pkg@^1.0.0/a.css';\n@import 'pkg@^2.0.0/b.css';",
@@ -987,6 +1122,7 @@ describe('validateThemeCssDependencies', () => {
     };
     await expect(
       validateThemeCssDependencies({
+        entryContextDir: projectDir,
         workspaceDir: projectDir,
         themesDir: abs('themes'),
         themeIndexes: new Set([theme]),
@@ -1012,6 +1148,7 @@ describe('validateThemeCssDependencies', () => {
     };
     await expect(
       validateThemeCssDependencies({
+        entryContextDir: projectDir,
         workspaceDir: projectDir,
         themesDir: abs('themes'),
         themeIndexes: new Set([theme]),
@@ -1036,6 +1173,7 @@ describe('validateThemeCssDependencies', () => {
     };
     await expect(
       validateThemeCssDependencies({
+        entryContextDir: projectDir,
         workspaceDir: abs('.vivliostyle'),
         themesDir: abs('.vivliostyle/themes'),
         themeIndexes: new Set([theme]),


### PR DESCRIPTION
A stylesheet importing its own package by name, e.g. the example stylesheet of a theme package under development (`example.css` in the theme-base repository importing `@vivliostyle/theme-base`), could not be resolved by the CSS import resolution added in #889, and the package of the same name was installed from the npm registry instead.

Assisted-by: Claude Code:claude-fable-5-1

<details>
<summary>How the AI was used</summary>

- The human author reported the problem and requested that imports referring to the package containing the importer resolve correctly.
- The AI investigated the existing resolver, proposed the design (Node.js self-referencing rule, resolution order, in-place URL mapping instead of mounting), and implemented the resolver changes, the pre-installation scan, and the tests.
- The human author reviewed the result and verified it via the test suite, lint, and typecheck.

</details>
